### PR TITLE
ImageDataObject Integration

### DIFF
--- a/Tease AI/Classes/Common.vb
+++ b/Tease AI/Classes/Common.vb
@@ -1,0 +1,101 @@
+﻿'===========================================================================================
+'
+'									 Common.vb
+'
+' This file contains general functions not related to specific Tasks in Tease-AI.
+'===========================================================================================
+Imports System.IO
+
+
+''' <summary>
+''' Exposes static methods for common tasks.
+''' </summary>
+Public Class Common
+
+#Region "--------------------------------------- TextFiles ----------------------------------------------"
+
+	''' =========================================================================================================
+	''' <summary>
+	''' Reads a TextFile into a generic List(of String). EmptyLines are removed from the list.
+	''' </summary>
+	''' <param name="GetText">The Filepath to read.</param>
+	''' <returns>A List(of String) containing all Lines of the given File. Returns 
+	''' an empty List if the specified file doesn't exists, or an exception occurs.</returns>
+	''' <remarks>This Method will create the given DirectoryStructure for the given
+	''' Filepath if it doesn't exist.</remarks>
+	Friend Shared Function Txt2List(ByVal GetText As String) As List(Of String)
+		Try
+			If GetText = Nothing Then Return New List(Of String)
+			' Check if the given Directory exists. MyDirectory.Exists will 
+			' try to create the directory, if it's an App-sub-dir.
+			If myDirectory.Exists(Path.GetDirectoryName(Path.GetFullPath(GetText))) Then
+				Log.Write("Loading Text-File: " & GetText, 5)
+				If File.Exists(GetText) Then
+					Using TextReader As New StreamReader(GetText)
+						Dim TextList As New List(Of String)
+
+						While TextReader.Peek <> -1
+							TextList.Add(TextReader.ReadLine())
+						End While
+
+						' Remove all empty Lines from list.
+						TextList.RemoveAll(Function(x) x = "")
+
+						Return TextList
+					End Using
+				End If
+			End If
+		Catch ex As Exception
+			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+			'						       All Errors
+			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+			Log.WriteError(ex.Message, ex, "Error loading TextFile: " & GetText)
+		End Try
+		Return New List(Of String)
+	End Function
+
+	''' =========================================================================================================
+	''' <summary>
+	''' Reads the First line of the given textfile.
+	''' </summary>
+	''' <param name="GetText">On success the first line as string. Otherwise an
+	''' empty String.</param>
+	''' <returns></returns>
+	Friend Shared Function TxtReadLine(ByVal GetText As String) As String
+		Try
+			If GetText = Nothing Then Return Nothing
+			' Check if the given Directory exists. MyDirectory.Exists will 
+			' try to create the directory, if it's an App-sub-dir.
+			If myDirectory.Exists(Path.GetDirectoryName(Path.GetFullPath(GetText))) Then
+				If File.Exists(GetText) Then
+					Using TextReader As New StreamReader(GetText)
+						Return TextReader.ReadLine
+					End Using
+				End If
+			End If
+		Catch ex As Exception
+			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+			'						       All Errors
+			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+			Log.WriteError(ex.Message, ex, "Error loading TextFile: " & GetText)
+		End Try
+		Return ""
+	End Function
+
+#End Region ' TextFiles
+
+	''' =========================================================================================================
+	''' <summary>
+	''' Checks if the given string is an URL.
+	''' </summary>
+	''' <param name="path">The string to be tested.</param>
+	''' <returns>True if the given string is an URL.</returns>
+	Friend Shared Function isURL(path As String) As Boolean
+		If path.Contains("/") And path.Contains("://") Then
+			Return True
+		Else
+			Return False
+		End If
+	End Function
+
+End Class

--- a/Tease AI/Form1.vb
+++ b/Tease AI/Form1.vb
@@ -5406,7 +5406,7 @@ SkipGotoSearch:
 
 			Debug.Print("FileGoto = " & FileGoto)
 
-			Dim gotoline As Integer = 0
+			Dim gotoline As Integer = -1
 			Do
 				gotoline += 1
 				If GotoDommeLevel = True And gotoline = CountGotoLines Then
@@ -9661,398 +9661,100 @@ StatusUpdateEnd:
 
 		If StringClean.Contains("#RandomSlideshowCategory") Then StringClean = StringClean.Replace("#RandomSlideshowCategory", RandomSlideshowCategory)
 
+        '▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+        '                                   ImageCount
+        '▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+        If StringClean.Contains("#LocalImageCount") Then
+			Dim temp As Dictionary(Of ImageGenre, ImageDataContainer) = GetImageData()
+			Dim counter As Integer = 0
 
-		If StringClean.Contains("#LocalImageCount") Then
-            'TODO: Implement ImageDataobject
-
-            Dim CheckString As String
-			Dim CheckBoolean As Boolean
-			Dim LocalList As New List(Of String)
-			LocalList.Clear()
-
-			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-			Dim files As String()
-
-			For i As Integer = 1 To 11
-				CheckString = "NULL"
-				CheckBoolean = False
-				If i = 1 And FrmSettings.CBIHardcore.Checked = True And Directory.Exists(FrmSettings.LBLIHardcore.Text) Then CheckString = FrmSettings.LBLIHardcore.Text
-				If i = 2 And FrmSettings.CBISoftcore.Checked = True And Directory.Exists(FrmSettings.LBLISoftcore.Text) Then CheckString = FrmSettings.LBLISoftcore.Text
-				If i = 3 And FrmSettings.CBILesbian.Checked = True And Directory.Exists(FrmSettings.LBLILesbian.Text) Then CheckString = FrmSettings.LBLILesbian.Text
-				If i = 4 And FrmSettings.CBIBlowjob.Checked = True And Directory.Exists(FrmSettings.LBLIBlowjob.Text) Then CheckString = FrmSettings.LBLIBlowjob.Text
-				If i = 5 And FrmSettings.CBIFemdom.Checked = True And Directory.Exists(FrmSettings.LBLIFemdom.Text) Then CheckString = FrmSettings.LBLIFemdom.Text
-				If i = 6 And FrmSettings.CBILezdom.Checked = True And Directory.Exists(FrmSettings.LBLILezdom.Text) Then CheckString = FrmSettings.LBLILezdom.Text
-				If i = 7 And FrmSettings.CBIHentai.Checked = True And Directory.Exists(FrmSettings.LBLIHentai.Text) Then CheckString = FrmSettings.LBLIHentai.Text
-				If i = 8 And FrmSettings.CBIGay.Checked = True And Directory.Exists(FrmSettings.LBLIGay.Text) Then CheckString = FrmSettings.LBLIGay.Text
-				If i = 9 And FrmSettings.CBIMaledom.Checked = True And Directory.Exists(FrmSettings.LBLIMaledom.Text) Then CheckString = FrmSettings.LBLIMaledom.Text
-				If i = 10 And FrmSettings.CBICaptions.Checked = True And Directory.Exists(FrmSettings.LBLICaptions.Text) Then CheckString = FrmSettings.LBLICaptions.Text
-				If i = 11 And FrmSettings.CBIGeneral.Checked = True And Directory.Exists(FrmSettings.LBLIGeneral.Text) Then CheckString = FrmSettings.LBLIGeneral.Text
-
-				If i = 1 And FrmSettings.CBIHardcoreSD.Checked = True Then CheckBoolean = True
-				If i = 2 And FrmSettings.CBISoftcoreSD.Checked = True Then CheckBoolean = True
-				If i = 3 And FrmSettings.CBILesbianSD.Checked = True Then CheckBoolean = True
-				If i = 4 And FrmSettings.CBIBlowjobSD.Checked = True Then CheckBoolean = True
-				If i = 5 And FrmSettings.CBIFemdomSD.Checked = True Then CheckBoolean = True
-				If i = 6 And FrmSettings.CBILezdomSD.Checked = True Then CheckBoolean = True
-				If i = 7 And FrmSettings.CBIHentaiSD.Checked = True Then CheckBoolean = True
-				If i = 8 And FrmSettings.CBIGaySD.Checked = True Then CheckBoolean = True
-				If i = 9 And FrmSettings.CBIMaledomSD.Checked = True Then CheckBoolean = True
-				If i = 10 And FrmSettings.CBICaptionsSD.Checked = True Then CheckBoolean = True
-				If i = 11 And FrmSettings.CBIGeneralSD.Checked = True Then CheckBoolean = True
-
-
-				If Not CheckString = "NULL" Then
-					If CheckBoolean = True Then
-						files = myDirectory.GetFiles(CheckString, "*.*", SearchOption.AllDirectories)
-					Else
-						files = myDirectory.GetFiles(CheckString, "*.*")
-					End If
-					Array.Sort(files)
-					For Each fi As String In files
-						If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-							LocalList.Add(fi)
-						End If
-					Next
-				End If
+			For Each genre As ImageGenre In temp.Keys
+				counter += temp(genre).CountImages(ImageSourceType.Local)
 			Next
 
-			StringClean = StringClean.Replace("#LocalImageCount", LocalList.Count)
-
+			StringClean = StringClean.Replace("#LocalImageCount", counter)
 		End If
 
+		If StringClean.Contains("#BlogImageCount") Then
+			StringClean = StringClean.Replace("#BlogImageCount", GetImageData(ImageGenre.Blog).CountImages())
+		End If
 
+		If StringClean.Contains("#ButtImageCount") Then
+			StringClean = StringClean.Replace("#ButtImageCount", GetImageData(ImageGenre.Butt).CountImages())
+		End If
+
+		If StringClean.Contains("#ButtsImageCount") Then
+			StringClean = StringClean.Replace("#ButtsImageCount", GetImageData(ImageGenre.Butt).CountImages())
+		End If
+
+		If StringClean.Contains("#BoobImageCount") Then
+			StringClean = StringClean.Replace("#BoobImageCount", GetImageData(ImageGenre.Boobs).CountImages())
+		End If
+
+		If StringClean.Contains("#BoobsImageCount") Then
+			StringClean = StringClean.Replace("#BoobsImageCount", GetImageData(ImageGenre.Boobs).CountImages())
+		End If
 
 		If StringClean.Contains("#HardcoreImageCount") Then
-            'TODO: Implement ImageDataobject
-            Dim CheckString As String
-            Dim CheckBoolean As Boolean
-			Dim LocalList As New List(Of String)
-			LocalList.Clear()
-			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-			Dim files As String()
-			CheckString = "NULL"
-			CheckBoolean = False
-			If FrmSettings.CBIHardcore.Checked = True And Directory.Exists(FrmSettings.LBLIHardcore.Text) Then CheckString = FrmSettings.LBLIHardcore.Text
-			If FrmSettings.CBIHardcoreSD.Checked = True Then CheckBoolean = True
-			If Not CheckString = "NULL" Then
-				If CheckBoolean = True Then
-					files = myDirectory.GetFiles(CheckString, "*.*", SearchOption.AllDirectories)
-				Else
-					files = myDirectory.GetFiles(CheckString, "*.*")
-				End If
-				Array.Sort(files)
-				For Each fi As String In files
-					If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-						LocalList.Add(fi)
-					End If
-				Next
-			End If
-			StringClean = StringClean.Replace("#HardcoreImageCount", LocalList.Count)
+			StringClean = StringClean.Replace("#HardcoreImageCount", GetImageData(ImageGenre.Hardcore).CountImages())
+		End If
+
+		If StringClean.Contains("#HardcoreImageCount") Then
+			StringClean = StringClean.Replace("#HardcoreImageCount", GetImageData(ImageGenre.Hardcore).CountImages())
 		End If
 
 		If StringClean.Contains("#SoftcoreImageCount") Then
-            'TODO: Implement ImageDataobject
-            Dim CheckString As String
-            Dim CheckBoolean As Boolean
-			Dim LocalList As New List(Of String)
-			LocalList.Clear()
-			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-			Dim files As String()
-			CheckString = "NULL"
-			CheckBoolean = False
-			If FrmSettings.CBISoftcore.Checked = True And Directory.Exists(FrmSettings.LBLISoftcore.Text) Then CheckString = FrmSettings.LBLISoftcore.Text
-			If FrmSettings.CBISoftcoreSD.Checked = True Then CheckBoolean = True
-			If Not CheckString = "NULL" Then
-				If CheckBoolean = True Then
-					files = myDirectory.GetFiles(CheckString, "*.*", SearchOption.AllDirectories)
-				Else
-					files = myDirectory.GetFiles(CheckString, "*.*")
-				End If
-				Array.Sort(files)
-				For Each fi As String In files
-					If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-						LocalList.Add(fi)
-					End If
-				Next
-			End If
-			StringClean = StringClean.Replace("#SoftcoreImageCount", LocalList.Count)
+			StringClean = StringClean.Replace("#SoftcoreImageCount", GetImageData(ImageGenre.Softcore).CountImages())
 		End If
 
 		If StringClean.Contains("#LesbianImageCount") Then
-            'TODO: Implement ImageDataobject
-            Dim CheckString As String
-            Dim CheckBoolean As Boolean
-			Dim LocalList As New List(Of String)
-			LocalList.Clear()
-			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-			Dim files As String()
-			CheckString = "NULL"
-			CheckBoolean = False
-			If FrmSettings.CBILesbian.Checked = True And Directory.Exists(FrmSettings.LBLILesbian.Text) Then CheckString = FrmSettings.LBLILesbian.Text
-			If FrmSettings.CBILesbianSD.Checked = True Then CheckBoolean = True
-			If Not CheckString = "NULL" Then
-				If CheckBoolean = True Then
-					files = myDirectory.GetFiles(CheckString, "*.*", SearchOption.AllDirectories)
-				Else
-					files = myDirectory.GetFiles(CheckString, "*.*")
-				End If
-				Array.Sort(files)
-				For Each fi As String In files
-					If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-						LocalList.Add(fi)
-					End If
-				Next
-			End If
-			StringClean = StringClean.Replace("#LesbianImageCount", LocalList.Count)
+			StringClean = StringClean.Replace("#LesbianImageCount", GetImageData(ImageGenre.Lesbian).CountImages())
 		End If
 
 		If StringClean.Contains("#BlowjobImageCount") Then
-            'TODO: Implement ImageDataobject
-            Dim CheckString As String
-            Dim CheckBoolean As Boolean
-			Dim LocalList As New List(Of String)
-			LocalList.Clear()
-			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-			Dim files As String()
-			CheckString = "NULL"
-			CheckBoolean = False
-			If FrmSettings.CBIBlowjob.Checked = True And Directory.Exists(FrmSettings.LBLIBlowjob.Text) Then CheckString = FrmSettings.LBLIBlowjob.Text
-			If FrmSettings.CBIBlowjobSD.Checked = True Then CheckBoolean = True
-			If Not CheckString = "NULL" Then
-				If CheckBoolean = True Then
-					files = myDirectory.GetFiles(CheckString, "*.*", SearchOption.AllDirectories)
-				Else
-					files = myDirectory.GetFiles(CheckString, "*.*")
-				End If
-				Array.Sort(files)
-				For Each fi As String In files
-					If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-						LocalList.Add(fi)
-					End If
-				Next
-			End If
-			StringClean = StringClean.Replace("#BlowjobImageCount", LocalList.Count)
+			StringClean = StringClean.Replace("#BlowjobImageCount", GetImageData(ImageGenre.Blowjob).CountImages())
 		End If
 
 		If StringClean.Contains("#FemdomImageCount") Then
-            'TODO: Implement ImageDataobject
-            Dim CheckString As String
-            Dim CheckBoolean As Boolean
-			Dim LocalList As New List(Of String)
-			LocalList.Clear()
-			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-			Dim files As String()
-			CheckString = "NULL"
-			CheckBoolean = False
-			If FrmSettings.CBIFemdom.Checked = True And Directory.Exists(FrmSettings.LBLIFemdom.Text) Then CheckString = FrmSettings.LBLIFemdom.Text
-			If FrmSettings.CBIFemdomSD.Checked = True Then CheckBoolean = True
-			If Not CheckString = "NULL" Then
-				If CheckBoolean = True Then
-					files = myDirectory.GetFiles(CheckString, "*.*", SearchOption.AllDirectories)
-				Else
-					files = myDirectory.GetFiles(CheckString, "*.*")
-				End If
-				Array.Sort(files)
-				For Each fi As String In files
-					If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-						LocalList.Add(fi)
-					End If
-				Next
-			End If
-			StringClean = StringClean.Replace("#FemdomImageCount", LocalList.Count)
+			StringClean = StringClean.Replace("#FemdomImageCount", GetImageData(ImageGenre.Femdom).CountImages())
 		End If
 
 		If StringClean.Contains("#LezdomImageCount") Then
-            'TODO: Implement ImageDataobject
-            Dim CheckString As String
-            Dim CheckBoolean As Boolean
-			Dim LocalList As New List(Of String)
-			LocalList.Clear()
-			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-			Dim files As String()
-			CheckString = "NULL"
-			CheckBoolean = False
-			If FrmSettings.CBILezdom.Checked = True And Directory.Exists(FrmSettings.LBLILezdom.Text) Then CheckString = FrmSettings.LBLILezdom.Text
-			If FrmSettings.CBILezdomSD.Checked = True Then CheckBoolean = True
-			If Not CheckString = "NULL" Then
-				If CheckBoolean = True Then
-					files = myDirectory.GetFiles(CheckString, "*.*", SearchOption.AllDirectories)
-				Else
-					files = myDirectory.GetFiles(CheckString, "*.*")
-				End If
-				Array.Sort(files)
-				For Each fi As String In files
-					If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-						LocalList.Add(fi)
-					End If
-				Next
-			End If
-			StringClean = StringClean.Replace("#LezdomImageCount", LocalList.Count)
+			StringClean = StringClean.Replace("#LezdomImageCount", GetImageData(ImageGenre.Lezdom).CountImages())
 		End If
 
 		If StringClean.Contains("#HentaiImageCount") Then
-            'TODO: Implement ImageDataobject
-            Dim CheckString As String
-            Dim CheckBoolean As Boolean
-			Dim LocalList As New List(Of String)
-			LocalList.Clear()
-			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-			Dim files As String()
-			CheckString = "NULL"
-			CheckBoolean = False
-			If FrmSettings.CBIHentai.Checked = True And Directory.Exists(FrmSettings.LBLIHentai.Text) Then CheckString = FrmSettings.LBLIHentai.Text
-			If FrmSettings.CBIHentaiSD.Checked = True Then CheckBoolean = True
-			If Not CheckString = "NULL" Then
-				If CheckBoolean = True Then
-					files = myDirectory.GetFiles(CheckString, "*.*", SearchOption.AllDirectories)
-				Else
-					files = myDirectory.GetFiles(CheckString, "*.*")
-				End If
-				Array.Sort(files)
-				For Each fi As String In files
-					If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-						LocalList.Add(fi)
-					End If
-				Next
-			End If
-			StringClean = StringClean.Replace("#HentaiImageCount", LocalList.Count)
+			StringClean = StringClean.Replace("#HentaiImageCount", GetImageData(ImageGenre.Hentai).CountImages())
 		End If
 
 		If StringClean.Contains("#GayImageCount") Then
-            'TODO: Implement ImageDataobject
-            Dim CheckString As String
-            Dim CheckBoolean As Boolean
-			Dim LocalList As New List(Of String)
-			LocalList.Clear()
-			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-			Dim files As String()
-			CheckString = "NULL"
-			CheckBoolean = False
-			If FrmSettings.CBIGay.Checked = True And Directory.Exists(FrmSettings.LBLIGay.Text) Then CheckString = FrmSettings.LBLIGay.Text
-			If FrmSettings.CBIGaySD.Checked = True Then CheckBoolean = True
-			If Not CheckString = "NULL" Then
-				If CheckBoolean = True Then
-					files = myDirectory.GetFiles(CheckString, "*.*", SearchOption.AllDirectories)
-				Else
-					files = myDirectory.GetFiles(CheckString, "*.*")
-				End If
-				Array.Sort(files)
-				For Each fi As String In files
-					If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-						LocalList.Add(fi)
-					End If
-				Next
-			End If
-			StringClean = StringClean.Replace("#GayImageCount", LocalList.Count)
+			StringClean = StringClean.Replace("#GayImageCount", GetImageData(ImageGenre.Gay).CountImages())
 		End If
 
 		If StringClean.Contains("#MaledomImageCount") Then
-            'TODO: Implement ImageDataobject
-            Dim CheckString As String
-            Dim CheckBoolean As Boolean
-			Dim LocalList As New List(Of String)
-			LocalList.Clear()
-			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-			Dim files As String()
-			CheckString = "NULL"
-			CheckBoolean = False
-			If FrmSettings.CBIMaledom.Checked = True And Directory.Exists(FrmSettings.LBLIMaledom.Text) Then CheckString = FrmSettings.LBLIMaledom.Text
-			If FrmSettings.CBIMaledomSD.Checked = True Then CheckBoolean = True
-			If Not CheckString = "NULL" Then
-				If CheckBoolean = True Then
-					files = myDirectory.GetFiles(CheckString, "*.*", SearchOption.AllDirectories)
-				Else
-					files = myDirectory.GetFiles(CheckString, "*.*")
-				End If
-				Array.Sort(files)
-				For Each fi As String In files
-					If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-						LocalList.Add(fi)
-					End If
-				Next
-			End If
-			StringClean = StringClean.Replace("#MaledomImageCount", LocalList.Count)
+			StringClean = StringClean.Replace("#MaledomImageCount", GetImageData(ImageGenre.Maledom).CountImages())
 		End If
 
 		If StringClean.Contains("#CaptionsImageCount") Then
-            'TODO: Implement ImageDataobject
-            Dim CheckString As String
-            Dim CheckBoolean As Boolean
-			Dim LocalList As New List(Of String)
-			LocalList.Clear()
-			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-			Dim files As String()
-			CheckString = "NULL"
-			CheckBoolean = False
-			If FrmSettings.CBICaptions.Checked = True And Directory.Exists(FrmSettings.LBLICaptions.Text) Then CheckString = FrmSettings.LBLICaptions.Text
-			If FrmSettings.CBICaptionsSD.Checked = True Then CheckBoolean = True
-			If Not CheckString = "NULL" Then
-				If CheckBoolean = True Then
-					files = myDirectory.GetFiles(CheckString, "*.*", SearchOption.AllDirectories)
-				Else
-					files = myDirectory.GetFiles(CheckString, "*.*")
-				End If
-				Array.Sort(files)
-				For Each fi As String In files
-					If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-						LocalList.Add(fi)
-					End If
-				Next
-			End If
-			StringClean = StringClean.Replace("#CaptionsImageCount", LocalList.Count)
+			StringClean = StringClean.Replace("#CaptionsImageCount", GetImageData(ImageGenre.Captions).CountImages())
 		End If
 
-        If StringClean.Contains("#GeneralImageCount") Then
-            'TODO: Implement ImageDataobject
-            Dim CheckString As String
-            Dim CheckBoolean As Boolean
-            Dim LocalList As New List(Of String)
-            LocalList.Clear()
-            Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-            Dim files As String()
-            CheckString = "NULL"
-            CheckBoolean = False
-            If FrmSettings.CBIGeneral.Checked = True And Directory.Exists(FrmSettings.LBLIGeneral.Text) Then CheckString = FrmSettings.LBLIGeneral.Text
-            If FrmSettings.CBIGeneralSD.Checked = True Then CheckBoolean = True
-            If Not CheckString = "NULL" Then
-                If CheckBoolean = True Then
-                    files = myDirectory.GetFiles(CheckString, "*.*", SearchOption.AllDirectories)
-                Else
-                    files = myDirectory.GetFiles(CheckString, "*.*")
-                End If
-                Array.Sort(files)
-                For Each fi As String In files
-                    If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-                        LocalList.Add(fi)
-                    End If
-                Next
-            End If
-            StringClean = StringClean.Replace("#GeneralImageCount", LocalList.Count)
-        End If
+		If StringClean.Contains("#GeneralImageCount") Then
+			StringClean = StringClean.Replace("#GeneralImageCount", GetImageData(ImageGenre.General).CountImages())
+		End If
 
-
-        If StringClean.Contains("#LikedImageCount") Then
-			Try
-				Dim LikeList As List(Of String) = Txt2List(Application.StartupPath & "\Images\System\LikedImageURLs.txt")
-				StringClean = StringClean.Replace("#LikedImageCount", LikeList.Count)
-			Catch
-				StringClean = StringClean.Replace("#LikedImageCount", "0")
-			End Try
-
+		If StringClean.Contains("#LikedImageCount") Then
+			StringClean = StringClean.Replace("#LikedImageCount", GetImageData(ImageGenre.Liked).CountImages())
 		End If
 
 		If StringClean.Contains("#DislikedImageCount") Then
-			Try
-				Dim DislikeList As List(Of String) = Txt2List(Application.StartupPath & "\Images\System\DislikedImageURLs.txt")
-				StringClean = StringClean.Replace("#DislikedImageCount", DislikeList.Count)
-			Catch
-				StringClean = StringClean.Replace("#DislikedImageCount", "0")
-			End Try
-
+			StringClean = StringClean.Replace("#DislikedImageCount", GetImageData(ImageGenre.Disliked).CountImages())
 		End If
+        '▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+        ' ImageCount - End
+        '▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
 
-
-		StringClean = StringClean.Replace("#CurrentImage", CurrentImage)
+        StringClean = StringClean.Replace("#CurrentImage", CurrentImage)
 
 		Return StringClean
 
@@ -13699,98 +13401,94 @@ ExternalAudio:
 
 			CustomSlideshowList.Clear()
 
-			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-			Dim files As String()
-
-			Dim dicImageData As Dictionary(Of String, ImageDataContainer) = GetImageData()
 
 			If LCase(SlideFlag).Contains("hardcore") Then
 				Try
-					CustomSlideshowList.AddRange(dicImageData("hardcore").ToList())
+					CustomSlideshowList.AddRange(GetImageData(ImageGenre.Hardcore).ToList())
 				Catch
 				End Try
 			End If
 
 			If LCase(SlideFlag).Contains("softcore") Then
 				Try
-					CustomSlideshowList.AddRange(dicImageData("softcore").ToList())
+					CustomSlideshowList.AddRange(GetImageData(ImageGenre.Softcore).ToList())
 				Catch
 				End Try
 			End If
 
 			If LCase(SlideFlag).Contains("lesbian") Then
 				Try
-					CustomSlideshowList.AddRange(dicImageData("lesbian").ToList())
+					CustomSlideshowList.AddRange(GetImageData(ImageGenre.Lesbian).ToList())
 				Catch
 				End Try
 			End If
 
 			If LCase(SlideFlag).Contains("blowjob") Then
 				Try
-					CustomSlideshowList.AddRange(dicImageData("blowjob").ToList())
+					CustomSlideshowList.AddRange(GetImageData(ImageGenre.Blowjob).ToList())
 				Catch
 				End Try
 			End If
 
 			If LCase(SlideFlag).Contains("femdom") Then
 				Try
-					CustomSlideshowList.AddRange(dicImageData("femdom").ToList())
+					CustomSlideshowList.AddRange(GetImageData(ImageGenre.Femdom).ToList())
 				Catch
 				End Try
 			End If
 
 			If LCase(SlideFlag).Contains("lezdom") Then
 				Try
-					CustomSlideshowList.AddRange(dicImageData("lezdom").ToList())
+					CustomSlideshowList.AddRange(GetImageData(ImageGenre.Lezdom).ToList())
 				Catch
 				End Try
 			End If
 
 			If LCase(SlideFlag).Contains("hentai") Then
 				Try
-					CustomSlideshowList.AddRange(dicImageData("hentai").ToList())
+					CustomSlideshowList.AddRange(GetImageData(ImageGenre.Hentai).ToList())
 				Catch
 				End Try
 			End If
 
 			If LCase(SlideFlag).Contains("gay") Then
 				Try
-					CustomSlideshowList.AddRange(dicImageData("gay").ToList())
+					CustomSlideshowList.AddRange(GetImageData(ImageGenre.Gay).ToList())
 				Catch
 				End Try
 			End If
 
 			If LCase(SlideFlag).Contains("maledom") Then
 				Try
-					CustomSlideshowList.AddRange(dicImageData("maledom").ToList())
+					CustomSlideshowList.AddRange(GetImageData(ImageGenre.Maledom).ToList())
 				Catch
 				End Try
 			End If
 
 			If LCase(SlideFlag).Contains("captions") Then
 				Try
-					CustomSlideshowList.AddRange(dicImageData("captions").ToList())
+					CustomSlideshowList.AddRange(GetImageData(ImageGenre.Captions).ToList())
 				Catch
 				End Try
 			End If
 
 			If LCase(SlideFlag).Contains("general") Then
 				Try
-					CustomSlideshowList.AddRange(dicImageData("general").ToList())
+					CustomSlideshowList.AddRange(GetImageData(ImageGenre.General).ToList())
 				Catch
 				End Try
 			End If
 
 			If LCase(SlideFlag).Contains("boob") Or LCase(SlideFlag).Contains("boobs") Then
 				Try
-					CustomSlideshowList.AddRange(dicImageData("boobs").ToList())
+					CustomSlideshowList.AddRange(GetImageData(ImageGenre.Boobs).ToList())
 				Catch
 				End Try
 			End If
 
 			If LCase(SlideFlag).Contains("butt") Or LCase(SlideFlag).Contains("butts") Then
 				Try
-					CustomSlideshowList.AddRange(dicImageData("butt").ToList())
+					CustomSlideshowList.AddRange(GetImageData(ImageGenre.Butt).ToList())
 				Catch
 				End Try
 			End If
@@ -16326,7 +16024,7 @@ Skip_RandomFile:
 			Application.DoEvents()
 			PoundCount -= 1
 			If ListClean(PoundCount).Contains("@SelfYoung") Then
-				If FrmSettings.domageNumBox.Value > FrmSettings.NBSelfAgeMin.Value - 1 Then	'Or DommeVideo = False Then
+				If FrmSettings.domageNumBox.Value > FrmSettings.NBSelfAgeMin.Value - 1 Then 'Or DommeVideo = False Then
 					If StrokeFilter = True Then
 						For i As Integer = 0 To StrokeTauntCount - 1
 							ListClean.Remove(ListClean(PoundCount))
@@ -16366,7 +16064,7 @@ Skip_RandomFile:
 			Application.DoEvents()
 			PoundCount -= 1
 			If ListClean(PoundCount).Contains("@SelfOld") Then
-				If FrmSettings.domageNumBox.Value < FrmSettings.NBSelfAgeMax.Value + 1 Then	'Or DommeVideo = False Then
+				If FrmSettings.domageNumBox.Value < FrmSettings.NBSelfAgeMax.Value + 1 Then 'Or DommeVideo = False Then
 					If StrokeFilter = True Then
 						For i As Integer = 0 To StrokeTauntCount - 1
 							ListClean.Remove(ListClean(PoundCount))
@@ -20630,12 +20328,12 @@ Skip_RandomFile:
 			If Not Directory.Exists(FrmSettings.LBLIGeneral.Text) Or FrmSettings.CBIGeneral.Checked = False Or CustomSlideshow = True Or FlagExists("SYS_NoPornAllowed") = True Or LockImage = True Then Return False
 		End If
 
-	
+
 		If FilterString.Contains("@ShowBlogImage") Or FilterString.Contains("@NewBlogImage") Then
 			If FrmSettings.URLFileList.CheckedItems.Count = 0 Or CustomSlideshow = True Or FlagExists("SYS_NoPornAllowed") = True Or LockImage = True Then Return False
 		End If
-		If FilterString.Contains("@ShowLocalImage") And FrmSettings.CBIHardcore.Checked = False And FrmSettings.CBISoftcore.Checked = False And FrmSettings.CBILesbian.Checked = False And _
-		   FrmSettings.CBIBlowjob.Checked = False And FrmSettings.CBIFemdom.Checked = False And FrmSettings.CBILezdom.Checked = False And FrmSettings.CBIHentai.Checked = False And _
+		If FilterString.Contains("@ShowLocalImage") And FrmSettings.CBIHardcore.Checked = False And FrmSettings.CBISoftcore.Checked = False And FrmSettings.CBILesbian.Checked = False And
+		   FrmSettings.CBIBlowjob.Checked = False And FrmSettings.CBIFemdom.Checked = False And FrmSettings.CBILezdom.Checked = False And FrmSettings.CBIHentai.Checked = False And
 			  FrmSettings.CBIGay.Checked = False And FrmSettings.CBIMaledom.Checked = False And FrmSettings.CBICaptions.Checked = False And FrmSettings.CBIGeneral.Checked = False Then Return False
 		If FilterString.Contains("@ShowLocalImage") Then
 			If FlagExists("SYS_NoPornAllowed") = True Or LockImage = True Then Return False
@@ -20889,7 +20587,7 @@ Skip_RandomFile:
 		If FilterString.Contains("@Flag(") Then
 			Dim WriteFlag As String = GetParentheses(FilterString, "@Flag(")
 
-			If Not File.Exists(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\System\Flags\" & WriteFlag) And _
+			If Not File.Exists(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\System\Flags\" & WriteFlag) And
 			Not File.Exists(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\System\Flags\Temp\" & WriteFlag) Then Return False
 
 		End If
@@ -20897,7 +20595,7 @@ Skip_RandomFile:
 		If FilterString.Contains("@NotFlag(") Then
 			Dim WriteFlag As String = GetParentheses(FilterString, "@NotFlag(")
 
-			If File.Exists(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\System\Flags\" & WriteFlag) Or _
+			If File.Exists(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\System\Flags\" & WriteFlag) Or
 			File.Exists(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\System\Flags\Temp\" & WriteFlag) Then Return False
 
 		End If
@@ -21084,7 +20782,7 @@ Skip_RandomFile:
 				.Add("@ShowCaptionsImage", Not Directory.Exists(FrmSettings.LBLICaptions.Text) Or FrmSettings.CBICaptions.Checked = False Or CustomSlideshow = True Or FlagExists("SYS_NoPornAllowed") = True Or LockImage = True)
 				.Add("@ShowGeneralImage", Not Directory.Exists(FrmSettings.LBLIGeneral.Text) Or FrmSettings.CBIGeneral.Checked = False Or CustomSlideshow = True Or FlagExists("SYS_NoPornAllowed") = True Or LockImage = True)
 				.Add("@ShowBlogImage", FrmSettings.URLFileList.CheckedItems.Count = 0 Or CustomSlideshow = True Or FlagExists("SYS_NoPornAllowed") = True Or LockImage = True)
-				.Add("@NewBlogImage", __ConditionDic("@ShowBlogImage"))	' duplicate Command, lets get the Value af the other one.
+				.Add("@NewBlogImage", __ConditionDic("@ShowBlogImage")) ' duplicate Command, lets get the Value af the other one.
 				.Add("@ShowLocalImage", FlagExists("SYS_NoPornAllowed") = True Or CustomSlideshow = True Or LockImage = True _
 					  Or (FrmSettings.CBIHardcore.Checked = False And FrmSettings.CBISoftcore.Checked = False And FrmSettings.CBILesbian.Checked = False And FrmSettings.CBIBlowjob.Checked = False _
 					   And FrmSettings.CBIFemdom.Checked = False And FrmSettings.CBILezdom.Checked = False And FrmSettings.CBIHentai.Checked = False And FrmSettings.CBIGay.Checked = False _
@@ -21211,25 +20909,25 @@ Skip_RandomFile:
 			' Minimum length is 3 Chars, maximum Command length has no restriction.
 			Dim __re As Regex = New Regex("@[@\w\d+]{3,}[\(\[]*", RegexOptions.IgnoreCase)
 
-			
-				' Execute regex on current line, to find all containing Commands
-				Dim mc As MatchCollection = __re.Matches(FilterString)
 
-				For Each m As Match In mc
-					If __ConditionDic.Keys.Contains(m.Value) AndAlso __ConditionDic(m.Value) Then
-						'===============================================================================
-						'					Known Command - DELETE Condition = TRUE
-						'===============================================================================
-						' The Command is known and his delete condition is True -> delete line
+			' Execute regex on current line, to find all containing Commands
+			Dim mc As MatchCollection = __re.Matches(FilterString)
+
+			For Each m As Match In mc
+				If __ConditionDic.Keys.Contains(m.Value) AndAlso __ConditionDic(m.Value) Then
+					'===============================================================================
+					'					Known Command - DELETE Condition = TRUE
+					'===============================================================================
+					' The Command is known and his delete condition is True -> delete line
 					Return False
-						
-					ElseIf __ConditionDic.Keys.Contains(m.Value) = False Then
-						'===============================================================================
-						'						Unknown Command / BracketCommand
-						'===============================================================================
-						Dim Condition As Boolean = False
 
-						Select Case m.Value.ToUpper
+				ElseIf __ConditionDic.Keys.Contains(m.Value) = False Then
+					'===============================================================================
+					'						Unknown Command / BracketCommand
+					'===============================================================================
+					Dim Condition As Boolean = False
+
+					Select Case m.Value.ToUpper
 						Case "@DommeLevel(".ToUpper : Condition = FilterCheck(GetParentheses(FilterString, "@DommeLevel("), FrmSettings.domlevelNumBox)
 						Case "@Cup(".ToUpper : Condition = FilterCheck(GetParentheses(FilterString, "@Cup("), FrmSettings.boobComboBox)
 						Case "@AllowsOrgasm(".ToUpper : Condition = FilterCheck(GetParentheses(FilterString, "@AllowsOrgasm("), FrmSettings.alloworgasmComboBox)
@@ -21239,17 +20937,17 @@ Skip_RandomFile:
 						Case "@CheckDate(".ToUpper : Condition = CheckDateList(FilterString)
 						Case "@DommeTag(".ToUpper : Condition = GetDommeImage(GetParentheses(FilterString, "@DommeTag(")) = False Or LockImage = True
 						Case "@ImageTag(".ToUpper : Condition = GetLocalImage(FilterString)
-							Case Else
-								'<= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <=
-								'					Unknown Command => goto next Match
-								'<= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <=
-								Dim f As String = "" ' Debug line to add the ability to set a breakpoint.
-								Exit For
-						End Select
-						' The Command is known and his delete condition is True -> delete line
+						Case Else
+							'<= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <=
+							'					Unknown Command => goto next Match
+							'<= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <= <=
+							Dim f As String = "" ' Debug line to add the ability to set a breakpoint.
+							Exit For
+					End Select
+					' The Command is known and his delete condition is True -> delete line
 					If Condition Then Return False
-					End If
-				Next ' of Regex matches (Commands)
+				End If
+			Next ' of Regex matches (Commands)
 		Catch ex As Exception
 			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
 			'                                            All Errors
@@ -21637,41 +21335,41 @@ FinishTNA:
 
 		If FrmSettings.URLFileList.CheckedItems.Count = 0 Then
 			GetLocalImage()
-            Exit Sub
-        End If
+			Exit Sub
+		End If
 
-        Try
-            FoundString = GetRandomImage(ImageSourceType.Blog)
+		Try
+			FoundString = GetRandomImage(ImageGenre.Blog)
 
-            ClearMainPictureBox()
+			ClearMainPictureBox()
 
-            ShowImage(FoundString, True)
-            JustShowedBlogImage = True
+			ShowImage(FoundString, True)
+			JustShowedBlogImage = True
 
-        Catch ex As Exception
-            GetLocalImage()
-            Exit Sub
-        End Try
+		Catch ex As Exception
+			GetLocalImage()
+			Exit Sub
+		End Try
 
-    End Sub
-
-
-    Public Sub GetLocalImage()
-
-        FoundString = GetRandomImage(ImageSourceType.Local)
-
-        ClearMainPictureBox()
-
-        ShowImage(FoundString, True)
-        JustShowedBlogImage = True
-
-        DeleteLocalImageFilePath = FoundString
-        CurrentImage = FoundString
-
-    End Sub
+	End Sub
 
 
-    Public Sub RunModuleScript(IsEdging As Boolean)
+	Public Sub GetLocalImage()
+
+		FoundString = GetRandomImage(ImageSourceType.Local)
+
+		ClearMainPictureBox()
+
+		ShowImage(FoundString, True)
+		JustShowedBlogImage = True
+
+		DeleteLocalImageFilePath = FoundString
+		CurrentImage = FoundString
+
+	End Sub
+
+
+	Public Sub RunModuleScript(IsEdging As Boolean)
 
 		ShowModule = True
 
@@ -23516,7 +23214,7 @@ TryNext:
 				'RunFileText()
 
 
-				
+
 
 				'AvoidTheEdge.Stop()
 				'AvoidTheEdgeGame = False
@@ -24149,8 +23847,8 @@ TryNext:
 
 	End Sub
 
-    Private Sub RemoveFromUrlFile_Click(sender As System.Object, e As System.EventArgs) Handles ToolStripMenuItem4.Click
-        Try
+	Private Sub RemoveFromUrlFile_Click(sender As System.Object, e As System.EventArgs) Handles ToolStripMenuItem4.Click
+		Try
             ' Lock Control
             ToolStripMenuItem4.Enabled = False
 
@@ -24159,8 +23857,8 @@ TryNext:
 
                 ' Fine the URL in all URLFiles
                 Dim foundFiles As ObjectModel.ReadOnlyCollection(Of String) =
-                    FileIO.FileSystem.FindInFiles(Application.StartupPath & "\Images\System\URL Files\",
-                                                  CurrentImage, True, FileIO.SearchOption.SearchTopLevelOnly)
+					FileIO.FileSystem.FindInFiles(Application.StartupPath & "\Images\System\URL Files\",
+												  CurrentImage, True, FileIO.SearchOption.SearchTopLevelOnly)
 
                 ' Delete the URL from all Files 
                 For Each filePath As String In foundFiles
@@ -24172,21 +23870,21 @@ TryNext:
 
                     'Write modified List to disk.
                     File.WriteAllLines(filePath, deleteFile)
-                Next
-            End If
-        Catch ex As Exception
+				Next
+			End If
+		Catch ex As Exception
             '▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
             '						       All Errors
             '▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
             Log.WriteError(ex.Message & vbCrLf & ToString(), ex, "Error while deleting URL-From files.")
-            MsgBox("An Exception Occured while deleting the URL from Files." & vbCrLf _
-                   & ex.Message, MsgBoxStyle.Exclamation, "Delete URL from Files")
-        End Try
-    End Sub
+			MsgBox("An Exception Occured while deleting the URL from Files." & vbCrLf _
+				   & ex.Message, MsgBoxStyle.Exclamation, "Delete URL from Files")
+		End Try
+	End Sub
 
 #Region "-------------------------------------------------- Save Blog Image ---------------------------------------------------"
 
-    Private Sub HardcoreToolStripMenuItem_Click(sender As System.Object, e As System.EventArgs) Handles HardcoreToolStripMenuItem.Click
+	Private Sub HardcoreToolStripMenuItem_Click(sender As System.Object, e As System.EventArgs) Handles HardcoreToolStripMenuItem.Click
 		SaveImage("Hardcore")
 	End Sub
 	Private Sub SoftcoreToolStripMenuItem_Click(sender As System.Object, e As System.EventArgs) Handles SoftcoreToolStripMenuItem.Click
@@ -24533,75 +24231,6 @@ GetDommeSlideshow:
 
 
 	End Sub
-
-	''' =========================================================================================================
-	''' <summary>
-	''' Reads a TextFile into a generic List(of String). EmptyLines are removed from the list.
-	''' </summary>
-	''' <param name="GetText">The Filepath to read.</param>
-	''' <returns>A List(of String) containing all Lines of the given File. Returns 
-	''' an empty List if the specified file doesn't exists, or an exception occurs.</returns>
-	''' <remarks>This Method will create the given DirectoryStructure for the given
-	''' Filepath if it doesn't exist.</remarks>
-	Public Shared Function Txt2List(ByVal GetText As String) As List(Of String)
-		Try
-			If GetText = Nothing Then Return New List(Of String)
-			' Check if the given Directory exists. MyDirectory.Exists will 
-			' try to create the directory, if it's an App-sub-dir.
-			If myDirectory.Exists(Path.GetDirectoryName(Path.GetFullPath(GetText))) Then
-				Log.Write("Loading Text-File: " & GetText, 5)
-				If File.Exists(GetText) Then
-					Using TextReader As New StreamReader(GetText)
-						Dim TextList As New List(Of String)
-
-						While TextReader.Peek <> -1
-							TextList.Add(TextReader.ReadLine())
-						End While
-
-						' Remove all empty Lines from list.
-						TextList.RemoveAll(Function(x) x = "")
-
-						Return TextList
-					End Using
-				End If
-			End If
-		Catch ex As Exception
-			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
-			'						       All Errors
-			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
-			Log.WriteError(ex.Message, ex, "Error loading TextFile: " & GetText)
-		End Try
-		Return New List(Of String)
-	End Function
-
-	''' =========================================================================================================
-	''' <summary>
-	''' Reads the First line of the given textfile.
-	''' </summary>
-	''' <param name="GetText">On success the first line as string. Otherwise an
-	''' empty String.</param>
-	''' <returns></returns>
-	Public Shared Function TxtReadLine(ByVal GetText As String) As String
-		Try
-			If GetText = Nothing Then Return Nothing
-			' Check if the given Directory exists. MyDirectory.Exists will 
-			' try to create the directory, if it's an App-sub-dir.
-			If myDirectory.Exists(Path.GetDirectoryName(Path.GetFullPath(GetText))) Then
-				If File.Exists(GetText) Then
-					Using TextReader As New StreamReader(GetText)
-						Return TextReader.ReadLine
-					End Using
-				End If
-			End If
-		Catch ex As Exception
-			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
-			'						       All Errors
-			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
-			Log.WriteError(ex.Message, ex, "Error loading TextFile: " & GetText)
-		End Try
-		Return ""
-	End Function
-
 
 	Public Function StripBlankLines(ByVal SpaceClean As List(Of String)) As List(Of String)
 		For i As Integer = SpaceClean.Count - 1 To 0 Step -1
@@ -26207,7 +25836,7 @@ GetDommeSlideshow:
 		Me.Dispose()
 	End Sub
 
-#End Region
+#End Region ' File
 
 #Region "------------------------------------------------------ Settings ------------------------------------------------------"
 
@@ -26289,7 +25918,7 @@ GetDommeSlideshow:
 		FrmSettings.Focus()
 	End Sub
 
-#End Region
+#End Region ' Settings
 
 #Region "-------------------------------------------------------- APPs --------------------------------------------------------"
 
@@ -26634,7 +26263,7 @@ GetDommeSlideshow:
 
 	End Sub
 
-#End Region
+#End Region ' APPs
 
 #Region "-------------------------------------------------------- Games -------------------------------------------------------"
 
@@ -26673,7 +26302,7 @@ GetDommeSlideshow:
 		FrmCardList.Focus()
 	End Sub
 
-#End Region
+#End Region ' Games
 
 #Region "----------------------------------------------------- Interface ------------------------------------------------------"
 
@@ -26744,7 +26373,7 @@ GetDommeSlideshow:
 		If SplitContainer1.Height > 430 Then SplitContainer1.SplitterDistance = SplitContainer1.Height - 252
 	End Sub
 
-#End Region
+#End Region ' Interface
 
 #Region "------------------------------------------------------- Tools --------------------------------------------------------"
 
@@ -26758,7 +26387,7 @@ GetDommeSlideshow:
 		Form9.Focus()
 	End Sub
 
-#End Region
+#End Region ' Tools
 
 #Region "------------------------------------------------------ Milovana ------------------------------------------------------"
 
@@ -26782,7 +26411,7 @@ GetDommeSlideshow:
 		Process.Start("https://milovana.com/forum/")
 	End Sub
 
-#End Region
+#End Region ' Milovana
 
 	Private Sub RunScriptToolStripMenuItem_Click(sender As System.Object, e As System.EventArgs) Handles RunScriptToolStripMenuItem.Click
 
@@ -26823,7 +26452,7 @@ GetDommeSlideshow:
 		FrmSettings.Focus()
 	End Sub
 
-#End Region
+#End Region ' Menu
 
 	Private Sub Form1_MouseClick(sender As Object, e As System.Windows.Forms.MouseEventArgs) Handles Me.MouseClick
 		If SplitContainer1.Width + 270 > Me.Width Then AdjustWindow()
@@ -28342,16 +27971,16 @@ SkipNew:
 	End Sub
 
 
-#End Region
+#End Region ' DommeTag APP
 
-#Region "------------------------------------------------------ Lazy-Sub-------------------------------------------------------"
+#Region "------------------------------------------------------ Lazy-Sub ------------------------------------------------------"
 
-	Private Sub Button25_Click(sender As System.Object, e As System.EventArgs) Handles BTNStop.Click
+	Private Sub Button25_Click(sender As System.Object, e As System.EventArgs) Handles BTNStop.Click, Button7.Click
 		chatBox.Text = "Let me stop"
 		sendButton.PerformClick()
 	End Sub
 
-	Private Sub BTNYes_Click(sender As System.Object, e As System.EventArgs) Handles BTNYes.Click
+	Private Sub BTNYes_Click(sender As System.Object, e As System.EventArgs) Handles BTNYes.Click, Button2.Click
 		Try
 			chatBox.Text = "Yes " & FrmSettings.TBHonorific.Text
 		Catch
@@ -28361,7 +27990,7 @@ SkipNew:
 		sendButton.PerformClick()
 	End Sub
 
-	Private Sub BTNNo_Click(sender As System.Object, e As System.EventArgs) Handles BTNNo.Click
+	Private Sub BTNNo_Click(sender As System.Object, e As System.EventArgs) Handles BTNNo.Click, Button3.Click
 		Try
 			chatBox.Text = "No " & FrmSettings.TBHonorific.Text
 		Catch
@@ -28371,32 +28000,32 @@ SkipNew:
 		sendButton.PerformClick()
 	End Sub
 
-	Private Sub BTNEdge_Click(sender As System.Object, e As System.EventArgs) Handles BTNEdge.Click
+	Private Sub BTNEdge_Click(sender As System.Object, e As System.EventArgs) Handles BTNEdge.Click, Button4.Click
 		chatBox.Text = "On the edge"
 		sendButton.PerformClick()
 	End Sub
 
-	Private Sub BTNSpeedUp_Click(sender As System.Object, e As System.EventArgs) Handles BTNSpeedUp.Click
+	Private Sub BTNSpeedUp_Click(sender As System.Object, e As System.EventArgs) Handles BTNSpeedUp.Click, Button8.Click
 		chatBox.Text = "Let me speed up"
 		sendButton.PerformClick()
 	End Sub
 
-	Private Sub BTNSlowDown_Click(sender As System.Object, e As System.EventArgs) Handles BTNSlowDown.Click
+	Private Sub BTNSlowDown_Click(sender As System.Object, e As System.EventArgs) Handles BTNSlowDown.Click, Button5.Click
 		chatBox.Text = "Let me slow down"
 		sendButton.PerformClick()
 	End Sub
 
-	Private Sub BTNStroke_Click(sender As System.Object, e As System.EventArgs) Handles BTNStroke.Click
+	Private Sub BTNStroke_Click(sender As System.Object, e As System.EventArgs) Handles BTNStroke.Click, Button6.Click
 		chatBox.Text = "May I start stroking?"
 		sendButton.PerformClick()
 	End Sub
 
-	Private Sub BTNAskToCum_Click(sender As System.Object, e As System.EventArgs) Handles BTNAskToCum.Click
+	Private Sub BTNAskToCum_Click(sender As System.Object, e As System.EventArgs) Handles BTNAskToCum.Click, Button9.Click
 		chatBox.Text = "Please let me cum!"
 		sendButton.PerformClick()
 	End Sub
 
-	Private Sub BTNGreeting_Click(sender As System.Object, e As System.EventArgs) Handles BTNGreeting.Click
+	Private Sub BTNGreeting_Click(sender As System.Object, e As System.EventArgs) Handles BTNGreeting.Click, Button10.Click
 
 		If SaidHello = True Then
 			LockImage = False
@@ -28418,7 +28047,7 @@ SkipNew:
 		sendButton.PerformClick()
 	End Sub
 
-	Private Sub BTNSafeword_Click(sender As System.Object, e As System.EventArgs) Handles BTNSafeword.Click
+	Private Sub BTNSafeword_Click(sender As System.Object, e As System.EventArgs) Handles BTNSafeword.Click, Button11.Click
 		Try
 			chatBox.Text = FrmSettings.TBSafeword.Text
 		Catch
@@ -28747,7 +28376,7 @@ SkipNew:
 
 	End Sub
 
-#End Region
+#End Region ' Lazy-Sub
 
 #Region "-------------------------------------------------- Randomizer-App ----------------------------------------------------"
 
@@ -29406,91 +29035,6 @@ SkipNew:
 
 #End Region
 
-#Region "---------------------------------------------------- LazySub-AV ------------------------------------------------------"
-
-	Private Sub Button7_Click_1(sender As System.Object, e As System.EventArgs) Handles Button7.Click
-		chatBox.Text = "Let me stop"
-		sendButton.PerformClick()
-	End Sub
-
-	Private Sub Button2_Click_3(sender As System.Object, e As System.EventArgs) Handles Button2.Click
-		Try
-			chatBox.Text = "Yes " & FrmSettings.TBHonorific.Text
-		Catch
-			chatBox.Text = "Yes"
-		End Try
-
-		sendButton.PerformClick()
-	End Sub
-
-	Private Sub Button3_Click_2(sender As System.Object, e As System.EventArgs) Handles Button3.Click
-		Try
-			chatBox.Text = "No " & FrmSettings.TBHonorific.Text
-		Catch
-			chatBox.Text = "No"
-		End Try
-
-		sendButton.PerformClick()
-	End Sub
-
-	Private Sub Button4_Click_1(sender As System.Object, e As System.EventArgs) Handles Button4.Click
-		chatBox.Text = "On the edge"
-		sendButton.PerformClick()
-	End Sub
-
-	Private Sub Button8_Click(sender As System.Object, e As System.EventArgs) Handles Button8.Click
-		chatBox.Text = "Let me speed up"
-		sendButton.PerformClick()
-	End Sub
-
-	Private Sub Button5_Click_1(sender As System.Object, e As System.EventArgs) Handles Button5.Click
-		chatBox.Text = "Let me slow down"
-		sendButton.PerformClick()
-	End Sub
-
-	Private Sub Button6_Click_1(sender As System.Object, e As System.EventArgs) Handles Button6.Click
-		chatBox.Text = "May I start stroking?"
-		sendButton.PerformClick()
-	End Sub
-
-	Private Sub Button9_Click_2(sender As System.Object, e As System.EventArgs) Handles Button9.Click
-		chatBox.Text = "Please let me cum!"
-		sendButton.PerformClick()
-	End Sub
-
-	Private Sub Button10_Click(sender As System.Object, e As System.EventArgs) Handles Button10.Click
-		If SaidHello = True Then
-			LockImage = False
-			RapidFire = False
-			If SlideshowLoaded = True Then
-				nextButton.Enabled = True
-				previousButton.Enabled = True
-				DommeSlideshowToolStripMenuItem.Enabled = True
-			End If
-			Return
-		End If
-
-		Try
-			chatBox.Text = "Hello " & FrmSettings.TBHonorific.Text
-		Catch
-			chatBox.Text = "Hello"
-		End Try
-
-		sendButton.PerformClick()
-	End Sub
-
-	Private Sub Button11_Click(sender As System.Object, e As System.EventArgs) Handles Button11.Click
-		Try
-			chatBox.Text = FrmSettings.TBSafeword.Text
-		Catch
-			chatBox.Text = "@Error"
-		End Try
-
-		sendButton.PerformClick()
-	End Sub
-
-#End Region
-
 #End Region ' Apps
 
 	Private Sub ChatText_Resize(sender As Object, e As EventArgs) Handles ChatText.Resize
@@ -29798,7 +29342,7 @@ SkipNew:
 
 
 		If StringClean.Contains("@ShowBlogImage") Then
-			If BeginImageFetch("Blog") <> "" Then
+			If BeginImageFetch(ImageGenre.Blog) <> "" Then
 				JustShowedBlogImage = True
 				StringClean = StringClean.Replace("@ShowBlogImage", "")
 			Else
@@ -29817,7 +29361,7 @@ SkipNew:
 			End If
 
 			JustShowedBlogImage = True
-			BeginImageFetch("Butt")
+			BeginImageFetch(ImageGenre.Butt)
 			StringClean = StringClean.Replace("@ShowButtImage", "")
 			StringClean = StringClean.Replace("@ShowButtsImage", "")
 
@@ -29832,7 +29376,7 @@ SkipNew:
 			End If
 
 			JustShowedBlogImage = True
-			BeginImageFetch("Boobs")
+			BeginImageFetch(ImageGenre.Boobs)
 			StringClean = StringClean.Replace("@ShowBoobImage", "")
 			StringClean = StringClean.Replace("@ShowBoobsImage", "")
 
@@ -29845,7 +29389,7 @@ SkipNew:
 				If randomizer.Next(1, 101) < 51 Then Return StringClean
 			End If
 			JustShowedBlogImage = True
-			BeginImageFetch("Hardcore")
+			BeginImageFetch(ImageGenre.Hardcore)
 			StringClean = StringClean.Replace("@ShowHardcoreImage", "")
 		End If
 
@@ -29856,7 +29400,7 @@ SkipNew:
 				If randomizer.Next(1, 101) < 51 Then Return StringClean
 			End If
 			JustShowedBlogImage = True
-			BeginImageFetch("Softcore")
+			BeginImageFetch(ImageGenre.Softcore)
 			StringClean = StringClean.Replace("@ShowSoftcoreImage", "")
 		End If
 
@@ -29867,7 +29411,7 @@ SkipNew:
 				If randomizer.Next(1, 101) < 51 Then Return StringClean
 			End If
 			JustShowedBlogImage = True
-			BeginImageFetch("Lesbian")
+			BeginImageFetch(ImageGenre.Lesbian)
 			StringClean = StringClean.Replace("@ShowLesbianImage", "")
 		End If
 
@@ -29878,7 +29422,7 @@ SkipNew:
 				If randomizer.Next(1, 101) < 51 Then Return StringClean
 			End If
 			JustShowedBlogImage = True
-			BeginImageFetch("Blowjob")
+			BeginImageFetch(ImageGenre.Blowjob)
 			StringClean = StringClean.Replace("@ShowBlowjobImage", "")
 		End If
 
@@ -29889,7 +29433,7 @@ SkipNew:
 				If randomizer.Next(1, 101) < 51 Then Return StringClean
 			End If
 			JustShowedBlogImage = True
-			BeginImageFetch("Femdom")
+			BeginImageFetch(ImageGenre.Femdom)
 			StringClean = StringClean.Replace("@ShowFemdomImage", "")
 		End If
 
@@ -29900,7 +29444,7 @@ SkipNew:
 				If randomizer.Next(1, 101) < 51 Then Return StringClean
 			End If
 			JustShowedBlogImage = True
-			BeginImageFetch("Lezdom")
+			BeginImageFetch(ImageGenre.Lezdom)
 			StringClean = StringClean.Replace("@ShowLezdomImage", "")
 		End If
 
@@ -29911,7 +29455,7 @@ SkipNew:
 				If randomizer.Next(1, 101) < 51 Then Return StringClean
 			End If
 			JustShowedBlogImage = True
-			BeginImageFetch("Hentai")
+			BeginImageFetch(ImageGenre.Hentai)
 			StringClean = StringClean.Replace("@ShowHentaiImage", "")
 		End If
 
@@ -29922,7 +29466,7 @@ SkipNew:
 				If randomizer.Next(1, 101) < 51 Then Return StringClean
 			End If
 			JustShowedBlogImage = True
-			BeginImageFetch("Gay")
+			BeginImageFetch(ImageGenre.Gay)
 			StringClean = StringClean.Replace("@ShowGayImage", "")
 		End If
 
@@ -29933,7 +29477,7 @@ SkipNew:
 				If randomizer.Next(1, 101) < 51 Then Return StringClean
 			End If
 			JustShowedBlogImage = True
-			BeginImageFetch("Maledom")
+			BeginImageFetch(ImageGenre.Maledom)
 			StringClean = StringClean.Replace("@ShowMaledomImage", "")
 		End If
 
@@ -29944,7 +29488,7 @@ SkipNew:
 				If randomizer.Next(1, 101) < 51 Then Return StringClean
 			End If
 			JustShowedBlogImage = True
-			BeginImageFetch("Captions")
+			BeginImageFetch(ImageGenre.Captions)
 			StringClean = StringClean.Replace("@ShowCaptionsImage", "")
 		End If
 
@@ -29955,7 +29499,7 @@ SkipNew:
 				If randomizer.Next(1, 101) < 51 Then Return StringClean
 			End If
 			JustShowedBlogImage = True
-			BeginImageFetch("General")
+			BeginImageFetch(ImageGenre.General)
 			StringClean = StringClean.Replace("@ShowGeneralImage", "")
 		End If
 
@@ -30003,7 +29547,7 @@ SkipNew:
 	End Sub
 
 	Public Function CheckGenreImage(ByVal Genre As String) As Boolean
-
+		'TODO: Next Step ImageDataContainer-Integration. Replace this function with ImageDataContainer member.
 		If CustomSlideshow = True Or FlagExists("SYS_NoPornAllowed") = True Or LockImage = True Then Return False
 
 		If Genre = "Hardcore" Then
@@ -30076,27 +29620,6 @@ SkipNew:
 		Return True
 
 	End Function
-
-	Public Sub SaveSessionImage(ByVal SessionImage As Image)
-
-		If FrmSettings.CBBlogImageWindow.Checked = True Then
-			Dim ImageFlag As String = ImageLocation
-
-			'Skip all local Files.
-			If ImageFlag.Contains("/") And ImageFlag.Contains("://") Then
-				Do Until Not ImageFlag.Contains("/")
-					ImageFlag = ImageFlag.Remove(0, 1)
-				Loop
-
-				If Not File.Exists(Application.StartupPath & "\Images\Session Images\" & ImageFlag) Then
-					SessionImage.Save(Application.StartupPath & "\Images\Session Images\" & ImageFlag)
-					FrmSettings.CalculateSessionImages()
-				Else
-					Debug.Print("Session Image already exists")
-				End If
-			End If
-		End If
-	End Sub
 
 
 End Class

--- a/Tease AI/Form1.vb
+++ b/Tease AI/Form1.vb
@@ -287,9 +287,17 @@ Public Class Form1
 	Public WebImageLineTotal As Integer
 	Public WebImagePath As String
 
+    ''' <summary>
+    ''' Variable Deprected. Remove from Suspend and Resume Session needed. 
+    ''' </summary>
+    '''TODO: Remove ImageUrlFilePath
+    Dim ImageUrlFilePath As String
 
-	Dim ImageUrlFilePath As String
-	Dim ImageUrlFileIndex As Integer
+    ''' <summary>
+    ''' Variable Deprected. Remove from Suspend and Resume Session needed. 
+    ''' </summary>
+    '''TODO: Remove ImageUrlFileIndex
+    Dim ImageUrlFileIndex As Integer
 
 
 	Dim ReaderString As String
@@ -9655,8 +9663,9 @@ StatusUpdateEnd:
 
 
 		If StringClean.Contains("#LocalImageCount") Then
+            'TODO: Implement ImageDataobject
 
-			Dim CheckString As String
+            Dim CheckString As String
 			Dim CheckBoolean As Boolean
 			Dim LocalList As New List(Of String)
 			LocalList.Clear()
@@ -9714,8 +9723,9 @@ StatusUpdateEnd:
 
 
 		If StringClean.Contains("#HardcoreImageCount") Then
-			Dim CheckString As String
-			Dim CheckBoolean As Boolean
+            'TODO: Implement ImageDataobject
+            Dim CheckString As String
+            Dim CheckBoolean As Boolean
 			Dim LocalList As New List(Of String)
 			LocalList.Clear()
 			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
@@ -9741,8 +9751,9 @@ StatusUpdateEnd:
 		End If
 
 		If StringClean.Contains("#SoftcoreImageCount") Then
-			Dim CheckString As String
-			Dim CheckBoolean As Boolean
+            'TODO: Implement ImageDataobject
+            Dim CheckString As String
+            Dim CheckBoolean As Boolean
 			Dim LocalList As New List(Of String)
 			LocalList.Clear()
 			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
@@ -9768,8 +9779,9 @@ StatusUpdateEnd:
 		End If
 
 		If StringClean.Contains("#LesbianImageCount") Then
-			Dim CheckString As String
-			Dim CheckBoolean As Boolean
+            'TODO: Implement ImageDataobject
+            Dim CheckString As String
+            Dim CheckBoolean As Boolean
 			Dim LocalList As New List(Of String)
 			LocalList.Clear()
 			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
@@ -9795,8 +9807,9 @@ StatusUpdateEnd:
 		End If
 
 		If StringClean.Contains("#BlowjobImageCount") Then
-			Dim CheckString As String
-			Dim CheckBoolean As Boolean
+            'TODO: Implement ImageDataobject
+            Dim CheckString As String
+            Dim CheckBoolean As Boolean
 			Dim LocalList As New List(Of String)
 			LocalList.Clear()
 			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
@@ -9822,8 +9835,9 @@ StatusUpdateEnd:
 		End If
 
 		If StringClean.Contains("#FemdomImageCount") Then
-			Dim CheckString As String
-			Dim CheckBoolean As Boolean
+            'TODO: Implement ImageDataobject
+            Dim CheckString As String
+            Dim CheckBoolean As Boolean
 			Dim LocalList As New List(Of String)
 			LocalList.Clear()
 			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
@@ -9849,8 +9863,9 @@ StatusUpdateEnd:
 		End If
 
 		If StringClean.Contains("#LezdomImageCount") Then
-			Dim CheckString As String
-			Dim CheckBoolean As Boolean
+            'TODO: Implement ImageDataobject
+            Dim CheckString As String
+            Dim CheckBoolean As Boolean
 			Dim LocalList As New List(Of String)
 			LocalList.Clear()
 			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
@@ -9876,8 +9891,9 @@ StatusUpdateEnd:
 		End If
 
 		If StringClean.Contains("#HentaiImageCount") Then
-			Dim CheckString As String
-			Dim CheckBoolean As Boolean
+            'TODO: Implement ImageDataobject
+            Dim CheckString As String
+            Dim CheckBoolean As Boolean
 			Dim LocalList As New List(Of String)
 			LocalList.Clear()
 			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
@@ -9903,8 +9919,9 @@ StatusUpdateEnd:
 		End If
 
 		If StringClean.Contains("#GayImageCount") Then
-			Dim CheckString As String
-			Dim CheckBoolean As Boolean
+            'TODO: Implement ImageDataobject
+            Dim CheckString As String
+            Dim CheckBoolean As Boolean
 			Dim LocalList As New List(Of String)
 			LocalList.Clear()
 			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
@@ -9930,8 +9947,9 @@ StatusUpdateEnd:
 		End If
 
 		If StringClean.Contains("#MaledomImageCount") Then
-			Dim CheckString As String
-			Dim CheckBoolean As Boolean
+            'TODO: Implement ImageDataobject
+            Dim CheckString As String
+            Dim CheckBoolean As Boolean
 			Dim LocalList As New List(Of String)
 			LocalList.Clear()
 			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
@@ -9957,8 +9975,9 @@ StatusUpdateEnd:
 		End If
 
 		If StringClean.Contains("#CaptionsImageCount") Then
-			Dim CheckString As String
-			Dim CheckBoolean As Boolean
+            'TODO: Implement ImageDataobject
+            Dim CheckString As String
+            Dim CheckBoolean As Boolean
 			Dim LocalList As New List(Of String)
 			LocalList.Clear()
 			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
@@ -9983,35 +10002,36 @@ StatusUpdateEnd:
 			StringClean = StringClean.Replace("#CaptionsImageCount", LocalList.Count)
 		End If
 
-		If StringClean.Contains("#GeneralImageCount") Then
-			Dim CheckString As String
-			Dim CheckBoolean As Boolean
-			Dim LocalList As New List(Of String)
-			LocalList.Clear()
-			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-			Dim files As String()
-			CheckString = "NULL"
-			CheckBoolean = False
-			If FrmSettings.CBIGeneral.Checked = True And Directory.Exists(FrmSettings.LBLIGeneral.Text) Then CheckString = FrmSettings.LBLIGeneral.Text
-			If FrmSettings.CBIGeneralSD.Checked = True Then CheckBoolean = True
-			If Not CheckString = "NULL" Then
-				If CheckBoolean = True Then
-					files = myDirectory.GetFiles(CheckString, "*.*", SearchOption.AllDirectories)
-				Else
-					files = myDirectory.GetFiles(CheckString, "*.*")
-				End If
-				Array.Sort(files)
-				For Each fi As String In files
-					If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-						LocalList.Add(fi)
-					End If
-				Next
-			End If
-			StringClean = StringClean.Replace("#GeneralImageCount", LocalList.Count)
-		End If
+        If StringClean.Contains("#GeneralImageCount") Then
+            'TODO: Implement ImageDataobject
+            Dim CheckString As String
+            Dim CheckBoolean As Boolean
+            Dim LocalList As New List(Of String)
+            LocalList.Clear()
+            Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
+            Dim files As String()
+            CheckString = "NULL"
+            CheckBoolean = False
+            If FrmSettings.CBIGeneral.Checked = True And Directory.Exists(FrmSettings.LBLIGeneral.Text) Then CheckString = FrmSettings.LBLIGeneral.Text
+            If FrmSettings.CBIGeneralSD.Checked = True Then CheckBoolean = True
+            If Not CheckString = "NULL" Then
+                If CheckBoolean = True Then
+                    files = myDirectory.GetFiles(CheckString, "*.*", SearchOption.AllDirectories)
+                Else
+                    files = myDirectory.GetFiles(CheckString, "*.*")
+                End If
+                Array.Sort(files)
+                For Each fi As String In files
+                    If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
+                        LocalList.Add(fi)
+                    End If
+                Next
+            End If
+            StringClean = StringClean.Replace("#GeneralImageCount", LocalList.Count)
+        End If
 
 
-		If StringClean.Contains("#LikedImageCount") Then
+        If StringClean.Contains("#LikedImageCount") Then
 			Try
 				Dim LikeList As List(Of String) = Txt2List(Application.StartupPath & "\Images\System\LikedImageURLs.txt")
 				StringClean = StringClean.Replace("#LikedImageCount", LikeList.Count)
@@ -21617,278 +21637,41 @@ FinishTNA:
 
 		If FrmSettings.URLFileList.CheckedItems.Count = 0 Then
 			GetLocalImage()
-			Return
-		End If
+            Exit Sub
+        End If
 
-AlreadySeen:
+        Try
+            FoundString = GetRandomImage(ImageSourceType.Blog)
 
+            ClearMainPictureBox()
 
+            ShowImage(FoundString, True)
+            JustShowedBlogImage = True
 
-		Dim URLList As New List(Of String)
-		URLList.Clear()
+        Catch ex As Exception
+            GetLocalImage()
+            Exit Sub
+        End Try
 
+    End Sub
 
-		For Each foundFile As String In My.Computer.FileSystem.GetFiles(Application.StartupPath & "\Images\System\URL Files\", FileIO.SearchOption.SearchTopLevelOnly, "*.txt")
-			URLList.Add(foundFile.Replace(".txt", ""))
-		Next
 
+    Public Sub GetLocalImage()
 
-		For i As Integer = FrmSettings.URLFileList.Items.Count - 1 To 0 Step -1
-			For j As Integer = URLList.Count - 1 To 0 Step -1
-				If FrmSettings.URLFileList.GetItemChecked(i) = False And FrmSettings.URLFileList.Items(i) = URLList(j).Replace(Application.StartupPath & "\Images\System\URL Files\", "") Then
-					URLList.Remove(URLList(j))
-					Exit For
-				End If
-			Next
-		Next
+        FoundString = GetRandomImage(ImageSourceType.Local)
 
+        ClearMainPictureBox()
 
+        ShowImage(FoundString, True)
+        JustShowedBlogImage = True
 
+        DeleteLocalImageFilePath = FoundString
+        CurrentImage = FoundString
 
+    End Sub
 
-		Debug.Print("URLList.COunt = " & URLList.Count)
-		For i As Integer = 0 To URLList.Count - 1
-			Debug.Print(i & " " & URLList(i))
-		Next
 
-		'Debug.Print("URLList Count = " & URLList.Count)
-
-		ImageUrlFilePath = URLList(randomizer.Next(0, URLList.Count)) & ".txt"
-
-		Debug.Print(ImageUrlFilePath)
-
-		' Read all lines of given file.
-		Dim linesGB As List(Of String) = Txt2List(ImageUrlFilePath)
-
-		Do
-			ImageUrlFileIndex = randomizer.Next(0, linesGB.Count)
-			FoundString = linesGB(ImageUrlFileIndex)
-		Loop Until FoundString <> ""
-
-		Debug.Print("FoundString = " & FoundString)
-
-		'  If File.Exists(Application.StartupPath & "\Images\System\DislikedImageURLs.txt") Then
-		'Dim ImageRepeat() As String = Filter(System.IO.File.ReadAllLines(Application.StartupPath & "\Images\System\DislikedImageURLs.txt"), FoundString)
-		'If Not UBound(ImageRepeat) = -1 Then GoTo AlreadySeen
-		'End If
-		'If File.Exists(Application.StartupPath & "\Images\System\LikedImageURLs.txt") Then
-		'Dim ImageRepeat2() As String = Filter(System.IO.File.ReadAllLines(Application.StartupPath & "\Images\System\LikedImageURLs.txt"), FoundString)
-		'If Not UBound(ImageRepeat2) = -1 Then GoTo AlreadySeen
-		'End If
-
-
-		ClearMainPictureBox()
-
-
-
-
-		Try
-
-			JustShowedBlogImage = True
-
-
-			If FoundString.Contains("/") Then
-				Try
-					ShowImage(FoundString, True)
-					'ImageLocation = FoundString
-					'DisplayImage(FoundString)
-					'ImageThread.Start()
-					'mainPictureBox.Image = New System.Drawing.Bitmap(New IO.MemoryStream(New System.Net.WebClient().DownloadData(FoundString)))
-				Catch
-					ClearMainPictureBox()
-					MessageBox.Show(Me, "Failed to load image!", "Error!", MessageBoxButtons.OK, MessageBoxIcon.Exclamation)
-				End Try
-			Else
-				ShowImage(FoundString, True)
-				'ImageLocation = FoundString
-				'PBImage = FoundString
-				'ImageThread.Start()
-				'mainPictureBox.Image = Image.FromFile(FoundString)
-				DeleteLocalImageFilePath = FoundString
-			End If
-
-			CurrentImage = FoundString
-
-			mainPictureBox.Refresh()
-
-
-			If FrmSettings.CBBlogImageWindow.Checked = True Then
-				WebImage = FoundString
-				Do Until Not WebImage.Contains("/")
-					WebImage = WebImage.Remove(0, 1)
-				Loop
-				If Not File.Exists(Application.StartupPath & "\Images\Session Images\" & WebImage) Then
-					Try
-						My.Computer.Network.DownloadFile(FoundString, Application.StartupPath & "\Images\Session Images\" & WebImage)
-						FrmSettings.CalculateSessionImages()
-					Catch
-					End Try
-				Else
-					Debug.Print("Session Image already exists")
-				End If
-
-			End If
-
-			Try
-				GC.Collect()
-			Catch ex As Exception
-
-			End Try
-
-			Debug.Print("Blog Image PictureStrip")
-			PictureStrip.Items(0).Enabled = True
-			PictureStrip.Items(1).Enabled = True
-			PictureStrip.Items(2).Enabled = True
-			PictureStrip.Items(3).Enabled = True
-			PictureStrip.Items(4).Enabled = True
-			PictureStrip.Items(5).Enabled = True
-
-		Catch
-			GetLocalImage()
-			Return
-		End Try
-
-
-
-
-	End Sub
-
-
-	Public Sub GetLocalImage()
-
-
-		Dim CheckString As String
-		Dim CheckBoolean As Boolean
-		Dim LocalList As New List(Of String)
-		LocalList.Clear()
-
-		Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-		Dim files As String()
-
-		For i As Integer = 1 To 11
-			CheckString = "NULL"
-			CheckBoolean = False
-			If i = 1 And FrmSettings.CBIHardcore.Checked = True And Directory.Exists(FrmSettings.LBLIHardcore.Text) Then CheckString = FrmSettings.LBLIHardcore.Text
-			If i = 2 And FrmSettings.CBISoftcore.Checked = True And Directory.Exists(FrmSettings.LBLISoftcore.Text) Then CheckString = FrmSettings.LBLISoftcore.Text
-			If i = 3 And FrmSettings.CBILesbian.Checked = True And Directory.Exists(FrmSettings.LBLILesbian.Text) Then CheckString = FrmSettings.LBLILesbian.Text
-			If i = 4 And FrmSettings.CBIBlowjob.Checked = True And Directory.Exists(FrmSettings.LBLIBlowjob.Text) Then CheckString = FrmSettings.LBLIBlowjob.Text
-			If i = 5 And FrmSettings.CBIFemdom.Checked = True And Directory.Exists(FrmSettings.LBLIFemdom.Text) Then CheckString = FrmSettings.LBLIFemdom.Text
-			If i = 6 And FrmSettings.CBILezdom.Checked = True And Directory.Exists(FrmSettings.LBLILezdom.Text) Then CheckString = FrmSettings.LBLILezdom.Text
-			If i = 7 And FrmSettings.CBIHentai.Checked = True And Directory.Exists(FrmSettings.LBLIHentai.Text) Then CheckString = FrmSettings.LBLIHentai.Text
-			If i = 8 And FrmSettings.CBIGay.Checked = True And Directory.Exists(FrmSettings.LBLIGay.Text) Then CheckString = FrmSettings.LBLIGay.Text
-			If i = 9 And FrmSettings.CBIMaledom.Checked = True And Directory.Exists(FrmSettings.LBLIMaledom.Text) Then CheckString = FrmSettings.LBLIMaledom.Text
-			If i = 10 And FrmSettings.CBICaptions.Checked = True And Directory.Exists(FrmSettings.LBLICaptions.Text) Then CheckString = FrmSettings.LBLICaptions.Text
-			If i = 11 And FrmSettings.CBIGeneral.Checked = True And Directory.Exists(FrmSettings.LBLIGeneral.Text) Then CheckString = FrmSettings.LBLIGeneral.Text
-
-			If i = 1 And FrmSettings.CBIHardcoreSD.Checked = True Then CheckBoolean = True
-			If i = 2 And FrmSettings.CBISoftcoreSD.Checked = True Then CheckBoolean = True
-			If i = 3 And FrmSettings.CBILesbianSD.Checked = True Then CheckBoolean = True
-			If i = 4 And FrmSettings.CBIBlowjobSD.Checked = True Then CheckBoolean = True
-			If i = 5 And FrmSettings.CBIFemdomSD.Checked = True Then CheckBoolean = True
-			If i = 6 And FrmSettings.CBILezdomSD.Checked = True Then CheckBoolean = True
-			If i = 7 And FrmSettings.CBIHentaiSD.Checked = True Then CheckBoolean = True
-			If i = 8 And FrmSettings.CBIGaySD.Checked = True Then CheckBoolean = True
-			If i = 9 And FrmSettings.CBIMaledomSD.Checked = True Then CheckBoolean = True
-			If i = 10 And FrmSettings.CBICaptionsSD.Checked = True Then CheckBoolean = True
-			If i = 11 And FrmSettings.CBIGeneralSD.Checked = True Then CheckBoolean = True
-
-
-			If Not CheckString = "NULL" Then
-				If CheckBoolean = True Then
-					files = myDirectory.GetFiles(CheckString, "*.*", SearchOption.AllDirectories)
-				Else
-					files = myDirectory.GetFiles(CheckString, "*.*")
-				End If
-
-				Array.Sort(files)
-
-				For Each fi As String In files
-					If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-						LocalList.Add(fi)
-					End If
-				Next
-
-			End If
-
-		Next
-
-		If LocalList.Count = 0 Then
-			FoundString = Application.StartupPath & "\Images\System\NoLocalImagesFound.jpg"
-		Else
-			Do
-				FoundString = LocalList(randomizer.Next(0, LocalList.Count))
-			Loop Until FoundString <> ""
-		End If
-
-
-		JustShowedBlogImage = True
-
-		Debug.Print("Local Image PictureStrip")
-		PictureStrip.Items(0).Enabled = True
-		PictureStrip.Items(1).Enabled = False
-		PictureStrip.Items(2).Enabled = False
-		PictureStrip.Items(3).Enabled = True
-		PictureStrip.Items(4).Enabled = True
-		PictureStrip.Items(5).Enabled = False
-
-
-
-		ClearMainPictureBox()
-
-		' ### 0000000000000000000
-
-		ShowImage(FoundString)
-		'ImageLocation = FoundString
-		'PBImage = FoundString
-		'ImageThread.Start()
-		'DisplayImage(Image.FromFile(FoundString))
-		'mainPictureBox.Image = Image.FromFile(FoundString)
-		DeleteLocalImageFilePath = FoundString
-		CurrentImage = FoundString
-
-		'If UCase(FoundString).Contains(".GIF") Then
-
-		'Debug.Print("GIF Found")
-
-		'If FoundString.Contains("\") Then
-		'TempGif = Image.FromFile(FoundString)
-		'End If
-
-		'If FoundString.Contains("/") Then
-		'mainPictureBox.Image.Dispose()
-		'mainPictureBox.Image = Nothing
-
-		'If File.Exists(Application.StartupPath & "\Scripts\" & dompersonalityComboBox.Text & "\System\Temp\Temp.gif") Then
-		'My.Computer.FileSystem.DeleteFile(Application.StartupPath & "\Scripts\" & dompersonalityComboBox.Text & "\System\Temp\Temp.gif")
-		'End If
-		'My.Computer.Network.DownloadFile(FoundString, Application.StartupPath & "\Scripts\" & dompersonalityComboBox.Text & "\System\Temp\Temp.gif")
-		'TempGif = Image.FromFile(Application.StartupPath & "\Scripts\" & dompersonalityComboBox.Text & "\System\Temp\Temp.gif")
-		'End If
-
-		'mainPictureBox.Image = TempGif
-		'Else
-		'Debug.Print("Gif Not found")
-		'mainPictureBox.Load(FoundString)
-		'TempGif.Dispose()
-		'If File.Exists(Application.StartupPath & "\Scripts\" & dompersonalityComboBox.Text & "\System\Temp\Temp.gif") Then
-		'My.Computer.FileSystem.DeleteFile(Application.StartupPath & "\Scripts\" & dompersonalityComboBox.Text & "\System\Temp\Temp.gif")
-		'End If
-		'End If
-
-
-		Try
-			GC.Collect()
-		Catch
-		End Try
-		'mainPictureBox.Load(FoundString)
-
-
-
-
-	End Sub
-
-
-	Public Sub RunModuleScript(IsEdging As Boolean)
+    Public Sub RunModuleScript(IsEdging As Boolean)
 
 		ShowModule = True
 
@@ -24366,42 +24149,44 @@ TryNext:
 
 	End Sub
 
-	Private Sub RemoveFromUrlFile_Click(sender As System.Object, e As System.EventArgs) Handles ToolStripMenuItem4.Click
+    Private Sub RemoveFromUrlFile_Click(sender As System.Object, e As System.EventArgs) Handles ToolStripMenuItem4.Click
+        Try
+            ' Lock Control
+            ToolStripMenuItem4.Enabled = False
 
-		'For Each foundFile As String In My.Computer.FileSystem.GetFiles(Application.StartupPath & "\Images\System\URL Files\", FileIO.SearchOption.SearchTopLevelOnly, "*.txt")
-		Debug.Print(ImageUrlFilePath)
-		' Read all lines of the given file.
-		Dim RemoveList As List(Of String) = Txt2List(ImageUrlFilePath)
+            ' Chekc if directory exits,
+            If myDirectory.Exists(Application.StartupPath & "\Images\System\URL Files\") Then
 
-		'For i As Integer = RemoveList.Count - 1 To 0 Step -1
-		Debug.Print(RemoveList(ImageUrlFileIndex))
-		Debug.Print("foundstring = " & FoundString)
-		'If RemoveList(i) = FoundString Then
-		'Debug.Print("MMMMMMMMMMMMMMMMMMMMMMMAAAAAAAAAAAAAAAAATTTTTTTTTTTTTTTTCCCCCCCCCCCCCCHHHHHHHHHHHHHHHHH")
-		RemoveList.Remove(RemoveList(ImageUrlFileIndex))
-		'End If
-		'Next
+                ' Fine the URL in all URLFiles
+                Dim foundFiles As ObjectModel.ReadOnlyCollection(Of String) =
+                    FileIO.FileSystem.FindInFiles(Application.StartupPath & "\Images\System\URL Files\",
+                                                  CurrentImage, True, FileIO.SearchOption.SearchTopLevelOnly)
 
-		If File.Exists(ImageUrlFilePath) Then My.Computer.FileSystem.DeleteFile(ImageUrlFilePath)
+                ' Delete the URL from all Files 
+                For Each filePath As String In foundFiles
+                    ' read all lines from file
+                    Dim deleteFile As List(Of String) = Txt2List(filePath)
 
-		Debug.Print(RemoveList.Count)
+                    ' Delete all Lines containing the URL
+                    deleteFile.RemoveAll(Function(x) x.Contains(CurrentImage))
 
-		For i As Integer = 0 To RemoveList.Count - 1
-			If File.Exists(ImageUrlFilePath) Then
-				My.Computer.FileSystem.WriteAllText(ImageUrlFilePath, Environment.NewLine & RemoveList(i), True)
-			Else
-				My.Computer.FileSystem.WriteAllText(ImageUrlFilePath, RemoveList(i), True)
-			End If
-		Next
-		'Next
-
-		PictureStrip.Items(5).Enabled = False
-
-	End Sub
+                    'Write modified List to disk.
+                    File.WriteAllLines(filePath, deleteFile)
+                Next
+            End If
+        Catch ex As Exception
+            '▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+            '						       All Errors
+            '▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+            Log.WriteError(ex.Message & vbCrLf & ToString(), ex, "Error while deleting URL-From files.")
+            MsgBox("An Exception Occured while deleting the URL from Files." & vbCrLf _
+                   & ex.Message, MsgBoxStyle.Exclamation, "Delete URL from Files")
+        End Try
+    End Sub
 
 #Region "-------------------------------------------------- Save Blog Image ---------------------------------------------------"
 
-	Private Sub HardcoreToolStripMenuItem_Click(sender As System.Object, e As System.EventArgs) Handles HardcoreToolStripMenuItem.Click
+    Private Sub HardcoreToolStripMenuItem_Click(sender As System.Object, e As System.EventArgs) Handles HardcoreToolStripMenuItem.Click
 		SaveImage("Hardcore")
 	End Sub
 	Private Sub SoftcoreToolStripMenuItem_Click(sender As System.Object, e As System.EventArgs) Handles SoftcoreToolStripMenuItem.Click

--- a/Tease AI/Form1/ImageFuctions.vb
+++ b/Tease AI/Form1/ImageFuctions.vb
@@ -1,14 +1,33 @@
 ﻿Imports System.IO
+Imports Tease_AI.Common
 
 Partial Class Form1
 
 #Region "-------------------------------------------------- ImageDataContainer ------------------------------------------------"
 
     Friend Enum ImageSourceType
-        Blog
-        Local
-        Remote
-    End Enum
+		Local
+		Remote
+	End Enum
+
+	Enum ImageGenre
+		Blog
+		Butt
+		Boobs
+		Hardcore
+		Softcore
+		Lesbian
+		Blowjob
+		Femdom
+		Lezdom
+		Hentai
+		Gay
+		Maledom
+		Captions
+		General
+		Liked
+		Disliked
+	End Enum
 
     ''' <summary>
     ''' Represents a Object which can store all necessary Data related to genere-Images. 
@@ -16,25 +35,33 @@ Partial Class Form1
     ''' and retrieved from it.
     ''' </summary>
     Friend Class ImageDataContainer
-		Public Name As String = ""
+		Public Name As ImageGenre
 		Public URLFile As String = ""
 		Public LocalDirectory As String = ""
 		Public LocalSubDirectories As Boolean = False
 		Public OfflineMode As Boolean = My.Settings.OfflineMode
 
-		''' =========================================================================================================
-		''' <summary>
-		''' Returns a List of FilePaths or URLs.
-		''' </summary>
-		''' <returns>Returns a List Containing all Found Links. If none are 
-		''' Found an empty List is returned</returns>
-		Public Function ToList() As List(Of String)
+		Public Function CountImages() As Integer
+			Return ToList().Count
+		End Function
+
+		Public Function CountImages(ByRef Type As ImageSourceType) As Integer
+			Return ToList(Type).Count
+		End Function
+
+        ''' =========================================================================================================
+        ''' <summary>
+        ''' Returns a List of FilePaths or URLs.
+        ''' </summary>
+        ''' <returns>Returns a List Containing all Found Links. If none are 
+        ''' Found an empty List is returned</returns>
+        Public Function ToList() As List(Of String)
 			Dim rtnList As New List(Of String)
 
 			rtnList.AddRange(ToList(ImageSourceType.Local))
 
-			' Load only LocalFiles if Oflline-Mode is acivated.
-			If OfflineMode = False Then _
+            ' Load only LocalFiles if Oflline-Mode is acivated.
+            If OfflineMode = False Then _
 				rtnList.AddRange(ToList(ImageSourceType.Remote))
 
 			Return rtnList
@@ -53,20 +80,99 @@ Partial Class Form1
 			' If offline mode is activated then search only for local files.
 			If OfflineMode Then Type = ImageSourceType.Local
 
-			' Load Local ImageList
-			If Type = ImageSourceType.Local AndAlso LocalDirectory <> "" AndAlso LocalDirectory IsNot Nothing Then
-				If LocalSubDirectories = True Then
-					rtnList.AddRange(myDirectory.GetFilesImages(LocalDirectory, SearchOption.TopDirectoryOnly))
-				Else
-					rtnList.AddRange(myDirectory.GetFilesImages(LocalDirectory, SearchOption.AllDirectories))
+			If Name = ImageGenre.Blog Then
+				'▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+				'                                   Blog Images
+				'▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+				If OfflineMode Or Type = ImageSourceType.Local Then GoTo exitEmpty
+				Dim tmpList As New List(Of String)
+
+				' Load threadsafe all checked Items into List.
+				Dim temp As Object = FrmSettings.UIThread(Function()
+															  Return FrmSettings.URLFileList.CheckedItems.Cast(Of String).ToList
+														  End Function)
+
+				tmpList.AddRange(DirectCast(temp, List(Of String)))
+
+				' Remove Items where File does not exist.
+				tmpList.RemoveAll(Function(x) Not File.Exists(Application.StartupPath & "\Images\System\URL Files\" & x & ".txt"))
+
+				' Check Result if Files in List
+				If tmpList.Count < 1 Then GoTo exitEmpty
+
+				For Each fileName As String In tmpList
+					' Read the URL-File
+					Dim addList As List(Of String) = Txt2List(Application.StartupPath & "\Images\System\URL Files\" & fileName & ".txt")
+
+					' add lines from file
+					rtnList.AddRange(addList)
+				Next
+				'▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+				' Blog Images - End
+				'▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+			ElseIf Name = ImageGenre.Liked
+				'▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+				'                                  Liked Images
+				'▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+				Try
+					Dim addlist As List(Of String) = Txt2List(Application.StartupPath & "\Images\System\LikedImageURLs.txt")
+
+					' Remove all URLs if Offline-Mode is activated
+					If OfflineMode Or Type = ImageSourceType.Local Then
+						addlist.RemoveAll(Function(x) isURL(x))
+					End If
+
+					rtnList.AddRange(addlist)
+				Catch ex As Exception
+					Log.WriteError(ex.Message, ex, "Error occured while loading Likelist")
+					GoTo exitEmpty
+				End Try
+				'▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+				' Liked Images - End
+				'▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+			ElseIf Name = ImageGenre.Disliked
+				'▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+				'                                Disliked Images
+				'▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+				Try
+					Dim addlist As List(Of String) = Txt2List(Application.StartupPath & "\Images\System\DislikedImageURLs.txt")
+
+					' Remove all URLs if Offline-Mode is activated
+					If OfflineMode Or Type = ImageSourceType.Local Then
+						addlist.RemoveAll(Function(x) isURL(x))
+					End If
+
+					rtnList.AddRange(addlist)
+				Catch ex As Exception
+					Log.WriteError(ex.Message, ex, "Error occured while loading Dislikelist")
+					GoTo exitEmpty
+				End Try
+				'▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+				' Disliked Images - End
+				'▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+			Else
+				'▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+				'                                 Regular Genres
+				'▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+
+				' Load Local ImageList
+				If Type = ImageSourceType.Local AndAlso LocalDirectory <> "" AndAlso LocalDirectory IsNot Nothing Then
+					If LocalSubDirectories = False Then
+						rtnList.AddRange(myDirectory.GetFilesImages(LocalDirectory, SearchOption.TopDirectoryOnly))
+					Else
+						rtnList.AddRange(myDirectory.GetFilesImages(LocalDirectory, SearchOption.AllDirectories))
+					End If
 				End If
-			End If
 
-			' Load an URL-File
-			If Type = ImageSourceType.Remote And URLFile <> "" And URLFile IsNot Nothing Then
-				rtnList.AddRange(Txt2List(URLFile))
+				' Load an URL-File
+				If Type = ImageSourceType.Remote And URLFile <> "" And URLFile IsNot Nothing Then
+					rtnList.AddRange(Txt2List(URLFile))
+				End If
+				'▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+				' Regular Genres - End
+				'▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
 			End If
-
+exitEmpty:
 			Return rtnList
 		End Function
 
@@ -144,114 +250,123 @@ NoneFound:
 
 #End Region ' ImageDataContainer
 
+	Friend Function GetImageData(genre As ImageGenre) As ImageDataContainer
+		Dim tmpObj As Dictionary(Of ImageGenre, ImageDataContainer) = GetImageData()
 
-	''' =========================================================================================================
-	''' <summary>
-	''' Gets a dictionary which contains all nessecary data of genere-images.
-	''' </summary>
-	''' <returns>Returns a dictionary which contains all nessecary data of genere-images.</returns>
-	Friend Function GetImageData() As Dictionary(Of String, ImageDataContainer)
-		Dim rtnDic As New Dictionary(Of String, ImageDataContainer)(StringComparer.OrdinalIgnoreCase)
-		With rtnDic
-			.Add("Butt", New ImageDataContainer With
+		Return tmpObj(genre)
+	End Function
+
+    ''' =========================================================================================================
+    ''' <summary>
+    ''' Gets a dictionary which contains all nessecary data of genere-images.
+    ''' </summary>
+    ''' <returns>Returns a dictionary which contains all nessecary data of genere-images.</returns>
+    Friend Function GetImageData() As Dictionary(Of ImageGenre, ImageDataContainer)
+		Dim rtnDic As New Dictionary(Of ImageGenre, ImageDataContainer) '(StringComparer.OrdinalIgnoreCase)
+        With rtnDic
+			.Add(ImageGenre.Blog, New ImageDataContainer With {.Name = ImageGenre.Blog})
+			.Add(ImageGenre.Liked, New ImageDataContainer With {.Name = ImageGenre.Liked})
+			.Add(ImageGenre.Disliked, New ImageDataContainer With {.Name = ImageGenre.Disliked})
+
+			.Add(ImageGenre.Butt, New ImageDataContainer With
 				 {
-					.Name = "Butt",
+					.Name = ImageGenre.Butt,
 					.LocalDirectory = If(My.Settings.CBIButts, My.Settings.LBLButtPath, ""),
 					.LocalSubDirectories = My.Settings.CBButtSubDir,
 					.URLFile = If(My.Settings.CBURLButts, My.Settings.LBLButtURL, "")
 				})
 
-			.Add("Boobs", New ImageDataContainer With
+			.Add(ImageGenre.Boobs, New ImageDataContainer With
 				 {
-					.Name = "Butt",
+					.Name = ImageGenre.Boobs,
 					.LocalDirectory = If(My.Settings.CBIBoobs, My.Settings.LBLBoobPath, ""),
 					.LocalSubDirectories = My.Settings.CBButtSubDir,
 					.URLFile = If(My.Settings.CBURLBoobs, My.Settings.LBLBoobURL, "")
 				})
 
-			.Add("Hardcore", New ImageDataContainer With
+			.Add(ImageGenre.Hardcore, New ImageDataContainer With
 				 {
-					.Name = "Hardcore",
+					.Name = ImageGenre.Hardcore,
 					.LocalDirectory = If(My.Settings.CBIHardcore, My.Settings.IHardcore, ""),
 					.LocalSubDirectories = My.Settings.CBHardcore,
 					.URLFile = If(My.Settings.CBURLHardcore, My.Settings.HardcoreURLFile, "")
 				})
 
-			.Add("Softcore", New ImageDataContainer With
+			.Add(ImageGenre.Softcore, New ImageDataContainer With
 				 {
-					.Name = "Softcore",
+					.Name = ImageGenre.Softcore,
 					.LocalDirectory = If(My.Settings.CBISoftcore, My.Settings.ISoftcore, ""),
 					.LocalSubDirectories = My.Settings.CBSoftcore,
 					.URLFile = If(My.Settings.CBURLSoftcore, My.Settings.SoftcoreURLFile, "")
 				})
 
-			.Add("Lesbian", New ImageDataContainer With
+			.Add(ImageGenre.Lesbian, New ImageDataContainer With
 				 {
-					.Name = "Lesbian",
+					.Name = ImageGenre.Lesbian,
 					.LocalDirectory = If(My.Settings.CBILesbian, My.Settings.ILesbian, ""),
 					.LocalSubDirectories = My.Settings.CBLesbian,
 					.URLFile = If(My.Settings.CBURLLesbian, My.Settings.LesbianURLFile, "")
 				})
 
-			.Add("Blowjob", New ImageDataContainer With
+			.Add(ImageGenre.Blowjob, New ImageDataContainer With
 				 {
-					.Name = "Blowjob",
+					.Name = ImageGenre.Blowjob,
 					.LocalDirectory = If(My.Settings.CBIBlowjob, My.Settings.IBlowjob, ""),
 					.LocalSubDirectories = My.Settings.CBBlowjob,
 					.URLFile = If(My.Settings.CBURLBlowjob, My.Settings.BlowjobURLFile, "")
 				})
 
-			.Add("Femdom", New ImageDataContainer With
+			.Add(ImageGenre.Femdom, New ImageDataContainer With
 				 {
-					.Name = "Femdom",
+					.Name = ImageGenre.Femdom,
 					.LocalDirectory = If(My.Settings.CBIFemdom, My.Settings.IFemdom, ""),
 					.LocalSubDirectories = My.Settings.CBFemdom,
 					.URLFile = If(My.Settings.CBURLFemdom, My.Settings.FemdomURLFile, "")
 				})
 
-			.Add("Lezdom", New ImageDataContainer With
+			.Add(ImageGenre.Lezdom, New ImageDataContainer With
 				 {
-					.Name = "Lezdom",
+					.Name = ImageGenre.Lezdom,
 					.LocalDirectory = If(My.Settings.CBILezdom, My.Settings.ILezdom, ""),
 					.LocalSubDirectories = My.Settings.ILezdomSD,
 					.URLFile = If(My.Settings.CBURLLezdom, My.Settings.LezdomURLFile, "")
 				})
 
-			.Add("Hentai", New ImageDataContainer With
+			.Add(ImageGenre.Hentai, New ImageDataContainer With
 				 {
-					.Name = "Hentai",
+					.Name = ImageGenre.Hentai,
 					.LocalDirectory = If(My.Settings.CBIHentai, My.Settings.IHentai, ""),
 					.LocalSubDirectories = My.Settings.IHentaiSD,
 					.URLFile = If(My.Settings.CBURLHentai, My.Settings.HentaiURLFile, "")
 				})
 
-			.Add("Gay", New ImageDataContainer With
+			.Add(ImageGenre.Gay, New ImageDataContainer With
 				 {
-					.Name = "Gay",
+					.Name = ImageGenre.Gay,
 					.LocalDirectory = If(My.Settings.CBIGay, My.Settings.IGay, ""),
 					.LocalSubDirectories = My.Settings.IGaySD,
 					.URLFile = If(My.Settings.CBURLGay, My.Settings.GayURLFile, "")
 				})
 
-			.Add("Maledom", New ImageDataContainer With
+			.Add(ImageGenre.Maledom, New ImageDataContainer With
 				 {
-					.Name = "Maledom",
+					.Name = ImageGenre.Maledom,
 					.LocalDirectory = If(My.Settings.CBIMaledom, My.Settings.IMaledom, ""),
 					.LocalSubDirectories = My.Settings.IMaledomSD,
 					.URLFile = If(My.Settings.CBURLMaledom, My.Settings.MaledomURLFile, "")
 				})
 
-			.Add("Captions", New ImageDataContainer With
+			.Add(ImageGenre.Captions, New ImageDataContainer With
 				 {
-					.Name = "Captions",
+					.Name = ImageGenre.Captions,
 					.LocalDirectory = If(My.Settings.CBICaptions, My.Settings.ICaptions, ""),
 					.LocalSubDirectories = My.Settings.ICaptionsSD,
 					.URLFile = If(My.Settings.CBURLCaptions, My.Settings.CaptionsURLFile, "")
 				})
 
-			.Add("General", New ImageDataContainer With
+			.Add(ImageGenre.General, New ImageDataContainer With
 				 {
-					.Name = "General",
+					.Name = ImageGenre.General,
 					.LocalDirectory = If(My.Settings.CBIGeneral, My.Settings.IGeneral, ""),
 					.LocalSubDirectories = My.Settings.IGeneralSD,
 					.URLFile = If(My.Settings.CBURLGeneral, My.Settings.GeneralURLFile, "")
@@ -263,96 +378,55 @@ NoneFound:
 
 #Region "------------------------------------------------- GetRandom Image ----------------------------------------------------"
 
-    ''' <summary>
-    ''' Gets a random image URI from all available Sources
-    ''' </summary>
-    ''' <returns>The URI of a random Image.</returns>
-    Friend Function GetRandomImage() As String
+	''' <summary>
+	''' Gets a random image URI from all available Sources
+	''' </summary>
+	''' <returns>The URI of a random Image.</returns>
+	Friend Function GetRandomImage() As String
         ' Get all definitions for Images.
-        Dim dicFilePaths As Dictionary(Of String, ImageDataContainer) = GetImageData()
-        Dim AllImages As New List(Of String)
+        Dim dicFilePaths As Dictionary(Of ImageGenre, ImageDataContainer) = GetImageData()
+		Dim AllImages As New List(Of String)
 
         ' Fetch all available ImageLocations
-        For Each genre As String In dicFilePaths.Keys
-            AllImages.AddRange(dicFilePaths(genre).ToList())
-        Next
+        For Each genre As ImageGenre In dicFilePaths.Keys
+			AllImages.AddRange(dicFilePaths(genre).ToList())
+		Next
 
         ' Check if there are images
         If AllImages.Count = 0 Then Return Application.StartupPath & "\Images\System\NoLocalImagesFound.jpg"
 
         ' get an Random Image from the all available Locations
         Return AllImages(New Random().Next(0, AllImages.Count)).ToString
-    End Function
+	End Function
 
     ''' <summary>
     ''' Gets a random image URI for given Genre from Local and URL-Files.
     ''' </summary>
     ''' <param name="genre">Determines the Genre to get a random image for.</param>
     ''' <returns>The URI of a random Image.</returns>
-    Friend Function GetRandomImage(ByVal genre As String) As String
-		' Get all definitions for Images.
-		Dim dicFilePaths As Dictionary(Of String, ImageDataContainer) = GetImageData()
+    Friend Function GetRandomImage(ByVal genre As ImageGenre) As String
+        ' Get all definitions for Images.
+        Dim dicFilePaths As Dictionary(Of ImageGenre, ImageDataContainer) = GetImageData()
 
-		' get an Random Image from the Random Genre.
-		Return dicFilePaths(genre).Random()
+        ' get an Random Image from the Random Genre.
+        Return dicFilePaths(genre).Random()
 	End Function
 
-	''' <summary>
-	''' Gets a random image URI for the given sourcetype (URL or Local).
-	''' </summary>
-	''' <param name="source">Determines the source to get a random image for.</param>
-	''' <returns>The URI of a random Image.</returns>
-	Friend Function GetRandomImage(ByVal source As ImageSourceType) As String
-		' Get all definitions for Images.
-		Dim dicFilePaths As Dictionary(Of String, ImageDataContainer) = GetImageData()
+    ''' <summary>
+    ''' Gets a random image URI for the given sourcetype (URL or Local).
+    ''' </summary>
+    ''' <param name="source">Determines the source to get a random image for.</param>
+    ''' <returns>The URI of a random Image.</returns>
+    Friend Function GetRandomImage(ByVal source As ImageSourceType) As String
+        ' Get all definitions for Images.
+        Dim dicFilePaths As Dictionary(Of ImageGenre, ImageDataContainer) = GetImageData()
 
-        Dim allImages As New List(Of String)
+		Dim allImages As New List(Of String)
 
-        If source = ImageSourceType.Blog And My.Settings.OfflineMode = False Then
-            '▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
-            '                Get imagelocation from URL-Files not genrerelated.
-            '▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
-            Dim tmpList As New List(Of String)
-
-            ' Load all checked Items into List.
-            tmpList.AddRange(FrmSettings.URLFileList.CheckedItems.Cast(Of String))
-
-            ' Remove Items where File does not exist.
-            tmpList.RemoveAll(Function(x) Not File.Exists(Application.StartupPath & "\Images\System\URL Files\" & x & ".txt"))
-NextUrlFile:
-            ' Check Result if Files in List
-            If tmpList.Count < 1 Then GoTo NoNeFound
-
-            ' Get a random URL-File 
-            Dim fileName As String = tmpList(randomizer.Next(0, tmpList.Count))
-
-            ' Read the URL-File
-            Dim linesGB As List(Of String) = Txt2List(Application.StartupPath & "\Images\System\URL Files\" & fileName & ".txt")
-
-            ' Check if File is empty... 
-            If linesGB.Count = 0 Then
-                '... If yes then remove file From List and try again.
-                tmpList.Remove(fileName)
-                GoTo NextUrlFile
-            End If
-
-            ' Get a random Entry 
-            Do
-                FoundString = linesGB(randomizer.Next(0, linesGB.Count))
-            Loop Until FoundString <> ""
-
-            ' Return the image URL
-            Return FoundString
-            '▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
-            ' GetBlogimage - End
-            '▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
-        Else
-            ' Fetch all available ImageLocations for sourceType
-            For Each genre As String In dicFilePaths.Keys
-                allImages.AddRange(dicFilePaths(genre).ToList(source))
-            Next
-        End If
-
+        ' Fetch all available ImageLocations for sourceType
+        For Each genre As String In dicFilePaths.Keys
+			allImages.AddRange(dicFilePaths(genre).ToList(source))
+		Next
 
         ' Check if Genres are present.
         If allImages.Count = 0 Then GoTo NoNeFound
@@ -366,23 +440,23 @@ NoNeFound:
 		Else Return Application.StartupPath & "\Images\System\NoURLFilesSelected.jpg"
 	End Function
 
-	''' <summary>
-	''' Gets a random image URI for the given genre and sourcetype (URL or Local)..
-	''' </summary>
-	''' <param name="genre">Determines the genre to get a random image for.</param>
-	''' <param name="source">Determines the source to get a random image for.</param>
-	''' <returns>The URI of a random Image.</returns>
-	Friend Function GetRandomImage(ByVal genre As String, ByVal source As ImageSourceType) As String
-		' Get all definitions for Images.
-		Dim dicFilePaths As Dictionary(Of String, ImageDataContainer) = GetImageData()
+    ''' <summary>
+    ''' Gets a random image URI for the given genre and sourcetype (URL or Local)..
+    ''' </summary>
+    ''' <param name="genre">Determines the genre to get a random image for.</param>
+    ''' <param name="source">Determines the source to get a random image for.</param>
+    ''' <returns>The URI of a random Image.</returns>
+    Friend Function GetRandomImage(ByVal genre As ImageGenre, ByVal source As ImageSourceType) As String
+        ' Get all definitions for Images.
+        Dim dicFilePaths As Dictionary(Of ImageGenre, ImageDataContainer) = GetImageData()
 
-		' Check if the given Genre is found.
-		If dicFilePaths.Keys.Contains(genre) Then
-			' get an Random Image
-			Return dicFilePaths(genre).Random(source)
+        ' Check if the given Genre is found.
+        If dicFilePaths.Keys.Contains(genre) Then
+            ' get an Random Image
+            Return dicFilePaths(genre).Random(source)
 		Else
-			' Return the Error-Image FilePath
-			If source = ImageSourceType.Local _
+            ' Return the Error-Image FilePath
+            If source = ImageSourceType.Local _
 			Then Return Application.StartupPath & "\Images\System\NoLocalImagesFound.jpg" _
 			Else Return Application.StartupPath & "\Images\System\NoURLFilesSelected.jpg"
 		End If
@@ -406,9 +480,9 @@ NoNeFound:
 	Private Class ImageFetchObject
 		Public ImageLocation As String = ""
 
-        Public Source As ImageSourceType
+		Public Source As ImageSourceType
 
-        Private _SaveImageDirectory As String = ""
+		Private _SaveImageDirectory As String = ""
 
 		Public Property SaveImageDirectory As String
 			Get
@@ -456,7 +530,7 @@ NoNeFound:
 					Else
                         ' ####################### Local Image #########################
                         .Source = ImageSourceType.Local
-                        .FetchedImage = Image.FromFile(.ImageLocation)
+						.FetchedImage = Image.FromFile(.ImageLocation)
 					End If
 				End With
 			Catch ex As Exception
@@ -492,15 +566,15 @@ NoNeFound:
 				OldImage.Dispose()
 			End If
 			GC.Collect()
-            CheckDommeTags()
+			CheckDommeTags()
 
-            If FetchResult.Source = ImageSourceType.Local Then
-                Debug.Print("Local Image PictureStrip")
+			If FetchResult.Source = ImageSourceType.Local Then
+				Debug.Print("Local Image PictureStrip")
 
-                If _ImageFileNames.Contains(FetchResult.ImageLocation) Then _
-                    DeleteLocalImageFilePath = FetchResult.ImageLocation
+				If _ImageFileNames.Contains(FetchResult.ImageLocation) Then _
+					DeleteLocalImageFilePath = FetchResult.ImageLocation
 
-                CurrentImage = FetchResult.ImageLocation
+				CurrentImage = FetchResult.ImageLocation
 
                 'CopyImageLocation
                 ToolStripMenuItem5.Enabled = True
@@ -508,7 +582,7 @@ NoNeFound:
                 'Save Image
                 ToolStripMenuItem1.Enabled = False
 
-                SaveImageToToolStripMenuItem.Enabled = False
+				SaveImageToToolStripMenuItem.Enabled = False
 
                 'Like Image
                 ToolStripMenuItem2.Enabled = False
@@ -517,9 +591,9 @@ NoNeFound:
                 'Remove from URLFile
                 ToolStripMenuItem4.Enabled = False
 
-            Else
-                Debug.Print("Blog Image PictureStrip")
-                CurrentImage = FoundString
+			Else
+				Debug.Print("Blog Image PictureStrip")
+				CurrentImage = FoundString
 
                 'CopyImageLocation
                 ToolStripMenuItem5.Enabled = True
@@ -527,7 +601,7 @@ NoNeFound:
                 'Save Image
                 ToolStripMenuItem1.Enabled = True
 
-                SaveImageToToolStripMenuItem.Enabled = True
+				SaveImageToToolStripMenuItem.Enabled = True
 
                 'Like Image
                 ToolStripMenuItem2.Enabled = True
@@ -536,9 +610,9 @@ NoNeFound:
                 'Remove from URLFile
                 ToolStripMenuItem4.Enabled = True
 
-            End If
+			End If
 
-            Debug.Print("ImageFetch - RunWorkerCompleted - Done" & vbCrLf &
+			Debug.Print("ImageFetch - RunWorkerCompleted - Done" & vbCrLf &
 						"	ImageLocation: " & FetchResult.ImageLocation)
 		End If
 	End Sub
@@ -576,31 +650,19 @@ NoNeFound:
 	End Sub
 
 
-	''' <summary>
-	''' Starts to Download an Image on Background. Make sure, to tell the Backgroundworker, 
-	''' when you finished your work and waiting for him to complete.
-	''' </summary>
-	''' <param name="OnlineImage"></param>
-	''' <returns></returns>
-	Public Function BeginImageFetch(ByVal OnlineImage As String) As String
+    ''' <summary>
+    ''' Starts to Download an Image on Background. Make sure, to tell the Backgroundworker, 
+    ''' when you finished your work and waiting for him to complete.
+    ''' </summary>
+    ''' <param name="genre"></param>
+    ''' <returns></returns>
+    Public Function BeginImageFetch(ByVal genre As ImageGenre) As String
 
-		Dim ImageToCache As String = ""
 
-		If OnlineImage = "Blog" Then
-            '===============================================================================
-            '	                        Pick from available Blog
-            '===============================================================================
-            ' Set image to load
-            ImageToCache = GetRandomImage(ImageSourceType.Blog)
-        Else
-			'===============================================================================
-			'                            Pick by genre.
-			'===============================================================================
-			ImageToCache = GetRandomImage(OnlineImage)
-		End If
+		Dim ImageToCache As String = GetRandomImage(genre)
 
-		' Start the Image-Download, with manual Event-triggering.
-		If ImageToCache <> "" And ImageToCache IsNot Nothing _
+        ' Start the Image-Download, with manual Event-triggering.
+        If ImageToCache <> "" And ImageToCache IsNot Nothing _
 		Then ShowImage(ImageToCache, False)
 
 		Return ImageToCache

--- a/Tease AI/Form1/ImageFuctions.vb
+++ b/Tease AI/Form1/ImageFuctions.vb
@@ -4,17 +4,18 @@ Partial Class Form1
 
 #Region "-------------------------------------------------- ImageDataContainer ------------------------------------------------"
 
-	Friend Enum ImageSourceType
-		Local
-		Remote
-	End Enum
+    Friend Enum ImageSourceType
+        Blog
+        Local
+        Remote
+    End Enum
 
-	''' <summary>
-	''' Represents a Object which can store all necessary Data related to genere-Images. 
-	''' This obejct is intended for managing Images. All Data and conditions can be stored in here
-	''' and retrieved from it.
-	''' </summary>
-	Friend Class ImageDataContainer
+    ''' <summary>
+    ''' Represents a Object which can store all necessary Data related to genere-Images. 
+    ''' This obejct is intended for managing Images. All Data and conditions can be stored in here
+    ''' and retrieved from it.
+    ''' </summary>
+    Friend Class ImageDataContainer
 		Public Name As String = ""
 		Public URLFile As String = ""
 		Public LocalDirectory As String = ""
@@ -262,33 +263,33 @@ NoneFound:
 
 #Region "------------------------------------------------- GetRandom Image ----------------------------------------------------"
 
-	''' <summary>
-	''' Gets a random image URI from all available Sources
-	''' </summary>
-	''' <returns>The URI of a random Image.</returns>
-	Friend Function GetRandomImage() As String
-		' Get all definitions for Images.
-		Dim dicFilePaths As Dictionary(Of String, ImageDataContainer) = GetImageData()
+    ''' <summary>
+    ''' Gets a random image URI from all available Sources
+    ''' </summary>
+    ''' <returns>The URI of a random Image.</returns>
+    Friend Function GetRandomImage() As String
+        ' Get all definitions for Images.
+        Dim dicFilePaths As Dictionary(Of String, ImageDataContainer) = GetImageData()
+        Dim AllImages As New List(Of String)
 
-		'Count the Genres.
-		Dim GenreCount As Integer = dicFilePaths.Keys.Count
+        ' Fetch all available ImageLocations
+        For Each genre As String In dicFilePaths.Keys
+            AllImages.AddRange(dicFilePaths(genre).ToList())
+        Next
 
-		' Check if Genres are present.
-		If GenreCount = 0 Then Return Application.StartupPath & "\Images\System\NoLocalImagesFound.jpg"
+        ' Check if there are images
+        If AllImages.Count = 0 Then Return Application.StartupPath & "\Images\System\NoLocalImagesFound.jpg"
 
-		' Dertmine a Random ImageGenre.
-		Dim RandomGenre As String = dicFilePaths.Keys(New Random().Next(0, GenreCount)).ToString
+        ' get an Random Image from the all available Locations
+        Return AllImages(New Random().Next(0, AllImages.Count)).ToString
+    End Function
 
-		' get an Random Image from the Random Genre.
-		Return dicFilePaths(RandomGenre).Random()
-	End Function
-
-	''' <summary>
-	''' Gets a random image URI for given Genre from Local and URL-Files.
-	''' </summary>
-	''' <param name="genre">Determines the Genre to get a random image for.</param>
-	''' <returns>The URI of a random Image.</returns>
-	Friend Function GetRandomImage(ByVal genre As String) As String
+    ''' <summary>
+    ''' Gets a random image URI for given Genre from Local and URL-Files.
+    ''' </summary>
+    ''' <param name="genre">Determines the Genre to get a random image for.</param>
+    ''' <returns>The URI of a random Image.</returns>
+    Friend Function GetRandomImage(ByVal genre As String) As String
 		' Get all definitions for Images.
 		Dim dicFilePaths As Dictionary(Of String, ImageDataContainer) = GetImageData()
 
@@ -305,17 +306,59 @@ NoneFound:
 		' Get all definitions for Images.
 		Dim dicFilePaths As Dictionary(Of String, ImageDataContainer) = GetImageData()
 
-		'Count the Genres.
-		Dim GenreCount As Integer = dicFilePaths.Keys.Count
+        Dim allImages As New List(Of String)
 
-		' Check if Genres are present.
-		If GenreCount = 0 Then GoTo NoNeFound
+        If source = ImageSourceType.Blog And My.Settings.OfflineMode = False Then
+            '▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+            '                Get imagelocation from URL-Files not genrerelated.
+            '▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+            Dim tmpList As New List(Of String)
 
-		' Dertmine a Random ImageGenre.
-		Dim RandomGenre As String = dicFilePaths.Keys(New Random().Next(0, GenreCount)).ToString
+            ' Load all checked Items into List.
+            tmpList.AddRange(FrmSettings.URLFileList.CheckedItems.Cast(Of String))
 
-		' get an Random Image from the Random Genre.
-		Return dicFilePaths(RandomGenre).Random(source)
+            ' Remove Items where File does not exist.
+            tmpList.RemoveAll(Function(x) Not File.Exists(Application.StartupPath & "\Images\System\URL Files\" & x & ".txt"))
+NextUrlFile:
+            ' Check Result if Files in List
+            If tmpList.Count < 1 Then GoTo NoNeFound
+
+            ' Get a random URL-File 
+            Dim fileName As String = tmpList(randomizer.Next(0, tmpList.Count))
+
+            ' Read the URL-File
+            Dim linesGB As List(Of String) = Txt2List(Application.StartupPath & "\Images\System\URL Files\" & fileName & ".txt")
+
+            ' Check if File is empty... 
+            If linesGB.Count = 0 Then
+                '... If yes then remove file From List and try again.
+                tmpList.Remove(fileName)
+                GoTo NextUrlFile
+            End If
+
+            ' Get a random Entry 
+            Do
+                FoundString = linesGB(randomizer.Next(0, linesGB.Count))
+            Loop Until FoundString <> ""
+
+            ' Return the image URL
+            Return FoundString
+            '▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+            ' GetBlogimage - End
+            '▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+        Else
+            ' Fetch all available ImageLocations for sourceType
+            For Each genre As String In dicFilePaths.Keys
+                allImages.AddRange(dicFilePaths(genre).ToList(source))
+            Next
+        End If
+
+
+        ' Check if Genres are present.
+        If allImages.Count = 0 Then GoTo NoNeFound
+
+        ' get an Random Image for the given SourceType
+        Return allImages(New Random().Next(0, allImages.Count)).ToString
 NoNeFound:
 		' Return an Error-Image FilePath
 		If source = ImageSourceType.Local _
@@ -363,7 +406,9 @@ NoNeFound:
 	Private Class ImageFetchObject
 		Public ImageLocation As String = ""
 
-		Private _SaveImageDirectory As String = ""
+        Public Source As ImageSourceType
+
+        Private _SaveImageDirectory As String = ""
 
 		Public Property SaveImageDirectory As String
 			Get
@@ -396,9 +441,10 @@ NoNeFound:
 			Try
 				With FetchContainer
 					If .ImageLocation.Contains("/") And .ImageLocation.Contains("://") Then
-						' ###################### Online Image #########################
-						' Download the image
-						.FetchedImage = New Bitmap(New IO.MemoryStream(New System.Net.WebClient().DownloadData(.ImageLocation)))
+                        ' ###################### Online Image #########################
+                        .Source = ImageSourceType.Remote
+                        ' Download the image
+                        .FetchedImage = New Bitmap(New IO.MemoryStream(New System.Net.WebClient().DownloadData(.ImageLocation)))
 						'check if Folder is set and exists.
 						If .SaveImageDirectory <> "" _
 					AndAlso Directory.Exists(.SaveImageDirectory) Then
@@ -408,8 +454,9 @@ NoNeFound:
 							End If
 						End If
 					Else
-						' ####################### Local Image #########################
-						.FetchedImage = Image.FromFile(.ImageLocation)
+                        ' ####################### Local Image #########################
+                        .Source = ImageSourceType.Local
+                        .FetchedImage = Image.FromFile(.ImageLocation)
 					End If
 				End With
 			Catch ex As Exception
@@ -445,8 +492,53 @@ NoNeFound:
 				OldImage.Dispose()
 			End If
 			GC.Collect()
-			CheckDommeTags()
-			Debug.Print("ImageFetch - RunWorkerCompleted - Done" & vbCrLf &
+            CheckDommeTags()
+
+            If FetchResult.Source = ImageSourceType.Local Then
+                Debug.Print("Local Image PictureStrip")
+
+                If _ImageFileNames.Contains(FetchResult.ImageLocation) Then _
+                    DeleteLocalImageFilePath = FetchResult.ImageLocation
+
+                CurrentImage = FetchResult.ImageLocation
+
+                'CopyImageLocation
+                ToolStripMenuItem5.Enabled = True
+
+                'Save Image
+                ToolStripMenuItem1.Enabled = False
+
+                SaveImageToToolStripMenuItem.Enabled = False
+
+                'Like Image
+                ToolStripMenuItem2.Enabled = False
+                'DislikeImage
+                ToolStripMenuItem3.Enabled = False
+                'Remove from URLFile
+                ToolStripMenuItem4.Enabled = False
+
+            Else
+                Debug.Print("Blog Image PictureStrip")
+                CurrentImage = FoundString
+
+                'CopyImageLocation
+                ToolStripMenuItem5.Enabled = True
+
+                'Save Image
+                ToolStripMenuItem1.Enabled = True
+
+                SaveImageToToolStripMenuItem.Enabled = True
+
+                'Like Image
+                ToolStripMenuItem2.Enabled = True
+                'DislikeImage
+                ToolStripMenuItem3.Enabled = True
+                'Remove from URLFile
+                ToolStripMenuItem4.Enabled = True
+
+            End If
+
+            Debug.Print("ImageFetch - RunWorkerCompleted - Done" & vbCrLf &
 						"	ImageLocation: " & FetchResult.ImageLocation)
 		End If
 	End Sub
@@ -495,42 +587,12 @@ NoNeFound:
 		Dim ImageToCache As String = ""
 
 		If OnlineImage = "Blog" Then
-			'===============================================================================
-			'	                        Pick from available Blog
-			'===============================================================================
-			Dim tmpList As New List(Of String)
-
-			' Load all checked Items into List.
-			tmpList.AddRange(FrmSettings.URLFileList.CheckedItems.Cast(Of String))
-
-			' Remove Items where File does not exist.
-			tmpList.RemoveAll(Function(x) Not File.Exists(Application.StartupPath & "\Images\System\URL Files\" & x & ".txt"))
-NextUrlFile:
-			' Check Result if Files in List
-			If tmpList.Count < 1 Then Return ImageToCache
-
-			' Get a random URL-File 
-			ImageUrlFilePath = tmpList(randomizer.Next(0, tmpList.Count)) & ".txt"
-
-			' Read the URL-File
-			Dim linesGB As List(Of String) = Txt2List(Application.StartupPath & "\Images\System\URL Files\" & ImageUrlFilePath)
-
-			' Check if File is empty... 
-			If linesGB.Count = 0 Then
-				'... If yes then remove file From List and try again.
-				tmpList.Remove(ImageUrlFilePath)
-				GoTo NextUrlFile
-			End If
-
-			' Get a random Entry 
-			Do
-				ImageUrlFileIndex = randomizer.Next(0, linesGB.Count)
-				FoundString = linesGB(ImageUrlFileIndex)
-			Loop Until FoundString <> ""
-
-			' Set image to load
-			ImageToCache = FoundString
-		Else
+            '===============================================================================
+            '	                        Pick from available Blog
+            '===============================================================================
+            ' Set image to load
+            ImageToCache = GetRandomImage(ImageSourceType.Blog)
+        Else
 			'===============================================================================
 			'                            Pick by genre.
 			'===============================================================================

--- a/Tease AI/Form10.vb
+++ b/Tease AI/Form10.vb
@@ -29,7 +29,7 @@
 			LBCommands.Items.Clear()
 
 			Dim CommandList As New List(Of String)
-			CommandList = Form1.Txt2List(Application.StartupPath & "\System\Commands.txt")
+			CommandList = Txt2List(Application.StartupPath & "\System\Commands.txt")
 
 			For i As Integer = 0 To CommandList.Count - 3 Step 4
 				LBCommands.Items.Add(CommandList(i))
@@ -43,7 +43,7 @@
 			LBCommands.Items.Clear()
 
 			Dim CommandList As New List(Of String)
-			CommandList = Form1.Txt2List(Application.StartupPath & "\System\Command Filters.txt")
+			CommandList = Txt2List(Application.StartupPath & "\System\Command Filters.txt")
 
 			For i As Integer = 0 To CommandList.Count - 3 Step 4
 				LBCommands.Items.Add(CommandList(i))
@@ -57,7 +57,7 @@
 			LBCommands.Items.Clear()
 
 			Dim CommandList As New List(Of String)
-			CommandList = Form1.Txt2List(Application.StartupPath & "\System\System Keywords.txt")
+			CommandList = Txt2List(Application.StartupPath & "\System\System Keywords.txt")
 
 			For i As Integer = 0 To CommandList.Count - 3 Step 4
 				LBCommands.Items.Add(CommandList(i))
@@ -73,7 +73,7 @@
 		If comboCommandType.Text = "Commands" Then
 
 			Dim CommandList As New List(Of String)
-			CommandList = Form1.Txt2List(Application.StartupPath & "\System\Commands.txt")
+			CommandList = Txt2List(Application.StartupPath & "\System\Commands.txt")
 
 			For i As Integer = 0 To CommandList.Count - 1
 				If LBCommands.SelectedItem = CommandList(i) Then
@@ -89,7 +89,7 @@
 		If comboCommandType.Text = "Command Filters" Then
 
 			Dim CommandList As New List(Of String)
-			CommandList = Form1.Txt2List(Application.StartupPath & "\System\Command Filters.txt")
+			CommandList = Txt2List(Application.StartupPath & "\System\Command Filters.txt")
 
 			For i As Integer = 0 To CommandList.Count - 1
 				If LBCommands.SelectedItem = CommandList(i) Then
@@ -105,7 +105,7 @@
 		If comboCommandType.Text = "System Keywords" Then
 
 			Dim CommandList As New List(Of String)
-			CommandList = Form1.Txt2List(Application.StartupPath & "\System\System Keywords.txt")
+			CommandList = Txt2List(Application.StartupPath & "\System\System Keywords.txt")
 
 			For i As Integer = 0 To CommandList.Count - 1
 				If LBCommands.SelectedItem = CommandList(i) Then

--- a/Tease AI/Form8.vb
+++ b/Tease AI/Form8.vb
@@ -391,7 +391,7 @@ Public Class Form8
 		If File.Exists(TagFile) Then
 
 			Dim TagList As New List(Of String)
-			TagList = Form1.Txt2List(TagFile)
+			TagList = Txt2List(TagFile)
 
 			Dim FoundFile As Boolean = False
 
@@ -437,7 +437,7 @@ Public Class Form8
 		If File.Exists(TagFile) Then
 
 			Dim TagList As New List(Of String)
-			TagList = Form1.Txt2List(TagFile)
+			TagList = Txt2List(TagFile)
 
 			Dim FoundFile As Boolean = False
 
@@ -483,7 +483,7 @@ Public Class Form8
 		If File.Exists(TagFile) Then
 
 			Dim TagList As New List(Of String)
-			TagList = Form1.Txt2List(TagFile)
+			TagList = Txt2List(TagFile)
 
 			For i As Integer = TagList.Count - 1 To 0 Step -1
 				If TagList(i).Contains(Path.GetFileName(TagPath)) Then
@@ -526,7 +526,7 @@ Public Class Form8
 		If File.Exists(TagFile) Then
 
 			Dim TagList As New List(Of String)
-			TagList = Form1.Txt2List(TagFile)
+			TagList = Txt2List(TagFile)
 
 			For i As Integer = TagList.Count - 1 To 0 Step -1
 				If TagList(i).Contains(Path.GetFileName(TagPath)) Then

--- a/Tease AI/Form9.vb
+++ b/Tease AI/Form9.vb
@@ -30,7 +30,7 @@ Public Class Form9
 			GetaiBoxList.Clear()
 
 
-			GetaiBoxList = Form1.Txt2List(OpenFileDialog1.FileName)
+			GetaiBoxList = Txt2List(OpenFileDialog1.FileName)
 
 			NextCycle = 0
 
@@ -195,7 +195,7 @@ FoundScriptType:
 							Next
 
 							Dim CompareList As New List(Of String)
-							CompareList = Form1.Txt2List(aiFile)
+							CompareList = Txt2List(aiFile)
 
 							For x As Integer = 0 To CLBAIBox.Items.Count - 1
 								If CompareList.Contains(CLBAIBox.Items(x)) Then
@@ -283,7 +283,7 @@ FoundScriptType:
 				Dim Cycle As String = "All"
 
 				Dim GetResponse As New List(Of String)
-				GetResponse = Form1.Txt2List(aiFile)
+				GetResponse = Txt2List(aiFile)
 
 				Dim ResponseKeywords As String = GetResponse(0)
 
@@ -707,7 +707,7 @@ FoundScriptType:
 
 		For i As Integer = 0 To AIBoxList.Count - 1
 			AIBoxContents.Add("[aiBox File Begin] " & AIBoxList(i).Replace(Application.StartupPath & "\Scripts\" & Form1.dompersonalitycombobox.Text & "\", ""))
-			AIBoxCurrent = Form1.Txt2List(AIBoxList(i))
+			AIBoxCurrent = Txt2List(AIBoxList(i))
 			For j As Integer = 0 To AIBoxCurrent.Count - 1
 				AIBoxContents.Add(AIBoxCurrent(j))
 			Next
@@ -749,7 +749,7 @@ FoundScriptType:
 		Debug.Print("Hopedir = " & HopeDir)
 
 		AIBoxContents.Add("[aiBox File Begin] " & HopeDir)
-		AIBoxList = Form1.Txt2List(DropPath)
+		AIBoxList = Txt2List(DropPath)
 
 		For i As Integer = 0 To AIBoxList.Count - 1
 			AIBoxContents.Add(AIBoxList(i))
@@ -775,7 +775,7 @@ FoundScriptType:
 		GetaiBoxList.Clear()
 
 
-		GetaiBoxList = Form1.Txt2List(DropPath)
+		GetaiBoxList = Txt2List(DropPath)
 
 		NextCycle = 0
 
@@ -858,7 +858,7 @@ FoundScriptType:
 
 
 			AIBoxContents.Add("[aiBox File Begin] " & HopeDir)
-			AIBoxList = Form1.Txt2List(OpenFileDialog1.FileName)
+			AIBoxList = Txt2List(OpenFileDialog1.FileName)
 
 			For i As Integer = 0 To AIBoxList.Count - 1
 				AIBoxContents.Add(AIBoxList(i))

--- a/Tease AI/Tease AI.vbproj
+++ b/Tease AI/Tease AI.vbproj
@@ -94,12 +94,14 @@
     <Import Include="System.Windows.Forms" />
     <Import Include="System.Linq" />
     <Import Include="System.Xml.Linq" />
+    <Import Include="Tease_Ai.Common" />
     <Import Include="WMPLib" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Classes\BackgroundWorkerSyncable.vb">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Classes\Common.vb" />
     <Compile Include="Classes\Log.vb" />
     <Compile Include="Classes\myDirectory.vb" />
     <Compile Include="Classes\teaseAI_Timer.vb">


### PR DESCRIPTION
Integration Status: ongoing.
Bugfix: ImagesNot Found
GetRandomImage() and GetRandomImage(Sourcetype) returned randomly an errorimage, if one of all genres had no images.  Empty URL-List-Detection was not working.

Changed GetLocalImage() to work with GetRandomImage(SourceType.Local).
Changed GetBlogImage() to work with GetRandomImage(SourceType.Local).

PictureStrip:
Fixed: activation behaviour. Now BWimageFetcher activates the Items according to what is actually displayed.
Improved: Remove from URL-File removes the URL from all URLFiles.

Readme is not updated, to prevent MergeConflict. Please add:

Stefaf: Bugfix ErrorImage was shown randomly if one of all imagegenres had no images.
Stefaf: Bugfix ContextMenu MainImageBox did not activate or deactivate the MenuItems correct.
Stefaf: Improvement: Remove from URL-File option in ContextMenu MainPicturebox removes a ImageUrl from all URL-Files.
