### PR TITLE
Improvement ImageLoading

### DIFF
--- a/Tease AI/Classes/BackgroundWorkerSyncable.vb
+++ b/Tease AI/Classes/BackgroundWorkerSyncable.vb
@@ -1,0 +1,128 @@
+﻿''' <summary>
+''' BackgroundWorker-Class to raise the RunWorkerCompleted-Event manually.
+''' </summary>
+Public Class BackgroundWorkerSyncable
+	Inherits System.ComponentModel.BackgroundWorker
+
+
+#Region "------------------------------------------------- Sync Required -------------------------------------------------------"
+
+	Private _SyncRequired As Boolean = True
+
+	Public ReadOnly Property SyncRequired As Boolean
+		Get
+			Return _SyncRequired
+		End Get
+	End Property
+
+#End Region ' Sync Required
+
+#Region "------------------------------------------------- MyBaseRelated -------------------------------------------------------"
+
+	''' =========================================================================================================
+	''' <summary>
+	''' Gets a value indicating whether the BackgroundWorker is running an asynchronous operation or delaying the
+	''' RunWorkerCompleted-Event.
+	''' </summary>
+	''' <returns></returns>
+	''' <remarks></remarks>
+	Shadows ReadOnly Property isBusy As Boolean
+		Get
+			If MyBase.IsBusy Or _ResultCache IsNot Nothing Then
+				Return True
+			Else
+				Return False
+			End If
+		End Get
+	End Property
+
+	''' =========================================================================================================
+	''' <summary>
+	''' Starts the Bachgroundworker async.
+	''' </summary>
+	''' <remarks></remarks>
+	''' <exception cref="InvalidOperationException">Occurs if you try to start a new thread, without syncing the 
+	''' previous results.</exception>
+	Public Shadows Sub RunWorkerAsync(Obj As Object, Optional ByVal SyncRequired As Boolean = True)
+		If _ResultCache IsNot Nothing Then Throw New InvalidOperationException("Starting is not allowed while a previous result is cached.")
+		_SyncRequired = SyncRequired
+		_SyncTimeOut = False
+		MyBase.RunWorkerAsync(Obj)
+	End Sub
+
+	Protected Overrides Sub OnRunWorkerCompleted(e As System.ComponentModel.RunWorkerCompletedEventArgs)
+		If _SyncTimeOut Then Exit Sub
+		If SyncRequired Then
+			_ResultCache = e
+		Else
+			MyBase.OnRunWorkerCompleted(e)
+		End If
+	End Sub
+
+#End Region  ' MyBase-Related
+
+#Region "------------------------------------------------- Sync Members --------------------------------------------------------"
+
+	''' <summary>
+	''' caches the result of the DoWork.Event, when _SyncReqired = True  
+	''' </summary>
+	''' <remarks></remarks>
+	Private _ResultCache As System.ComponentModel.RunWorkerCompletedEventArgs = Nothing
+
+	Private _SyncTimeOut As Boolean
+
+	''' <summary>
+	''' Raises the RunWorkerCompled-Event, when the process in me.DoWork has been
+	''' finished. Otherwise this function starts a Application.DoEvents-Loop on 
+	''' the calling thread until the BackgroundWorker has finished or an the given 
+	''' Time has elapsed.
+	''' </summary>
+	''' <param name="Timeout">Time to wait in seconds, before the timeout occurs. After 
+	''' a Timeout the RunWorkerCompleted-Event will not trigger and the Data processed 
+	''' by the Backgroundthread is lost!</param>
+	''' <remarks>If a Timeout occurs, CancelAsnyc() is called.</remarks>
+	''' <exception cref="TimeoutException">Occurs if the given time has elapsed.</exception>
+	''' <exception cref="Exception">Rethrows all exceptions occured in me.DoWork!</exception>
+	Public Sub WaitToFinish(Optional ByVal Timeout As Integer = 0)
+		' Declare new Stopwatch Instance for measering time 
+		Dim sw As New Stopwatch
+		' Start it, when a timeout is set.
+		If Timeout > 0 Then sw.Start()
+
+		' Wait until the Background worker has done his work.
+		Do While MyBase.IsBusy
+			' =============================== Timeout ==================================
+			If sw.ElapsedMilliseconds > Timeout * 1000 Then
+				'Stop the Watch
+				sw.Stop()
+				' Set marker -> This will prevent triggering the RunWorkerCompleted
+				' For this Current process.
+				_SyncTimeOut = True
+				' Cancel the Backgroundwork
+				If Me.WorkerSupportsCancellation Then Me.CancelAsync()
+				' Throw an Exception
+				Throw New TimeoutException("Timeout occured during Syncing ThreadResults.")
+			End If
+			' Don't block the calling thread.
+			Application.DoEvents()
+		Loop
+		If _ResultCache Is Nothing Then Exit Sub
+		' if an Error occured in BGW.DoWork the Error is "rethrown" here.
+		If Me._ResultCache.Error IsNot Nothing Then Throw Me._ResultCache.Error
+
+		MyBase.OnRunWorkerCompleted(_ResultCache)
+		CancelSync()
+	End Sub
+
+	''' <summary>
+	''' Cancels the current Syncing and deletes all fetched data.
+	''' </summary>
+	''' <remarks></remarks>
+	Public Sub CancelSync()
+		_ResultCache = Nothing
+		_SyncRequired = False
+	End Sub
+
+#End Region  ' Sync-Members
+
+End Class

--- a/Tease AI/Form1.vb
+++ b/Tease AI/Form1.vb
@@ -6467,15 +6467,15 @@ EndSysMes:
 							FrmCardList.PBRiskyPic.Image = Image.FromFile(DomPic)
 						ElseIf DommeImageFound = True Then
 							' ######################## Domme Tags #########################
-							ShowImage(DommeImageSTR)
+							ShowImage(DommeImageSTR, True)
 							DommeImageFound = False
 						ElseIf LocalImageFound = True Then
 							' ######################## Local Img. #########################
-							ShowImage(LocalImageSTR)
+							ShowImage(LocalImageSTR, True)
 							LocalImageFound = False
 						Else
 							' ######################## Slideshow ##########################
-							ShowImage(DomPic)
+							ShowImage(DomPic, True)
 						End If
 					Catch ex As Exception
 						'@@@@@@@@@@@@@@@@@@@@@@@ Exception @@@@@@@@@@@@@@@@@@@@@@@@
@@ -7354,15 +7354,15 @@ EndSysMes:
 							FrmCardList.PBRiskyPic.Image = Image.FromFile(DomPic)
 						ElseIf DommeImageFound = True Then
 							' ######################## Domme Tags #########################
-							ShowImage(DommeImageSTR)
+							ShowImage(DommeImageSTR, True)
 							DommeImageFound = False
 						ElseIf LocalImageFound = True Then
 							' ######################## Local Img. #########################
-							ShowImage(LocalImageSTR)
+							ShowImage(LocalImageSTR, True)
 							LocalImageFound = False
 						Else
 							' ######################## Slideshow ##########################
-							ShowImage(DomPic)
+							ShowImage(DomPic, True)
 						End If
 					Catch ex As Exception
 						'@@@@@@@@@@@@@@@@@@@@@@@ Exception @@@@@@@@@@@@@@@@@@@@@@@@
@@ -7569,7 +7569,6 @@ NullResponseLine2:
 					End If
 
 				End If
-
 			End If
 		End If
 
@@ -16261,7 +16260,7 @@ Skip_RandomFile:
 
 		If FoundString.Contains("/") Then
 			Try
-				ShowImage(FoundString)
+				ShowImage(FoundString, True)
 				'ImageLocation = FoundString
 				'PBImage = FoundString
 				'ImageThread.Start()
@@ -16273,7 +16272,7 @@ Skip_RandomFile:
 				MessageBox.Show(Me, "Failed to load image!", "Error!", MessageBoxButtons.OK, MessageBoxIcon.Exclamation)
 			End Try
 		Else
-			ShowImage(FoundString)
+			ShowImage(FoundString, True)
 			'ImageLocation = FoundString
 			'PBImage = FoundString
 			'ImageThread.Start()
@@ -21039,7 +21038,7 @@ AlreadySeen:
 
 			If FoundString.Contains("/") Then
 				Try
-					ShowImage(FoundString)
+					ShowImage(FoundString, True)
 					'ImageLocation = FoundString
 					'DisplayImage(FoundString)
 					'ImageThread.Start()
@@ -21049,7 +21048,7 @@ AlreadySeen:
 					MessageBox.Show(Me, "Failed to load image!", "Error!", MessageBoxButtons.OK, MessageBoxIcon.Exclamation)
 				End Try
 			Else
-				ShowImage(FoundString)
+				ShowImage(FoundString, True)
 				'ImageLocation = FoundString
 				'PBImage = FoundString
 				'ImageThread.Start()
@@ -23638,6 +23637,35 @@ TryNext:
 
 #Region "-------------------------------------------------- MainPictureBox ----------------------------------------------------"
 
+	Public Sub ShowImage(ByVal ImageToShow As String, ByVal WaitToFinish As Boolean)
+		If FormLoading = True Then Return
+
+		Debug.Print(
+				"    _____                                  ______     _         _      " & vbCrLf &
+				"   |_   _|                                |  ____|   | |       | |     " & vbCrLf &
+				"     | |   _ __ ___    __ _   __ _   ___  | |__  ___ | |_  ___ | |__   " & vbCrLf &
+				"     | |  | '_ ` _ \  / _` | / _` | / _ \ |  __|/ _ \| __|/ __|| '_ \  " & vbCrLf &
+				"    _| |_ | | | | | || (_| || (_| ||  __/ | |  |  __/| |_| (__ | | | | " & vbCrLf &
+				"   |_____||_| |_| |_| \__,_| \__, | \___| |_|   \___| \__|\___||_| |_| " & vbCrLf &
+				"                              __/ |                                    " & vbCrLf &
+				"                             |___/                                     " & vbCrLf &
+				" ImageLocation: " & ImageToShow & vbCrLf &
+				" WaitToFinish:  " & WaitToFinish)
+
+		Dim FetchContainer As New ImageFetchObject
+		FetchContainer.ImageLocation = ImageToShow
+
+		If FrmSettings.CBBlogImageWindow.Checked = True _
+		Then FetchContainer.SaveImageDirectory = Application.StartupPath & " \ Images \ Session Images\" _
+		Else FetchContainer.SaveImageDirectory = ""
+
+		BWimageFetcher.RunWorkerAsync(FetchContainer, True)
+
+
+		If WaitToFinish Then BWimageFetcher.WaitToFinish()
+
+	End Sub
+
 	Private Sub mainPictureBox_LoadCompleted(sender As Object, e As System.ComponentModel.AsyncCompletedEventArgs) Handles mainPictureBox.LoadCompleted
 		ImageLocation = mainPictureBox.ImageLocation
 		CheckDommeTags()
@@ -23650,7 +23678,111 @@ TryNext:
 		End If
 	End Sub
 
-#End Region
+#Region "---------------------------------------------------- BWimageSync -----------------------------------------------------"
+
+#Region "---------------------------------------------------- Declarations ----------------------------------------------------"
+
+	''' <summary>
+	''' Modified Backgroundworker to load and save images on a different thread, with tth possibility to trigger 
+	''' the RunWorkerCompleted-Event manually
+	''' </summary>
+	Private WithEvents BWimageFetcher As New Tease_AI.BackgroundWorkerSyncable
+
+	''' <summary>
+	''' Object to pass data to a differnt thread.
+	''' </summary>
+	Private Class ImageFetchObject
+		Public ImageLocation As String = ""
+
+		Private _SaveImageDirectory As String = ""
+
+		Public Property SaveImageDirectory As String
+			Get
+				Return _SaveImageDirectory
+			End Get
+			Set(value As String)
+				If Not value.EndsWith("\") Then
+					_SaveImageDirectory = value & "\"
+				Else
+					_SaveImageDirectory = value
+
+				End If
+			End Set
+		End Property
+
+		Public FetchedImage As Image = Nothing
+	End Class
+
+#End Region ' Declarations
+
+
+	''' <summary>
+	''' Invokes included! This function should be used in a thread.
+	''' </summary>
+	Private Sub BWimageFetcher_DoWork(ByVal sender As Object,
+							 ByVal e As System.ComponentModel.DoWorkEventArgs) Handles BWimageFetcher.DoWork
+
+		If TypeOf e.Argument Is ImageFetchObject Then
+			Dim FetchContainer As ImageFetchObject = e.Argument
+			Try
+				With FetchContainer
+					If .ImageLocation.Contains("/") And .ImageLocation.Contains("://") Then
+						' ###################### Online Image #########################
+						' Download the image
+						.FetchedImage = New Bitmap(New IO.MemoryStream(New System.Net.WebClient().DownloadData(.ImageLocation)))
+						'check if Folder is set and exists.
+						If .SaveImageDirectory <> "" _
+					AndAlso Directory.Exists(.SaveImageDirectory) Then
+							'Check if the destination Filename exists.
+							If Not File.Exists(.SaveImageDirectory & Path.GetFileName(.ImageLocation)) Then
+								.FetchedImage.Save(.SaveImageDirectory & Path.GetFileName(.ImageLocation))
+							End If
+						End If
+					Else
+						' ####################### Local Image #########################
+						.FetchedImage = Image.FromFile(.ImageLocation)
+					End If
+				End With
+			Catch ex As Exception
+				' Do nothing, Just for Debug.
+				Throw
+			End Try
+			' Return the fetched data to the UI-Thread
+			e.Result = FetchContainer
+		End If
+		Debug.Print("ImageFetch - DoWork - Done")
+	End Sub
+
+	Private Sub BWimageFetcher_RunWorkerCompleted(sender As Object, e As System.ComponentModel.RunWorkerCompletedEventArgs) Handles BWimageFetcher.RunWorkerCompleted
+		If e.Cancelled Then Exit Sub
+		If e.Error IsNot Nothing Then Exit Sub
+
+		If TypeOf e.Result Is ImageFetchObject Then
+			Dim FetchResult As ImageFetchObject = e.Result
+			Dim OldImage As Image = mainPictureBox.Image
+			Dim NewImage As Bitmap = FetchResult.FetchedImage.Clone
+
+			mainPictureBox.Image = NewImage
+			mainPictureBox.Refresh()
+			mainPictureBox.Invalidate()
+
+			PBImage = FetchResult.ImageLocation
+			ImageLocation = FetchResult.ImageLocation
+			LBLImageInfo.Text = FetchResult.ImageLocation
+
+			If OldImage IsNot Nothing Then
+				OldImage.Dispose()
+			End If
+			GC.Collect()
+			CheckDommeTags()
+			Debug.Print("ImageFetch - RunWorkerCompleted - Done" & vbCrLf &
+						"	ImageLocation: " & FetchResult.ImageLocation)
+		End If
+	End Sub
+
+#End Region ' BWimageSync
+
+#End Region ' MainPictureBox
 
 #Region "-------------------------------------------------- PictureStrip ------------------------------------------------------"
 
@@ -24235,7 +24367,7 @@ GetDommeSlideshow:
 		DeleteLocalImageFilePath = ImageString
 
 		Try
-			ShowImage(ImageString)
+			ShowImage(ImageString, True)
 		Catch ex As Exception
 			Exit Sub
 
@@ -29133,7 +29265,11 @@ SkipNew:
 
 		Me.Invoke(New Action(AddressOf CheckDommeTags))
 
-		Debug.Print("PBImageThread")
+		If Me.InvokeRequired Then
+			Debug.Print("PBImageThread --- On different Thread")
+		Else
+			Debug.Print("PBImageThread --- On UI-Thread")
+		End If
 
 
 	End Sub
@@ -29766,7 +29902,7 @@ SkipNew:
 		End Try
 
 
-		ShowGotImage()
+		 ShowGotImage()
 
 	End Sub
 

--- a/Tease AI/Tease AI.vbproj
+++ b/Tease AI/Tease AI.vbproj
@@ -97,6 +97,9 @@
     <Import Include="WMPLib" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Classes\BackgroundWorkerSyncable.vb">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Classes\myDirectory.vb" />
     <Compile Include="Classes\teaseAI_Timer.vb">
       <SubType>Component</SubType>


### PR DESCRIPTION
Status: Class is working, Integration Ongoing (This will be tricky).

Added Class BackgroundWorkerSyncable, basically a Wrapper around System.ComponentModel.BackgroundWorker.Addes members to wait for the Backgroundworker to complete in a Application.DoEvents Loop and for delayed triggering the RunWorkerCompleted-Event.

Description
Now Images can be loaded on a BackgroundThread, while the calling procedure stops, until the the image has been loaded. Even manually syncing is possible. Simply Call ShowImage(ImageUrl, False). This way the Calling procedure is not blocked until the Backgroundworker is finished. In this case the BackgroundWorker wont trigger the RunWorkerCompleted-Event until BWimageFetcher.WaitToFinish() is called. This way the calling procedure can work while the Backgroundworker loads and saves the File. But this is currently not recommended, because Tease-AI could do something unsuspected, like one of the more than 20 Timers calling the Backgroundworker again, while it's busy. The BackgroundWorker will remain busy until the RunWorkerCompleted-Event has been executed! This would throw an InvalidOperation-Exception.

Possible Improvements:
Add Timeout for pending RunWorkerCompleted-Event
