### PR TITLE
Various Bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,18 @@ Fixed bug where Glitter Contacts did not appear correctly during Multiple Edges 
 
 Fixes added from Community Members:
 
+	Stefaf: Bugfix: UI-didn't resize on maximizing the window.
+	
+	Stefaf: Bugfix: DommeTagApp wasn't working properly. It was randomly showing and setting the wrong Tags for the wrong image.
+	
+	Stefaf: Bugfix/Addon: Only CH-Videos did load .flv Files. Now all Video-genres can load .flv-Files.
+	
+	Stefaf: Bugfix: Hold the Edge Taunts returned "TeaseAI did not return a Hold the Edge Taunt" <--- Sorry guys and gals, that was my fault. (stefaf) 
+
+	Stefaf: BugFix: @DommeTag() Didn't return the right picture, if the Task-Line contained a Keyword.
+	
+	Stefaf: Bugfix: @ShowBoobsImage() didn't work with local files.
+	
     Stefaf: Bugfix: Error during CensorshipsSucks, if the window is not maximized
 
     Stefaf: BugFix: URL-File Exiting on 404 without writing the gathered data

--- a/Tease AI/Form1.vb
+++ b/Tease AI/Form1.vb
@@ -27522,8 +27522,6 @@ SkipNew:
 
 
 	Public Function AddDommeTag(ByVal AddDomTag As String, ByVal AddCustomDomTag As String)
-		'MsgBox("This function is deactivated for maintenance", MsgBoxStyle.Information, "Not Available yet")
-		'Exit Function
 		Dim DomTag As String = "Tag" & AddDomTag
 		Dim Custom As String
 		If AddCustomDomTag = "Nothing" Then
@@ -27592,8 +27590,8 @@ SkipNew:
 				My.Computer.FileSystem.WriteAllText(Path.GetDirectoryName(ImageLocation) & "\ImageTags.txt", SettingsString, False)
 			End If
 
-		Else
-
+		ElseIf Path.GetDirectoryName(_ImageFileNames(FileCount)) = Path.GetDirectoryName(ImageLocation)
+			' Only Create new file for the loaded Slidshow. This Prevents URL-Image-Tagging.
 			My.Computer.FileSystem.WriteAllText(Path.GetDirectoryName(ImageLocation) & "\ImageTags.txt", Path.GetFileName(ImageLocation) & " " & DomTag & Custom, True)
 
 		End If
@@ -27603,8 +27601,6 @@ SkipNew:
 
 
 	Public Function RemoveDommeTag(ByVal RemoveDomTag As String, ByVal RemoveCustomDomTag As String)
-		'MsgBox("This function is deactivated for maintenance", MsgBoxStyle.Information, "Not Available yet")
-		'Exit Function
 		Dim DomTag As String = "Tag" & RemoveDomTag
 		Dim Custom As String
 		If RemoveCustomDomTag = "Nothing" Then
@@ -29165,13 +29161,8 @@ SkipNew:
 				Catch ex As Net.WebException
 					Exit Sub
 				End Try
-				' We have to set this Property manually, otherwise CheckDommeTag will give a wrong result.
-				mainPictureBox.ImageLocation = PBImage
-
 			Else
-				' This will set the ImageLocation of the PictureBox too
-				mainPictureBox.Load(PBImage)
-
+				mainPictureBox.Image = Image.FromFile(PBImage)
 			End If
 
 			If Not CachedImage Is Nothing Then CachedImage.Dispose()

--- a/Tease AI/Form1.vb
+++ b/Tease AI/Form1.vb
@@ -514,7 +514,10 @@ Public Class Form1
 	Dim PBImage As String
 	Dim DommeImageSTR As String
 	Dim LocalImageSTR As String
-
+	''' <summary>
+	''' This Variable contains the Path of origin of the displayed Image. CheckDommeTag() uses 
+	''' this string to get the curremt ImageData for the DommeTagApp.
+	''' </summary>
 	Dim ImageLocation As String
 
 	Public ResponseThread As Thread
@@ -16064,7 +16067,7 @@ retry_NextStage:
 							'			otherwise we can't evaluate task1.IsFaulted to rethrow the Exception...
 							' So, here is a simple workaround to override this, while debugging. Only change the 
 							' statement after AndAlso, otherwise it will behave wrong in the final programm.
-							If Debugger.IsAttached AndAlso 1 = 2 Then Return Nothing
+							If Debugger.IsAttached AndAlso 1 = 1 Then Return ""
 							Throw New Exception("No DommeImage found for Tags: '" & ___DomTag_Base & "' in directory: '" & __targetFolder & "'")
 						End If
                         ' Copy Matches to editable Container
@@ -23134,8 +23137,68 @@ TryNext:
 
 	End Sub
 
+	Private Sub WMPTimer_Tick(sender As teaseAI_Timer, e As System.EventArgs) Handles WMPTimer.Tick
 
-#End Region
+
+		If DomWMP.currentPlaylist.count <> 0 Then
+			Try
+				Dim VideoLength As Integer = DomWMP.currentMedia.duration
+				Dim VideoRemaining As Integer = Math.Floor(DomWMP.currentMedia.duration - DomWMP.Ctlcontrols.currentPosition)
+
+				Debug.Print("Video Length = " & VideoLength)
+				Debug.Print("Video Remaining = " & VideoRemaining)
+			Catch
+			End Try
+		End If
+
+
+
+
+
+		If DomTypeCheck = True Or DomWMP.playState = WMPLib.WMPPlayState.wmppsStopped Or DomWMP.playState = WMPLib.WMPPlayState.wmppsPaused Then Return
+
+		'Debug.Print("New movie loaded: " & DomWMP.URL.ToString)
+
+		VidFile = Path.GetFileName(DomWMP.URL.ToString)
+
+		Dim VidSplit As String() = VidFile.Split(".")
+		VidFile = ""
+		For i As Integer = 0 To VidSplit.Count - 2
+			VidFile = VidFile + VidSplit(i)
+		Next
+		'Debug.Print(VidFile)
+
+		If File.Exists(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\Video\Scripts\" & VidFile & ".txt") Then
+			Dim SubCheck As String()
+			Dim PlayPos As Integer
+			Dim WMPPos As Integer = Math.Ceiling(DomWMP.Ctlcontrols.currentPosition)
+
+			Dim SubList As New List(Of String)
+			SubList = Txt2List(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\Video\Scripts\" & VidFile & ".txt")
+
+			If Not SubList Is Nothing Then
+				For i As Integer = 0 To SubList.Count - 1
+					SubCheck = SubList(i).Split("]")
+					SubCheck(0) = SubCheck(0).Replace("[", "")
+					Dim SubCheck2 As String() = SubCheck(0).Split(":")
+
+					PlayPos = SubCheck2(0) * 3600
+					PlayPos += SubCheck2(1) * 60
+					PlayPos += SubCheck2(2)
+
+					If WMPPos = PlayPos Then
+						DomTask = SubCheck(1)
+						TypingDelayGeneric()
+						Debug.Print(SubList(i))
+					End If
+				Next
+			End If
+		End If
+
+
+	End Sub
+
+#End Region 'Domme-WMP
 
 	Private Sub domAvatar_MouseEnter(ByVal sender As Object, ByVal e As System.EventArgs) Handles domAvatar.MouseEnter
 		If FrmSettings.Visible = False And FrmCardList.Visible = False Then domAvatar.Focus()
@@ -23579,7 +23642,7 @@ TryNext:
 #Region "-------------------------------------------------- MainPictureBox ----------------------------------------------------"
 
 	Private Sub mainPictureBox_LoadCompleted(sender As Object, e As System.ComponentModel.AsyncCompletedEventArgs) Handles mainPictureBox.LoadCompleted
-
+		ImageLocation = mainPictureBox.ImageLocation
 		CheckDommeTags()
 		Debug.Print("ImageLoadCOmpleted")
 	End Sub
@@ -24258,6 +24321,7 @@ GetDommeSlideshow:
 
 	End Sub
 
+#Region "-------------------------------------------------- Contact 1-3 -------------------------------------------------------"
 
 	Public Sub GetContact1Pics()
 
@@ -24520,6 +24584,8 @@ GetDommeSlideshow:
 
 	End Sub
 
+#End Region
+
 	Private Sub DommeTimer_Tick(sender As teaseAI_Timer, e As System.EventArgs) Handles DommeTimer.Tick
 
 		AddContactTick -= 1
@@ -24565,6 +24631,7 @@ GetDommeSlideshow:
 		End If
 	End Sub
 
+#Region "-------------------------------------------- Session Supend/Reset ----------------------------------------------------"
 
 	Public Sub SuspendSession()
 
@@ -25623,67 +25690,7 @@ GetDommeSlideshow:
 
 	End Sub
 
-
-	Private Sub WMPTimer_Tick(sender As teaseAI_Timer, e As System.EventArgs) Handles WMPTimer.Tick
-
-
-		If DomWMP.currentPlaylist.count <> 0 Then
-			Try
-				Dim VideoLength As Integer = DomWMP.currentMedia.duration
-				Dim VideoRemaining As Integer = Math.Floor(DomWMP.currentMedia.duration - DomWMP.Ctlcontrols.currentPosition)
-
-				Debug.Print("Video Length = " & VideoLength)
-				Debug.Print("Video Remaining = " & VideoRemaining)
-			Catch
-			End Try
-		End If
-
-
-
-
-
-		If DomTypeCheck = True Or DomWMP.playState = WMPLib.WMPPlayState.wmppsStopped Or DomWMP.playState = WMPLib.WMPPlayState.wmppsPaused Then Return
-
-		'Debug.Print("New movie loaded: " & DomWMP.URL.ToString)
-
-		VidFile = Path.GetFileName(DomWMP.URL.ToString)
-
-		Dim VidSplit As String() = VidFile.Split(".")
-		VidFile = ""
-		For i As Integer = 0 To VidSplit.Count - 2
-			VidFile = VidFile + VidSplit(i)
-		Next
-		'Debug.Print(VidFile)
-
-		If File.Exists(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\Video\Scripts\" & VidFile & ".txt") Then
-			Dim SubCheck As String()
-			Dim PlayPos As Integer
-			Dim WMPPos As Integer = Math.Ceiling(DomWMP.Ctlcontrols.currentPosition)
-
-			Dim SubList As New List(Of String)
-			SubList = Txt2List(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\Video\Scripts\" & VidFile & ".txt")
-
-			If Not SubList Is Nothing Then
-				For i As Integer = 0 To SubList.Count - 1
-					SubCheck = SubList(i).Split("]")
-					SubCheck(0) = SubCheck(0).Replace("[", "")
-					Dim SubCheck2 As String() = SubCheck(0).Split(":")
-
-					PlayPos = SubCheck2(0) * 3600
-					PlayPos += SubCheck2(1) * 60
-					PlayPos += SubCheck2(2)
-
-					If WMPPos = PlayPos Then
-						DomTask = SubCheck(1)
-						TypingDelayGeneric()
-						Debug.Print(SubList(i))
-					End If
-				Next
-			End If
-		End If
-
-
-	End Sub
+#End Region 'Session Supend/Reset
 
 #Region "------------------------------------------------------ MenuStuff -----------------------------------------------------"
 
@@ -27162,6 +27169,8 @@ SkipNew:
 
 #Region "--------------------------------------------------- DommeTag APP -----------------------------------------------------"
 
+#Region "------------------------------------------------- Regular Buttons-----------------------------------------------------"
+
 	Private Sub Face_Click(sender As System.Object, e As System.EventArgs) Handles Face.Click
 		Debug.Print(mainPictureBox.ImageLocation)
 		If SlideshowLoaded = False Then Return
@@ -27509,10 +27518,12 @@ SkipNew:
 		End If
 	End Sub
 
+#End Region ' Regular Buttons
+
 
 	Public Function AddDommeTag(ByVal AddDomTag As String, ByVal AddCustomDomTag As String)
-		MsgBox("This function is deactivated for maintenance", MsgBoxStyle.Information, "Not Available yet")
-		Exit Function
+		'MsgBox("This function is deactivated for maintenance", MsgBoxStyle.Information, "Not Available yet")
+		'Exit Function
 		Dim DomTag As String = "Tag" & AddDomTag
 		Dim Custom As String
 		If AddCustomDomTag = "Nothing" Then
@@ -27525,7 +27536,8 @@ SkipNew:
 		Debug.Print("Custom = " & Custom)
 
 
-		Dim TagFile As String = Path.GetDirectoryName(_ImageFileNames(FileCount)) & "\ImageTags.txt"
+		'Dim TagFile As String = Path.GetDirectoryName(_ImageFileNames(FileCount)) & "\ImageTags.txt"
+		Dim TagFile As String = Path.GetDirectoryName(ImageLocation) & "\ImageTags.txt"
 
 		If File.Exists(TagFile) Then
 
@@ -27535,7 +27547,7 @@ SkipNew:
 			Dim FoundFile As Boolean = False
 
 			For i As Integer = 0 To TagList.Count - 1
-				If TagList(i).Contains(Path.GetFileName(_ImageFileNames(FileCount))) Then
+				If TagList(i).Contains(Path.GetFileName(ImageLocation)) Then
 					FoundFile = True
 					If Not TagList(i).Contains(DomTag) Then
 						TagList(i) = TagList(i) & " " & DomTag & Custom
@@ -27569,7 +27581,7 @@ SkipNew:
 				End If
 			Next
 
-			If FoundFile = False Then TagList.Add(Path.GetFileName(_ImageFileNames(FileCount)) & " " & DomTag & Custom)
+			If FoundFile = False Then TagList.Add(Path.GetFileName(ImageLocation) & " " & DomTag & Custom)
 
 			If TagList.Count > 0 Then
 				Dim SettingsString As String = ""
@@ -27577,12 +27589,12 @@ SkipNew:
 					SettingsString = SettingsString & TagList(i)
 					If i <> TagList.Count - 1 Then SettingsString = SettingsString & Environment.NewLine
 				Next
-				My.Computer.FileSystem.WriteAllText(Path.GetDirectoryName(_ImageFileNames(FileCount)) & "\ImageTags.txt", SettingsString, False)
+				My.Computer.FileSystem.WriteAllText(Path.GetDirectoryName(ImageLocation) & "\ImageTags.txt", SettingsString, False)
 			End If
 
 		Else
 
-			My.Computer.FileSystem.WriteAllText(Path.GetDirectoryName(_ImageFileNames(FileCount)) & "\ImageTags.txt", Path.GetFileName(_ImageFileNames(FileCount)) & " " & DomTag & Custom, True)
+			My.Computer.FileSystem.WriteAllText(Path.GetDirectoryName(ImageLocation) & "\ImageTags.txt", Path.GetFileName(ImageLocation) & " " & DomTag & Custom, True)
 
 		End If
 
@@ -27591,8 +27603,8 @@ SkipNew:
 
 
 	Public Function RemoveDommeTag(ByVal RemoveDomTag As String, ByVal RemoveCustomDomTag As String)
-		MsgBox("This function is deactivated for maintenance", MsgBoxStyle.Information, "Not Available yet")
-		Exit Function
+		'MsgBox("This function is deactivated for maintenance", MsgBoxStyle.Information, "Not Available yet")
+		'Exit Function
 		Dim DomTag As String = "Tag" & RemoveDomTag
 		Dim Custom As String
 		If RemoveCustomDomTag = "Nothing" Then
@@ -27602,7 +27614,8 @@ SkipNew:
 		End If
 
 		Dim SettingsString As String
-		Dim TagFile As String = Path.GetDirectoryName(_ImageFileNames(FileCount)) & "\ImageTags.txt"
+		'Dim TagFile As String = Path.GetDirectoryName(_ImageFileNames(FileCount)) & "\ImageTags.txt"
+		Dim TagFile As String = Path.GetDirectoryName(ImageLocation) & "\ImageTags.txt"
 		Debug.Print("TagFile = " & TagFile)
 
 		Debug.Print("DomTag & Custom = " & DomTag & Custom)
@@ -27613,7 +27626,7 @@ SkipNew:
 			TagList = Txt2List(TagFile)
 
 			For i As Integer = TagList.Count - 1 To 0 Step -1
-				If TagList(i).Contains(Path.GetFileName(_ImageFileNames(FileCount))) Then
+				If TagList(i).Contains(Path.GetFileName(ImageLocation)) Then
 					If TagList(i).Contains(DomTag & Custom) Then
 
 						If DomTag = "TagGarment" Or DomTag = "TagUnderwear" Or DomTag = "TagTattoo" Or DomTag = "TagSexToy" Or DomTag = "TagFurniture" Then
@@ -27646,9 +27659,9 @@ SkipNew:
 					SettingsString = SettingsString & TagList(i)
 					If i <> TagList.Count - 1 Then SettingsString = SettingsString & Environment.NewLine
 				Next
-				My.Computer.FileSystem.WriteAllText(Path.GetDirectoryName(_ImageFileNames(FileCount)) & "\ImageTags.txt", SettingsString, False)
+				My.Computer.FileSystem.WriteAllText(Path.GetDirectoryName(ImageLocation) & "\ImageTags.txt", SettingsString, False)
 			Else
-				If File.Exists(Path.GetDirectoryName(_ImageFileNames(FileCount)) & "\ImageTags.txt") Then My.Computer.FileSystem.DeleteFile(Path.GetDirectoryName(_ImageFileNames(FileCount)) & "\ImageTags.txt")
+				If File.Exists(Path.GetDirectoryName(ImageLocation) & "\ImageTags.txt") Then My.Computer.FileSystem.DeleteFile(Path.GetDirectoryName(ImageLocation) & "\ImageTags.txt")
 			End If
 
 		End If
@@ -27664,6 +27677,8 @@ SkipNew:
 	''' <see cref="Form1.mainPictureBox">PictureBox</see>. Everthing else doesn't work properly.</para>
 	''' <para>Right now there are only two working non-UI-Freezing posibilities: The Imagebox 
 	''' LoadCompleted-Event and PBImageThread. In PBImageThread an Invoke is required!</para>
+	''' This Function uses the <see cref="form1.ImageLocation">ImageLocation</see> Variable to get the
+	''' current ImageFilePath. 
 	''' </summary>
 	''' <remarks>
 	''' To Raise the PictureBoxCompleted-Event, you have to load an Image via LoadAsync(URL).
@@ -27752,19 +27767,9 @@ SkipNew:
 		TBFurniture.Text = ""
 
 
-		'LBLDomTagImg.Text = Path.GetFileName(_ImageFileNames(FileCount))
+		Dim tmpFileName As String = Path.GetFileName(ImageLocation)
 
-		Dim tmpFilePath As String
-
-		If mainPictureBox.ImageLocation <> "" Then
-			tmpFilePath = mainPictureBox.ImageLocation
-		Else
-			tmpFilePath = _ImageFileNames(FileCount)
-		End If
-
-		Dim tmpFileName As String = Path.GetFileName(tmpFilePath)
-
-		Dim TagFile As String = Path.GetDirectoryName(tmpFilePath) & "\ImageTags.txt"
+		Dim TagFile As String = Path.GetDirectoryName(ImageLocation) & "\ImageTags.txt"
 
 		If File.Exists(TagFile) Then
 
@@ -29144,14 +29149,10 @@ SkipNew:
 
 			If Not CachedImage2 Is Nothing Then
 				mainPictureBox.Image = CachedImage2
-				' Reset to Tell CheckDommeTag() this is definitely no DommeImage
-				mainPictureBox.ImageLocation = ""
 				SaveSessionImage(CachedImage2)
 				If Not CachedImage Is Nothing Then CachedImage.Dispose()
 			Else
 				mainPictureBox.Image = CachedImage
-				' Reset to Tell CheckDommeTag() this is definitely no DommeImage
-				mainPictureBox.ImageLocation = ""
 				SaveSessionImage(CachedImage)
 			End If
 			PreLoadImage = False

--- a/Tease AI/Form1.vb
+++ b/Tease AI/Form1.vb
@@ -26430,31 +26430,22 @@ GetDommeSlideshow:
 	Private Sub Form1_Resize(sender As Object, e As System.EventArgs) Handles Me.Resize
 
 		Debug.Print("Resize Called")
-
-		'Return
-		'If Not Me.Height < 734 And Not Me.Width < 978 Then AdjustWindow()
-
-		' Return
-
 		Debug.Print(Me.WindowState)
 		Debug.Print(Me.WindowCheck)
-		'If Me.WindowState = FormWindowState.Maximized Then
-		If Me.WindowState = 0 Then
-			Debug.Print("Maximized")
-			WindowCheck = True
-			AdjustWindow()
-		End If
 
-		If Me.WindowState = FormWindowState.Normal And WindowCheck = True Then
-			Debug.Print("Resized From Maximized")
-			WindowCheck = False
-			AdjustWindow()
-		End If
+		Select Case Me.WindowState
 
-		'AdjustWindow()
+			Case FormWindowState.Maximized
+				Debug.Print("Maximized")
+				WindowCheck = True
+				AdjustWindow()
 
+			Case FormWindowState.Normal And WindowCheck = True
+				Debug.Print("Resized From Maximized")
+				WindowCheck = False
+				AdjustWindow()
 
-
+		End Select
 	End Sub
 
 	Private Sub Form1_ResizeEnd(sender As Object, e As System.EventArgs) Handles Me.ResizeEnd
@@ -26900,70 +26891,6 @@ SkipNew:
 			StrokeSlowest = False
 		End If
 
-	End Sub
-
-	Private Sub Form_Resize()
-		'if handling resizing...
-		If bResize Then Exit Sub
-		Select Case Me.WindowState
-			Case vbMinimizedNoFocus
-				Exit Sub
-			Case vbMinimizedFocus
-				Exit Sub
-			Case vbNormal
-				'if left mouse button down...
-				If GetKeyState(VK_LBUTTON) < 0 Then
-					'let timer handle fix
-					With Me.tmrResize
-						.Enabled = False 'disable timer
-						Application.DoEvents() 'let screen catch up
-						.Enabled = True 're-enable timer
-					End With
-					Exit Sub
-				End If
-				'if too small...
-				If Me.Width < MyFormWd _
-				   Or Me.Height < MyFormHt Then
-					With Me.tmrResize 'smooth w/timer
-						.Enabled = False 'turn timer off
-						Application.DoEvents() 'screen catch up
-						.Enabled = True 'restart timer
-					End With
-					Exit Sub 'let timer do work
-				End If
-		End Select
-		'
-		'other control arrangement code goes here.
-		'
-	End Sub
-
-	Private Sub tmrResize_Timer()
-		'
-		' Exit if Mouse pick button still down 
-		'
-		If GetKeyState(VK_LBUTTON) < 0 Then Exit Sub
-		'
-		'turn off timer
-		'
-		Me.tmrResize.Enabled = False
-		'
-		'do nothing if minimized
-		'
-		If Me.WindowState = vbMinimizedFocus Or Me.WindowState = vbMinimizedNoFocus Then
-			Exit Sub
-		End If
-		'
-		'resize to minimum dims
-		'
-		bResize = True 'block resize envent
-		If Me.Width < MyFormWd Then
-			Me.Width = MyFormWd
-		End If
-		If Me.Height < MyFormHt Then
-			Me.Height = MyFormHt
-		End If
-		bResize = False 'unblock resize event
-		Call Form_Resize() 'now process all resizing
 	End Sub
 
 	Public Sub ApplyThemeColor()

--- a/Tease AI/Modules/Extension.Class.Form.vb
+++ b/Tease AI/Modules/Extension.Class.Form.vb
@@ -1,0 +1,101 @@
+﻿'===========================================================================================
+'
+'                                Extensions.Class.Forms
+'
+'
+' This File contains Functions to extend the functionallity of the Windows.Forms.Form-Class.
+'
+' Implemented this far:
+'
+' Form.UIThread(Action) + 2 Overloads	
+'		This functions are intended to syimplify access to a Control-inheriting-class from
+'		within another thread, without any delegates. Beware of the Consequences, if
+'		you use this Code in order to prevent deadlocks. This DOES NOT replace Events to 
+'		pass Parameters between Threads at all.
+'		
+'		Simpliest Example?:
+'
+'		You start a Thread in your Form-UI-Thread and wait for it to complete in a
+'		loop. In the started Thread you Invoke(!) a Function to retrieve a Value. But the 
+'		UI-Thread is busy waiting for the started Thread to finish. So each one will wait 
+'		until the other other is finished - Or the User Ends the deadlocked freezed program.
+'		
+'		Right now this Is only applied To Class Windows.Forms.Form.
+'		
+'		Original Code-Source: http://www.codeproject.com/Articles/37642/Avoiding-InvokeRequired
+'===========================================================================================
+
+''' <summary>
+''' This Module addes Extension Methods and Funtions, to enhance the Class 
+''' <see cref="Windows.Forms.Form">Windows.Forms.Form.</see>/>. This will affect 
+''' all instances of the current Solution.
+''' </summary>
+<HideModuleName>
+Public Module ExtensionsClassForm
+
+	''' =========================================================================================================
+	''' <summary>
+	''' This starts a procedure on the thread the Form was created in.
+	''' <para>Use this with caution, in order to prevent any Deadlocks or DataCorruption.
+	''' This Funtion is using Invoke! This will prevent the calling thread from continuing, 
+	''' until the given Code has been executed.</para>
+	''' </summary>
+	''' <param name="Form"></param>
+	''' <param name="code">The Code that has to be invoked.</param>
+	<System.Runtime.CompilerServices.Extension>
+	Public Sub UIThread(Form As Form, code As Action)
+		If Form.InvokeRequired Then
+			Form.Invoke(code)
+			Return
+		End If
+		code.Invoke()
+	End Sub
+
+	''' =========================================================================================================
+	''' <summary>
+	''' <para>This starts a Function on the thread the Form was created in.</para>
+	''' Use this with caution, in order to prevent any Deadlocks or DataCorruption. 
+	''' This Funtion is using Invoke! This will prevent the calling thread from continuing, 
+	''' until the given Code has been executed.
+	''' </summary>
+	''' <param name="Form"></param>
+	''' <param name="code">The Code that has to be invoked.</param>
+	''' <returns>Returns whatever the Code is returning..</returns>
+	''' <remarks>
+	''' </remarks>
+	<System.Runtime.CompilerServices.Extension>
+	Public Function UIThread(Form As Form, code As Func(Of Object)) As Object
+		If Form.InvokeRequired Then
+			Return Form.Invoke(code)
+		End If
+		Return code.Invoke()
+	End Function
+
+	''' =========================================================================================================
+	''' <summary>
+	''' This starts a procedure on the thread the Form was created in. 
+	''' <para>Use this with caution, in order to prevent any Deadlocks or DataCorruption.</para>
+	''' </summary>
+	''' 
+	''' <param name="Form"></param>
+	''' <param name="code">The Code that has to be invoked.</param>
+	''' <param name="execAsync">Set this parameter to TRUE, if you want to exceute the Code via BeginInvoke.</param>
+	''' <remarks>
+	''' BeginInoke is only possible, if the calling thread is another thread than the Form-Owning-Thread.
+	''' </remarks>
+	<System.Runtime.CompilerServices.Extension>
+	Public Function UIThread(Form As Form, code As Func(Of Object), execAsync As Boolean) As Object
+		If execAsync = False Then
+
+			If Form.InvokeRequired Then
+				Return Form.Invoke(code)
+			End If
+			Return code.Invoke()
+		Else
+			If Form.InvokeRequired Then
+				Return Form.BeginInvoke(code)
+			End If
+			Return code.Invoke()
+		End If
+	End Function
+End Module

--- a/Tease AI/Tease AI.vbproj
+++ b/Tease AI/Tease AI.vbproj
@@ -150,6 +150,7 @@
     <Compile Include="Form9.vb">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="Modules\Extension.Class.Form.vb" />
     <Compile Include="My Project\AssemblyInfo.vb" />
     <Compile Include="My Project\Application.Designer.vb">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
Domme Tag APP is now working correctly.

BugFix Maximize Window:
Form1_Resize() didn't capture WindowState.Maximized =2, Instead it captured WindowState.Normal = 0 twice. I don't know why it was replaced at some point of development. Added Select Statement, because it's easier to read, that those conditions will never happen at the same time.

CodeCleanup:
Removed Functions Form_Resize() and tmrResize_Timer(). There were not referenced at all and irritating by their name.

Added several Regions and removed the DomWMP_Tick.

Added Module Extension.Form.Class:
This Module extends the Windows.Form.Form-Class to simplify the access from within another Thread. This Methods and Functions will be applied on all Forms in this Solution. For further information take a look at the File Description.

Found Bug: LoadSlideshowImage() is causing an unhandled CrossThreadException when the UI-Thread, BGW-Thread and Thr-Thread get out of sync.

Found Issue: GetDommeImage causing incorrect Text, when no Image for Garmentcovering is found.  This will give back an Image, that doesn't contain a Garment.  The DommeResponse will contain then "NULL" instead of the Garment-Name. But this goes for all GarmentCovering Images, that don't have a GarmentNameTag too. Maybe it should just show "garment" instead of "NULL"?
