### PR TITLE
BugFix SaveSettingsimage, MuteMedia

### DIFF
--- a/Tease AI.sln
+++ b/Tease AI.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Basic Express 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "Tease AI", "Tease AI\Tease AI.vbproj", "{0471446B-925E-48F7-A6C4-8FDDD7AE2AA9}"
 EndProject
 Global

--- a/Tease AI/Form1.vb
+++ b/Tease AI/Form1.vb
@@ -29983,21 +29983,22 @@ SkipNew:
 	Public Sub SaveSessionImage(ByVal SessionImage As Image)
 
 		If FrmSettings.CBBlogImageWindow.Checked = True Then
-
 			Dim ImageFlag As String = ImageLocation
-			Do Until Not ImageFlag.Contains("/")
-				ImageFlag = ImageFlag.Remove(0, 1)
-			Loop
 
-			If Not File.Exists(Application.StartupPath & "\Images\Session Images\" & ImageFlag) Then
-				SessionImage.Save(Application.StartupPath & "\Images\Session Images\" & ImageFlag)
-				FrmSettings.CalculateSessionImages()
-			Else
-				Debug.Print("Session Image already exists")
+			'Skip all local Files.
+			If ImageFlag.Contains("/") And ImageFlag.Contains("://") Then
+				Do Until Not ImageFlag.Contains("/")
+					ImageFlag = ImageFlag.Remove(0, 1)
+				Loop
+
+				If Not File.Exists(Application.StartupPath & "\Images\Session Images\" & ImageFlag) Then
+					SessionImage.Save(Application.StartupPath & "\Images\Session Images\" & ImageFlag)
+					FrmSettings.CalculateSessionImages()
+				Else
+					Debug.Print("Session Image already exists")
+				End If
 			End If
-
 		End If
-
 	End Sub
 
 

--- a/Tease AI/Form2.Designer.vb
+++ b/Tease AI/Form2.Designer.vb
@@ -1394,6 +1394,8 @@ Partial Class FrmSettings
 		'CBMuteMedia
 		'
 		Me.CBMuteMedia.AutoSize = true
+		Me.CBMuteMedia.Checked = Global.Tease_AI.My.MySettings.Default.MuteMedia
+		Me.CBMuteMedia.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "MuteMedia", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
 		Me.CBMuteMedia.ForeColor = System.Drawing.Color.Black
 		Me.CBMuteMedia.Location = New System.Drawing.Point(7, 21)
 		Me.CBMuteMedia.Name = "CBMuteMedia"


### PR DESCRIPTION
Function SaveSettingsImage(Image) didn't check if the global "ImageLocation" contains Local Path or a remote. Added this Check.
Created DataBinding between CBMuteMedia and My.Seetings.MuteMedia. There is no chance this Setting isn't loading or saving anymore. The Binding is set on InitializeComponent. Afterwards each change of MySetting.MuteMedia will Update CBmutMedia.checked and vice versa.

As far as I know there is nothing more accurate than that.
