### PR TITLE
Bugfix: Function txt2List was not able to deal path = "" or Path = nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Tease-AI
 Tease AI is adult-oriented software that aims to create an interactive tease and denial experience by emulating an online chat session with a domme. 
 
+# Changelog - Patch 54
+
+Fixes added from Community Members:
+
+	Stefaf: Function txt2List(String) was not able to deal path = "" or path = nothing. Improved Error handling and logging.
+
 # Changelog - Patch 53
 
 Added check for empty string in MyDirectory Class

--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
 # Tease-AI
 Tease AI is adult-oriented software that aims to create an interactive tease and denial experience by emulating an online chat session with a domme. 
 
+# Todo:
+
+Stefaf: Integration of Class myDirectory: Status ongoing.
+	Testrun to sort Lists like Win-Explorer: Status Initial
+
 # Changelog - Patch 54
 
 Fixes added from Community Members:
 
 	Stefaf: Function txt2List(String) was not able to deal path = "" or path = nothing. Improved Error handling and logging.
-
+	
+	Stefaf: Added Offline-Mode-Support to the ImageDataContainer-Class and fixed some minor bugs in it.
+	
+	Stefaf: All lists retrieved with functions in Class myDirectory are now sorted alphabetically.
+	
 # Changelog - Patch 53
 
 Added check for empty string in MyDirectory Class

--- a/Tease AI/Classes/myDirectory.vb
+++ b/Tease AI/Classes/myDirectory.vb
@@ -12,11 +12,11 @@ Public NotInheritable Class myDirectory
 	''' </summary>
 	''' <param name="path">The path to test. </param>
 	''' <returns>true if path refers to an existing directory; false if the directory does not exist or 
-	''' an error occurs when trying to determine if the specified file exists.</returns>
+	''' an error occurs when trying to determine if the specified directory exists.</returns>
 	''' <remarks>BaseFunction to wrap around.</remarks>
 	Private Shared Function DirectoryCheck(path As String) As Boolean
 		If path.ToUpper = "No path selected".ToUpper Then Return False
-
+		If path = Nothing Then Return False
 		If path = "" Then Return False
 
 		If System.IO.Directory.Exists(path) Then

--- a/Tease AI/Classes/myDirectory.vb
+++ b/Tease AI/Classes/myDirectory.vb
@@ -41,6 +41,22 @@ Public NotInheritable Class myDirectory
 		End If
 	End Function
 
+	Private Shared Function Sort(SortObject As Object)
+		If TypeOf SortObject Is Array Then
+			'################## Arrays ###################
+			Array.Sort(DirectCast(SortObject, Array))
+			Return SortObject
+
+		ElseIf TypeOf SortObject Is List(Of String)
+			'############## List(of String) ##############
+			DirectCast(SortObject, List(Of String)).Sort()
+			Return SortObject
+
+		Else
+			Throw New InvalidCastException("Object Type unknown.")
+		End If
+	End Function
+
 	''' <summary>
 	''' Determines whether the given path refers to an existing directory on disk.
 	''' This Function creates the Root-directory if it doesn't extists and is a subdirectory of the 
@@ -72,7 +88,12 @@ Public NotInheritable Class myDirectory
 		' IF directory-check has failed return an empty String.Array
 		If DirectoryCheck(path) = False Then Return New List(Of String)().ToArray
 
-		Return System.IO.Directory.GetFiles(path)
+		' Read all Files 
+		Dim temp() As String = System.IO.Directory.GetFiles(path)
+
+		' Sort the result and return it
+		Return Sort(temp)
+
 	End Function
 
 	''' <summary>
@@ -95,7 +116,12 @@ Public NotInheritable Class myDirectory
 		' IF directory-check has failed return an empty String.Array
 		If DirectoryCheck(path) = False Then Return New List(Of String)().ToArray
 
-		Return System.IO.Directory.GetFiles(path, searchPattern)
+		' Read all Files with the given pattern
+		Dim temp() As String = System.IO.Directory.GetFiles(path, searchPattern)
+
+		' Sort the result and return it
+		Return Sort(temp)
+
 	End Function
 
 	''' <summary>
@@ -122,7 +148,12 @@ Public NotInheritable Class myDirectory
 		' IF directory-check has failed return an empty String.Array
 		If DirectoryCheck(path) = False Then Return New List(Of String)().ToArray
 
-		Return System.IO.Directory.GetFiles(path, searchPattern, searchOption)
+		' Read all Files with the given pattern and Searchoption
+		Dim temp() As String = System.IO.Directory.GetFiles(path, searchPattern, searchOption)
+
+		' Sort the result and return it
+		Return Sort(temp)
+
 	End Function
 
 #End Region
@@ -138,8 +169,13 @@ Public NotInheritable Class myDirectory
 				filter(i) = filter(i).ToLower
 			Next
 
-			Return myDirectory.GetFiles(path, "*", searchOption) _
+			' Read get all Files with the given pattern
+			Dim temp As List(Of String) = myDirectory.GetFiles(path, "*", searchOption) _
 					.Where(Function(f) filter.Contains(System.IO.Path.GetExtension(f).ToLower())).ToList
+
+			' Sort the result and return it
+			Return Sort(temp)
+
 		Catch ex As Exception
 			Throw
 		End Try

--- a/Tease AI/Form1.vb
+++ b/Tease AI/Form1.vb
@@ -24833,29 +24833,11 @@ GetDommeSlideshow:
 		_ImageFileNames.Clear()
 
 
-		Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-
-
-		Dim files As String()
-
 		If FrmSettings.CBSlideshowSubDir.Checked = True Then
-			files = myDirectory.GetFiles(GetFolder, "*.*", SearchOption.AllDirectories)
+			_ImageFileNames = myDirectory.GetFilesImages(GetFolder, SearchOption.AllDirectories)
 		Else
-			files = myDirectory.GetFiles(GetFolder, "*.*")
+			_ImageFileNames = myDirectory.GetFilesImages(GetFolder, SearchOption.TopDirectoryOnly)
 		End If
-
-
-		Array.Sort(files)
-
-
-
-		Dim TestCOUnt As Integer = 0
-		For Each fi As String In files
-			If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-				TestCOUnt += 1
-				_ImageFileNames.Add(fi)
-			End If
-		Next
 
 		FileCountMax = _ImageFileNames.Count - 1
 

--- a/Tease AI/Form1.vb
+++ b/Tease AI/Form1.vb
@@ -24994,51 +24994,70 @@ GetDommeSlideshow:
 
 	''' =========================================================================================================
 	''' <summary>
-	''' Reads a TextFile to a generic List(of String).
+	''' Reads a TextFile into a generic List(of String). EmptyLines are removed from the list.
 	''' </summary>
 	''' <param name="GetText">The Filepath to read.</param>
 	''' <returns>A List(of String) containing all Lines of the given File. Returns 
-	''' "Nothing" if the specified file doesn't exists.</returns>
+	''' an empty List if the specified file doesn't exists, or an exception occurs.</returns>
 	''' <remarks>This Method will create the given DirectoryStructure for the given
-	''' Filepath if it doesn't exists.</remarks>
+	''' Filepath if it doesn't exist.</remarks>
 	Public Shared Function Txt2List(ByVal GetText As String) As List(Of String)
+		Try
+			If GetText = Nothing Then Return New List(Of String)
+			' Check if the given Directory exists. MyDirectory.Exists will 
+			' try to create the directory, if it's an App-sub-dir.
+			If myDirectory.Exists(Path.GetDirectoryName(Path.GetFullPath(GetText))) Then
+				Log.Write("Loading Text-File: " & GetText, 5)
+				If File.Exists(GetText) Then
+					Using TextReader As New StreamReader(GetText)
+						Dim TextList As New List(Of String)
 
-		' check if the given Directory Exits, otherwise a IO.DirectoryNotFound Exception occurs.
-		If Directory.Exists(Path.GetDirectoryName(GetText)) = False Then
-			Directory.CreateDirectory(Path.GetDirectoryName(GetText))
-		End If
-		Log.Write("Load File: " & GetText, 5)
-		If File.Exists(GetText) Then
-			Using TextReader As New StreamReader(GetText)
-				Dim TextList As New List(Of String)
-				TextList.Clear()
-				While TextReader.Peek <> -1
-					TextList.Add(TextReader.ReadLine())
-				End While
+						While TextReader.Peek <> -1
+							TextList.Add(TextReader.ReadLine())
+						End While
 
-				' Remove all empty Lines from list.
-				TextList.RemoveAll(Function(x) x = "")
+						' Remove all empty Lines from list.
+						TextList.RemoveAll(Function(x) x = "")
 
-				Return TextList
-			End Using
-		End If
-		Return Nothing
+						Return TextList
+					End Using
+				End If
+			End If
+		Catch ex As Exception
+			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+			'						       All Errors
+			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+			Log.WriteError(ex.Message, ex, "Error loading TextFile: " & GetText)
+		End Try
+		Return New List(Of String)
 	End Function
 
-
+	''' =========================================================================================================
+	''' <summary>
+	''' Reads the First line of the given textfile.
+	''' </summary>
+	''' <param name="GetText">On success the first line as string. Otherwise an
+	''' empty String.</param>
+	''' <returns></returns>
 	Public Shared Function TxtReadLine(ByVal GetText As String) As String
-
-		' check if the given Directory Exits, otherwise a IO.DirectoryNotFound Exception occurs.
-		If Directory.Exists(Path.GetDirectoryName(GetText)) = False Then
-			Directory.CreateDirectory(Path.GetDirectoryName(GetText))
-		End If
-
-		If File.Exists(GetText) Then
-			Using TextReader As New StreamReader(GetText)
-				Return TextReader.ReadLine
-			End Using
-		End If
-		Return Nothing
+		Try
+			If GetText = Nothing Then Return Nothing
+			' Check if the given Directory exists. MyDirectory.Exists will 
+			' try to create the directory, if it's an App-sub-dir.
+			If myDirectory.Exists(Path.GetDirectoryName(Path.GetFullPath(GetText))) Then
+				If File.Exists(GetText) Then
+					Using TextReader As New StreamReader(GetText)
+						Return TextReader.ReadLine
+					End Using
+				End If
+			End If
+		Catch ex As Exception
+			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+			'						       All Errors
+			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+			Log.WriteError(ex.Message, ex, "Error loading TextFile: " & GetText)
+		End Try
+		Return ""
 	End Function
 
 


### PR DESCRIPTION
Changed reference form IO.Directory to myDirectory. 
Added relative Path-support. 
Changed failure return Object to New List(of String) in order to work with Iterations, without causing a NullRefernceException. 
Added Try-Catch-Block and Exception-Logging. 
All these changes have been applied to TxtReadLine also.
Added Check if path is "Nothing/NULL" to myDirectory.DirectoryCheck(Path string)
