### PR TITLE
Bugfix: @CheckFlag(abc, def)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Fixed bug where Glitter Contacts did not appear correctly during Multiple Edges 
 
 
 Fixes added from Community Members:
+	Stefaf: Bugfix: @CheckFlag(abc, def) Multiple Flags in Parentheses didn't work.
 
 	Stefaf: Bugfix: UI-didn't resize on maximizing the window.
 	

--- a/Tease AI/Form1.vb
+++ b/Tease AI/Form1.vb
@@ -10569,12 +10569,15 @@ RinseLatherRepeat:
 
 						Dim FlagArray() As String = CheckFlag.Split(",")
 
-						If File.Exists(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\System\Flags\" & FlagArray(0)) Or
-								File.Exists(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\System\Flags\Temp\" & FlagArray(0)) Then
-							SkipGotoLine = True
-							FileGoto = FlagArray(1)
-							GetGoto()
-						End If
+						For z As Integer = 0 To FlagArray.Length - 1
+							'Debug.Print("FlagArray(i) = " & FlagArray(i))
+							If File.Exists(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\System\Flags\" & FlagArray(z)) Or
+								File.Exists(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\System\Flags\Temp\" & FlagArray(z)) Then
+								SkipGotoLine = True
+								FileGoto = FlagArray(z)
+								GetGoto()
+							End If
+						Next
 
 					Else
 


### PR DESCRIPTION
Multiple Flags in Parentheses didn't work.
Updated Readme.
# Please Review the Changes!

I don't know, if this Code has been changed this way on purpose in commit https://github.com/Milo1885/Tease-AI/commit/1734288f3d4b61513e012e7bee209de4a019672a. This merge, will update the current Code, to work with multiple Flags in Parentheses and multiple @CheckFlag()-Statements.
