### PR TITLE
BugFix: CustomSlideshow ThreadException

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Fixed bug where Glitter Contacts did not appear correctly during Multiple Edges 
 
 
 Fixes added from Community Members:
+	Stefaf: Bugfix: The Custom Slideshow randomly caused an IllegalCrossThreadCall, when the Slideshow was still running while the Domme is writing a Response.
 
 	Stefaf: Bugfix: UI-didn't resize on maximizing the window.
 	

--- a/Tease AI/Form1.Designer.vb
+++ b/Tease AI/Form1.Designer.vb
@@ -123,7 +123,6 @@ Partial Class Form1
 		Me.LoadNewSlideshowToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
 		Me.StatusUpdates = New System.Windows.Forms.WebBrowser()
 		Me.BWGlitter = New System.ComponentModel.BackgroundWorker()
-		Me.BWSlideshow = New System.ComponentModel.BackgroundWorker()
 		Me.TeaseAINotify = New System.Windows.Forms.NotifyIcon(Me.components)
 		Me.TeaseAIMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
 		Me.GamesToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -1251,8 +1250,8 @@ Partial Class Form1
 		'OpenFileDialog1
 		'
 		Me.OpenFileDialog1.FileName = "OpenFileDialog1"
-		Me.OpenFileDialog1.Filter = "JPEG Files (*.jpg)|*.jpg|PNG Files (*.png)|*.png|BMP Files (*.bmp)|*.bmp|All file" & _
-		  "s (*.*)|*.*"
+		Me.OpenFileDialog1.Filter = "JPEG Files (*.jpg)|*.jpg|PNG Files (*.png)|*.png|BMP Files (*.bmp)|*.bmp|All file" &
+	"s (*.*)|*.*"
 		Me.OpenFileDialog1.Title = "Select an image file"
 		'
 		'GetColor
@@ -1511,9 +1510,6 @@ Partial Class Form1
 		Me.StatusUpdates.Name = "StatusUpdates"
 		Me.StatusUpdates.Size = New System.Drawing.Size(245, 386)
 		Me.StatusUpdates.TabIndex = 770
-		'
-		'BWSlideshow
-		'
 		'
 		'TeaseAINotify
 		'
@@ -2763,8 +2759,8 @@ Partial Class Form1
 		Me.LBLWishListText.Name = "LBLWishListText"
 		Me.LBLWishListText.Size = New System.Drawing.Size(220, 109)
 		Me.LBLWishListText.TabIndex = 108
-		Me.LBLWishListText.Text = "This is something I really want, let me tell you all about why I want it, you sho" & _
-		  "uld buy it for me because you know you like buying stuff for me. "
+		Me.LBLWishListText.Text = "This is something I really want, let me tell you all about why I want it, you sho" &
+	"uld buy it for me because you know you like buying stuff for me. "
 		'
 		'LBLWishlistCost
 		'
@@ -4210,7 +4206,6 @@ Partial Class Form1
 	Friend WithEvents BWGlitter As System.ComponentModel.BackgroundWorker
 	Friend WithEvents ToolStripMenuItem5 As System.Windows.Forms.ToolStripMenuItem
 	Friend WithEvents CustomSlideshowTimer As Tease_AI.teaseAI_Timer
-	Friend WithEvents BWSlideshow As System.ComponentModel.BackgroundWorker
 	Friend WithEvents Contact1Timer As Tease_AI.teaseAI_Timer
 	Friend WithEvents Contact2Timer As Tease_AI.teaseAI_Timer
 	Friend WithEvents Contact3Timer As Tease_AI.teaseAI_Timer

--- a/Tease AI/Form1.resx
+++ b/Tease AI/Form1.resx
@@ -667,9 +667,6 @@
   <metadata name="BWGlitter.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>457, 17</value>
   </metadata>
-  <metadata name="BWSlideshow.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1299, 128</value>
-  </metadata>
   <metadata name="TeaseAINotify.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>641, 167</value>
   </metadata>

--- a/Tease AI/Form1.vb
+++ b/Tease AI/Form1.vb
@@ -393,8 +393,6 @@ Public Class Form1
 	Dim CustomSlideshowList As New List(Of String)
 	Dim ImageString As String
 
-	Private Thr As Threading.Thread
-
 	Dim RapidFire As Boolean
 
 	Public GlitterTease As Boolean
@@ -423,7 +421,6 @@ Public Class Form1
 	Public FinalRiskyPick As Boolean
 
 	Public TempGif As Image
-	Dim original As Image
 	Dim resized As Image
 
 	Dim SysMes As Boolean
@@ -20673,7 +20670,7 @@ Skip_RandomFile:
 		End If
 	End Sub
 
-#End Region
+#End Region ' Chatbox
 
 	Public Sub GetTnAList()
 
@@ -24234,54 +24231,15 @@ GetDommeSlideshow:
 
 	Private Sub CustomSlideshowTimer_Tick(sender As teaseAI_Timer, e As System.EventArgs) Handles CustomSlideshowTimer.Tick
 
-
-		BWSlideshow.RunWorkerAsync()
-
-
-	End Sub
-
-	Public Sub LoadSlideshowImage()
-
-		'ClearMainPictureBox()
-
-
 		ImageString = CustomSlideshowList(randomizer.Next(0, CustomSlideshowList.Count))
-
-
 		DeleteLocalImageFilePath = ImageString
 
 		Try
-			original = Image.FromFile(ImageString)
-			LBLImageInfo.Text = ImageString
-			CurrentImage = ImageString
-		Catch
-			original = Image.FromFile(Application.StartupPath & "\Images\System\NoLocalImagesFound.jpg")
-			DeleteLocalImageFilePath = ""
-			LBLImageInfo.Text = Application.StartupPath & "\Images\System\NoLocalImagesFound.jpg"
-			CurrentImage = Application.StartupPath & "\Images\System\NoLocalImagesFound.jpg"
+			ShowImage(ImageString)
+		Catch ex As Exception
+			Exit Sub
+
 		End Try
-
-		Debug.Print("CurrentImage = " & CurrentImage)
-
-		Try
-			resized = ResizeImage(original, New Size(mainPictureBox.Width, mainPictureBox.Height))
-		Catch
-			resized = Image.FromFile(Application.StartupPath & "\Images\System\NoLocalImagesFound.jpg")
-		End Try
-
-
-		mainPictureBox.Image = resized
-
-
-		'GC.Collect
-
-		Try
-			original.Dispose()
-		Catch
-		End Try
-
-
-
 	End Sub
 
 	Public Shared Function ResizeImage(ByVal image As Image, ByVal size As Size, Optional ByVal preserveAspectRatio As Boolean = True) As Image
@@ -24310,16 +24268,6 @@ GetDommeSlideshow:
 		Return newImage
 
 	End Function
-
-	Private Sub BWSlideshow_DoWork(sender As System.Object, e As System.ComponentModel.DoWorkEventArgs) Handles BWSlideshow.DoWork
-		'TODO: Integrate proper GBW-Usage
-		Control.CheckForIllegalCrossThreadCalls = False
-
-		Thr = New Threading.Thread(New Threading.ThreadStart(AddressOf LoadSlideshowImage))
-		Thr.SetApartmentState(ApartmentState.STA)
-		Thr.Start()
-
-	End Sub
 
 #Region "-------------------------------------------------- Contact 1-3 -------------------------------------------------------"
 
@@ -29173,7 +29121,7 @@ SkipNew:
 
 
 		Try
-			LBLImageInfo.Text = ImageLocation
+			Me.UIThread(Sub() LBLImageInfo.Text = ImageLocation)
 		Catch
 			LBLImageInfo.Text = "Error!"
 		End Try


### PR DESCRIPTION
The Custom Slideshow randomly caused an IllegalCrossThreadCall, when the Slideshow was still running while the Domme is writing a Response.
Neseccary Changes: Removed Thread "Thr", Removed Image-Variable "original",  Removed Sub LoadSlideshowImage(), which was the AddressOf "Thr",  Modified Sub CustomSlideshowTimer_Tick() , to call ShowImage() what is loading the Image Async., Removed Object BWSlideshow, Added Invoke to set the LBLImageInfo.Text in DisplayImage().
