### PR TITLE
Fixes URL-File Refresh, GetDommeImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Fixes added from Community Members:
          - Removed redundant Code.
          - If you review and download images, the image was downloaded twice.
          - The Blog-XML was downloaded with XML-Doc. After you scraped an URL, you sometimes couldn't scrape it again.
-         - Deadlinks were imported again.
+         - Deadlinks were imported again. Now Deadlinks will be removed if you open a blog with Review and on rebuilding, 
+        	as long you don't cancel it. Refresh URL-File imports only new Images.
          - Adding an URL to DislikeList was only writing to file, so a disliked URL could get into File, if a blog contains it twice.
 
      Stefaf: @DommeTag() Overhaul 
@@ -25,6 +26,8 @@ Fixes added from Community Members:
 
          You want to show a butt without feet, you can enter "Ass, NotFeet".
          You want to show a closeup face without boobs: "Face, NotBoobs, Closeup"
+         This Function will return in 99% of all cases the nearest result for the given Tags. :D
+         Of course you must set up your DommeTags properly.
 
          If there is no image found for the specified Tags, the Tags will be altered and searched again:
 

--- a/Tease AI/Classes/URL_Files_BGW.vb
+++ b/Tease AI/Classes/URL_Files_BGW.vb
@@ -42,12 +42,12 @@ Namespace URL_Files
 		Idle
 		''' <summary>
 		''' Creates a new URL-File, with UserInteractions.
-		''' If it runs not the first time and is not cancelled Dead-URLs will be removed
+		''' If it runs <b>not</b> the first time and is not cancelled Dead-URLs will be removed.
 		''' </summary>
 		CreateURLFile
 		''' <summary>
-		''' Refreshes all URL-Files and automatically adds new URLs.
-		''' If not Cancelled, it will remove Dead-URLs.
+		''' Refreshes all URL-Files and automatically adds new URLs. It will scrape the blog
+		''' until a known Url is found. 
 		''' </summary>
 		RefreshURLFiles
 		''' <summary>
@@ -561,8 +561,12 @@ Scrape:
 							'########################## URL-Rebuild - Unknown URL ############################
 							' If Rebuilding URL-File skip Urls not previous known.
 							GoTo NextImage
+						ElseIf Me._Work = URL_File_Tasks.RefreshURLFiles AndAlso ___BlogListOld.Contains(___PhotoNode.InnerXml)
+							'############################# Refresh - Known URL ###############################
+							' If refreshing a URL-File and there is a known URL then stop scraping.
+							GoTo ExitScrape
 						ElseIf ___BlogListOld.Contains(___PhotoNode.InnerXml)
-							'########################## Create/Refresh - Known URL ###########################
+							'############################## Create - Known URL ###############################
 							___BlogListNew.Add(___PhotoNode.InnerXml)           ' Add to new list
 							___ImageCountTotal += 1                             ' Increment Image Counter.
 							GoTo NextImage                                      ' No Saving or Reviewing    
@@ -647,13 +651,13 @@ NextImage:
 ExitScrape:
 				Me.URL_FileCreate_OnProgressChanged(___ImageCountTotal, ___BlogCycle / ___BlogCycleSize, ___RoundPostsCount / ___BlogCycleSize, WorkingStages.Writing_File, Nothing)
 
-				' IF:   Work is Cancelled?
-				' Then: Write Combined New and Old List
+				' IF:   Work is Cancelled? Or do we refresh the file?
+				' Then: Write a combined copy of  new and old List
 				' Else: Write only New List. This removes Dead links.
 				Dim ___BlogListCombine As New List(Of String)
-				If Me.CancellationPending = True _
-		Then ___BlogListCombine = ___BlogListOld.Union(___BlogListNew).ToList _
-		Else ___BlogListCombine = ___BlogListNew
+				If Me.CancellationPending = True Or Me._Work = URL_File_Tasks.RefreshURLFiles _
+				Then ___BlogListCombine = ___BlogListOld.Union(___BlogListNew).ToList _
+				Else ___BlogListCombine = ___BlogListNew
 				'===============================================================================
 				' Delete old URL-File: Retry delayed 10 times if the File is blocked by use.
 				'===============================================================================

--- a/Tease AI/Form2.vb
+++ b/Tease AI/Form2.vb
@@ -2331,13 +2331,11 @@ trypreviousimage:
 						ElseIf __tmpResult.ErrorText.Capacity > 0
 							MessageBox.Show(Me, "URL Files have been refreshed with errors!" &
 											vbCrLf & vbCrLf & __tmpResult.ModifiedLinkCount & " new URLs have been added." &
-											vbCrLf & vbCrLf & __tmpResult.LinkCountTotal & " URLs in total." &
 											vbCrLf & vbCrLf & String.Join(vbCrLf, __tmpResult.ErrorText),
 											"Information", MessageBoxButtons.OK, MessageBoxIcon.Information)
 						Else
 							MessageBox.Show(Me, "All URL Files have been refreshed!" &
-											vbCrLf & vbCrLf & __tmpResult.ModifiedLinkCount & " new URLs have been added." &
-											vbCrLf & vbCrLf & __tmpResult.LinkCountTotal & " URLs in total.",
+											vbCrLf & vbCrLf & __tmpResult.ModifiedLinkCount & " new URLs have been added.",
 											"Information", MessageBoxButtons.OK, MessageBoxIcon.Information)
 						End If
 					Catch


### PR DESCRIPTION
URL-File-Refresh
- Refreshing a URL-File scraped the entire blog. Now it scraps until the first known URL and gets to the next file.
  GetDommeImage :
- The Funtion will in 99% return now the nearest result for the given Tags and not a random one.
- Skip alternation steps 1-6 was pointing to the wrong adress.
- Added DebugLine to optional shutdown the stupid "Unhandled Exception" while Debugger is atteched.
- Added additional comments.
