### PR TITLE
RelativeImageUrlPaths & Bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ Fixes added from Community Members:
 	Stefaf - Imporvement: @ShowLocalImage() Now the ImageDataContainer-Class is used. It doesn't try to get an single image from a single random genre any more. Instead it tries to get a single image from all given genres.
 
 	Stefaf - Improvement: Added logging at several points.
+	
+	Stefaf - Bugfix: 404 caused the Script to stop. Errors during ImageLoading will create now a LogEntry.
+	
+	Stefaf - Added Support for relative filepaths when using GenreImage-UrlFiles. Files outside the "Images\System\Url Files"-directory are neither included on Rebuild nor Refresh! But they are included in DeleteCommands.
+The PropertyNames containing the URL-FilePaths have been renamed, in order to enhance readability. Those settings have to be reapplied. This will also prevent the use of wrong Url-Files, when the settings were imported.
+
+	Stefaf - Improvement: Changed the way how UserSettings are stored. Now every(!) time a setting has changed, the settingsfile will be saved after a delay of one second(to keep disk traffic low).
+	
+	Stefaf - Improvement: Changed Labels for ImageURL-Files to readonly Textboxes. the Settings are now applied via DataBinding. Same on the ImageUrl-Checkboxes.
+	
+	
 
 	
 Conclusion List:

--- a/Tease AI/Classes/BackgroundWorkerSyncable.vb
+++ b/Tease AI/Classes/BackgroundWorkerSyncable.vb
@@ -141,8 +141,8 @@ Public Class BackgroundWorkerSyncable
 		Loop
 		If _ResultCache Is Nothing Then Exit Sub
 		' if an Error occured in BGW.DoWork the Error is "rethrown" here.
-		If Me._ResultCache.Error IsNot Nothing Then Throw Me._ResultCache.Error
-
+		'QnD-Bugfix: 404 caused scripts to stop
+		'If Me._ResultCache.Error IsNot Nothing Then Throw Me._ResultCache.Error
 		MyBase.OnRunWorkerCompleted(_ResultCache)
 		Reset()
 	End Sub

--- a/Tease AI/Form1.vb
+++ b/Tease AI/Form1.vb
@@ -9,9 +9,15 @@ Imports System.Text.RegularExpressions
 
 
 Public Class Form1
-	Shared ReadOnly pathLikeList As String = Application.StartupPath & "\Images\System\LikedImageURLs.txt"
-	Shared ReadOnly pathDislikeList As String = Application.StartupPath & "\Images\System\DislikedImageURLs.txt"
-	Shared ReadOnly pathImageTagList As String = Application.StartupPath & "\Images\System\LocalImageTags.txt"
+#Region "-------------------------------------- File Constants ------------------------------------------"
+	Friend Shared ReadOnly pathLikeList As String = Application.StartupPath & "\Images\System\LikedImageURLs.txt"
+	Friend Shared ReadOnly pathDislikeList As String = Application.StartupPath & "\Images\System\DislikedImageURLs.txt"
+	Friend Shared ReadOnly pathImageTagList As String = Application.StartupPath & "\Images\System\LocalImageTags.txt"
+	''' <summary>
+	''' The default directory URL-Files are located.
+	''' </summary>
+	Friend Shared ReadOnly pathUrlFileDir As String = Application.StartupPath & "\Images\System\URL Files\"
+#End Region ' File Constants.
 
 	Public Chat As String
 	Public randomizer As New Random
@@ -1329,9 +1335,7 @@ ByVal lpstrReturnString As String, ByVal uReturnLength As Integer, ByVal hwndCal
 		If My.Settings.CBButtSubDir = True Then FrmSettings.CBButtSubDir.Checked = True
 
 		FrmSettings.LBLBoobPath.Text = My.Settings.LBLBoobPath
-		FrmSettings.LBLBoobURL.Text = My.Settings.LBLBoobURL
 		FrmSettings.LBLButtPath.Text = My.Settings.LBLButtPath
-		FrmSettings.LBLButtURL.Text = My.Settings.LBLButtURL
 
 
 		FrmSplash.PBSplash.Value += 1
@@ -17736,43 +17740,43 @@ Skip_RandomFile:
 		Loop Until PoundCount = 0
 
 
-		PoundCount = PoundLine
-		Do
-			Application.DoEvents()
-			PoundCount -= 1
-			If ListClean(PoundCount).Contains("@ShowButtImage") Or ListClean(PoundCount).Contains("@ShowButtsImage") Then
-				If Not Directory.Exists(FrmSettings.LBLButtPath.Text) And Not File.Exists(FrmSettings.LBLButtURL.Text) Or FlagExists("SYS_NoPornAllowed") = True Or LockImage = True Then
-					If StrokeFilter = True Then
-						For i As Integer = 0 To StrokeTauntCount - 1
-							ListClean.Remove(ListClean(PoundCount))
-							PoundLine -= 1
-						Next
-					Else
-						ListClean.Remove(ListClean(PoundCount))
-						PoundLine -= 1
-					End If
-				End If
-			End If
-		Loop Until PoundCount = 0
+		'PoundCount = PoundLine
+		'Do
+		'	Application.DoEvents()
+		'	PoundCount -= 1
+		'	If ListClean(PoundCount).Contains("@ShowButtImage") Or ListClean(PoundCount).Contains("@ShowButtsImage") Then
+		'		If Not Directory.Exists(FrmSettings.LBLButtPath.Text) And Not File.Exists(FrmSettings.LBLButtURL.Text) Or FlagExists("SYS_NoPornAllowed") = True Or LockImage = True Then
+		'			If StrokeFilter = True Then
+		'				For i As Integer = 0 To StrokeTauntCount - 1
+		'					ListClean.Remove(ListClean(PoundCount))
+		'					PoundLine -= 1
+		'				Next
+		'			Else
+		'				ListClean.Remove(ListClean(PoundCount))
+		'				PoundLine -= 1
+		'			End If
+		'		End If
+		'	End If
+		'Loop Until PoundCount = 0
 
-		PoundCount = PoundLine
-		Do
-			Application.DoEvents()
-			PoundCount -= 1
-			If ListClean(PoundCount).Contains("@ShowBoobsImage") Or ListClean(PoundCount).Contains("@ShowBoobImage") Then
-				If Not Directory.Exists(FrmSettings.LBLBoobPath.Text) And Not File.Exists(FrmSettings.LBLBoobURL.Text) Or FlagExists("SYS_NoPornAllowed") = True Or LockImage = True Then
-					If StrokeFilter = True Then
-						For i As Integer = 0 To StrokeTauntCount - 1
-							ListClean.Remove(ListClean(PoundCount))
-							PoundLine -= 1
-						Next
-					Else
-						ListClean.Remove(ListClean(PoundCount))
-						PoundLine -= 1
-					End If
-				End If
-			End If
-		Loop Until PoundCount = 0
+		'PoundCount = PoundLine
+		'Do
+		'	Application.DoEvents()
+		'	PoundCount -= 1
+		'	If ListClean(PoundCount).Contains("@ShowBoobsImage") Or ListClean(PoundCount).Contains("@ShowBoobImage") Then
+		'		If Not Directory.Exists(FrmSettings.LBLBoobPath.Text) And Not File.Exists(FrmSettings.LBLBoobURL.Text) Or FlagExists("SYS_NoPornAllowed") = True Or LockImage = True Then
+		'			If StrokeFilter = True Then
+		'				For i As Integer = 0 To StrokeTauntCount - 1
+		'					ListClean.Remove(ListClean(PoundCount))
+		'					PoundLine -= 1
+		'				Next
+		'			Else
+		'				ListClean.Remove(ListClean(PoundCount))
+		'				PoundLine -= 1
+		'			End If
+		'		End If
+		'	End If
+		'Loop Until PoundCount = 0
 
 		PoundCount = PoundLine
 		Do
@@ -20801,10 +20805,10 @@ Skip_RandomFile:
 					  Or (FrmSettings.CBIHardcore.Checked = False And FrmSettings.CBISoftcore.Checked = False And FrmSettings.CBILesbian.Checked = False And FrmSettings.CBIBlowjob.Checked = False _
 					   And FrmSettings.CBIFemdom.Checked = False And FrmSettings.CBILezdom.Checked = False And FrmSettings.CBIHentai.Checked = False And FrmSettings.CBIGay.Checked = False _
 					   And FrmSettings.CBIMaledom.Checked = False And FrmSettings.CBICaptions.Checked = False And FrmSettings.CBIGeneral.Checked = False))
-				.Add("@ShowButtImage", Not Directory.Exists(FrmSettings.LBLButtPath.Text) And Not File.Exists(FrmSettings.LBLButtURL.Text) Or FlagExists("SYS_NoPornAllowed") = True Or CustomSlideshow = True Or LockImage = True)
-				.Add("@ShowButtsImage", __ConditionDic("@ShowButtImage")) ' duplicate Command, lets get the Value af the other one.
-				.Add("@ShowBoobImage", Not Directory.Exists(FrmSettings.LBLBoobPath.Text) And Not File.Exists(FrmSettings.LBLBoobURL.Text) Or FlagExists("SYS_NoPornAllowed") = True Or CustomSlideshow = True Or LockImage = True)
-				.Add("@ShowBoobsImage", __ConditionDic("@ShowBoobImage")) ' duplicate Command, lets get the Value af the other one.
+				'.Add("@ShowButtImage", Not Directory.Exists(FrmSettings.LBLButtPath.Text) And Not File.Exists(FrmSettings.LBLButtURL.Text) Or FlagExists("SYS_NoPornAllowed") = True Or CustomSlideshow = True Or LockImage = True)
+				'.Add("@ShowButtsImage", __ConditionDic("@ShowButtImage")) ' duplicate Command, lets get the Value af the other one.
+				'.Add("@ShowBoobImage", Not Directory.Exists(FrmSettings.LBLBoobPath.Text) And Not File.Exists(FrmSettings.LBLBoobURL.Text) Or FlagExists("SYS_NoPornAllowed") = True Or CustomSlideshow = True Or LockImage = True)
+				'.Add("@ShowBoobsImage", __ConditionDic("@ShowBoobImage")) ' duplicate Command, lets get the Value af the other one.
 				.Add("@1MinuteHold", SubHoldingEdge = False Or HoldEdgeTime < 60 Or HoldEdgeTime > 119)
 				.Add("@2MinuteHold", SubHoldingEdge = False Or HoldEdgeTime < 120 Or HoldEdgeTime > 179)
 				.Add("@3MinuteHold", SubHoldingEdge = False Or HoldEdgeTime < 180 Or HoldEdgeTime > 239)

--- a/Tease AI/Form1/ImageFuctions.vb
+++ b/Tease AI/Form1/ImageFuctions.vb
@@ -37,7 +37,43 @@ Partial Class Form1
     Friend Class ImageDataContainer
 		'TODO: ImageDataContainer Improve the usage of System Ressources.
 		Public Name As ImageGenre
-		Public URLFile As String = ""
+
+		''' =========================================================================================================
+		''' <summary>
+		''' Stores the absolute or relative Url-File-Path.
+		''' <para>Do not access this direct. Use the Property instead!</para>
+		''' </summary>
+		Private _URLFile As String = ""
+		''' <summary>
+		''' Gets or sets the Url-File-Path. Make sure you set this value with extension. Otherwise the value won't 
+		''' be accepted. The filepath can be a relatative or an absolute. A relative path will rooted with the 
+		''' standard URL-File directory
+		''' </summary>
+		''' <returns>The absolute Url-File-Path. </returns>
+		Public Property UrlFile As String
+			Get
+				If _URLFile = "" Then Return _URLFile
+				If _URLFile.ToLower.EndsWith(".txt") = False Then Return ""
+
+				If Path.IsPathRooted(_URLFile) Then
+					' Return an absolute FilePath
+					Return _URLFile
+				Else
+					' Return the relative path absolute.
+					Return pathUrlFileDir & _URLFile
+				End If
+            End Get
+			Set(value As String)
+				If value Is Nothing Then
+					_URLFile = ""
+				ElseIf value.ToLower.EndsWith(".txt") = False
+					_URLFile = ""
+				Else
+					_URLFile = value
+				End If
+			End Set
+		End Property
+
 		Public LocalDirectory As String = ""
 		Public LocalSubDirectories As Boolean = False
 		Public OfflineMode As Boolean = My.Settings.OfflineMode
@@ -330,7 +366,7 @@ NoneFound:
 					.Name = ImageGenre.Butt,
 					.LocalDirectory = If(My.Settings.CBIButts, My.Settings.LBLButtPath, ""),
 					.LocalSubDirectories = My.Settings.CBButtSubDir,
-					.URLFile = If(My.Settings.CBURLButts, My.Settings.LBLButtURL, ""),
+					.UrlFile = If(My.Settings.UrlFileButtEnabled, My.Settings.UrlFileButt, ""),
 					.SYS_NoPornAllowed = SysNoPornAllowed
 				})
 
@@ -339,7 +375,7 @@ NoneFound:
 					.Name = ImageGenre.Boobs,
 					.LocalDirectory = If(My.Settings.CBIBoobs, My.Settings.LBLBoobPath, ""),
 					.LocalSubDirectories = My.Settings.CBButtSubDir,
-					.URLFile = If(My.Settings.CBURLBoobs, My.Settings.LBLBoobURL, ""),
+					.UrlFile = If(My.Settings.UrlFileBoobsEnabled, My.Settings.UrlFileBoobs, ""),
 					.SYS_NoPornAllowed = SysNoPornAllowed
 				})
 
@@ -348,7 +384,7 @@ NoneFound:
 					.Name = ImageGenre.Hardcore,
 					.LocalDirectory = If(My.Settings.CBIHardcore, My.Settings.IHardcore, ""),
 					.LocalSubDirectories = My.Settings.CBHardcore,
-					.URLFile = If(My.Settings.CBURLHardcore, My.Settings.HardcoreURLFile, ""),
+					.UrlFile = If(My.Settings.UrlFileHardcoreEnabled, My.Settings.UrlFileHardcore, ""),
 					.SYS_NoPornAllowed = SysNoPornAllowed
 				})
 
@@ -357,7 +393,7 @@ NoneFound:
 					.Name = ImageGenre.Softcore,
 					.LocalDirectory = If(My.Settings.CBISoftcore, My.Settings.ISoftcore, ""),
 					.LocalSubDirectories = My.Settings.CBSoftcore,
-					.URLFile = If(My.Settings.CBURLSoftcore, My.Settings.SoftcoreURLFile, ""),
+					.UrlFile = If(My.Settings.UrlFileSoftcoreEnabled, My.Settings.UrlFileSoftcore, ""),
 					.SYS_NoPornAllowed = SysNoPornAllowed
 				})
 
@@ -366,7 +402,7 @@ NoneFound:
 					.Name = ImageGenre.Lesbian,
 					.LocalDirectory = If(My.Settings.CBILesbian, My.Settings.ILesbian, ""),
 					.LocalSubDirectories = My.Settings.CBLesbian,
-					.URLFile = If(My.Settings.CBURLLesbian, My.Settings.LesbianURLFile, ""),
+					.UrlFile = If(My.Settings.UrlFileLesbianEnabled, My.Settings.UrlFileLesbian, ""),
 					.SYS_NoPornAllowed = SysNoPornAllowed
 				})
 
@@ -375,7 +411,7 @@ NoneFound:
 					.Name = ImageGenre.Blowjob,
 					.LocalDirectory = If(My.Settings.CBIBlowjob, My.Settings.IBlowjob, ""),
 					.LocalSubDirectories = My.Settings.CBBlowjob,
-					.URLFile = If(My.Settings.CBURLBlowjob, My.Settings.BlowjobURLFile, ""),
+					.UrlFile = If(My.Settings.UrlFileBlowjobEnabled, My.Settings.UrlFileBlowjob, ""),
 					.SYS_NoPornAllowed = SysNoPornAllowed
 				})
 
@@ -384,7 +420,7 @@ NoneFound:
 					.Name = ImageGenre.Femdom,
 					.LocalDirectory = If(My.Settings.CBIFemdom, My.Settings.IFemdom, ""),
 					.LocalSubDirectories = My.Settings.CBFemdom,
-					.URLFile = If(My.Settings.CBURLFemdom, My.Settings.FemdomURLFile, ""),
+					.UrlFile = If(My.Settings.UrlFileFemdomEnabled, My.Settings.UrlFileFemdom, ""),
 					.SYS_NoPornAllowed = SysNoPornAllowed
 				})
 
@@ -393,7 +429,7 @@ NoneFound:
 					.Name = ImageGenre.Lezdom,
 					.LocalDirectory = If(My.Settings.CBILezdom, My.Settings.ILezdom, ""),
 					.LocalSubDirectories = My.Settings.ILezdomSD,
-					.URLFile = If(My.Settings.CBURLLezdom, My.Settings.LezdomURLFile, ""),
+					.UrlFile = If(My.Settings.UrlFileLezdomEnabled, My.Settings.UrlFileLezdom, ""),
 					.SYS_NoPornAllowed = SysNoPornAllowed
 				})
 
@@ -402,7 +438,7 @@ NoneFound:
 					.Name = ImageGenre.Hentai,
 					.LocalDirectory = If(My.Settings.CBIHentai, My.Settings.IHentai, ""),
 					.LocalSubDirectories = My.Settings.IHentaiSD,
-					.URLFile = If(My.Settings.CBURLHentai, My.Settings.HentaiURLFile, ""),
+					.UrlFile = If(My.Settings.UrlFileHentaiEnabled, My.Settings.UrlFileHentai, ""),
 					.SYS_NoPornAllowed = SysNoPornAllowed
 				})
 
@@ -411,7 +447,7 @@ NoneFound:
 					.Name = ImageGenre.Gay,
 					.LocalDirectory = If(My.Settings.CBIGay, My.Settings.IGay, ""),
 					.LocalSubDirectories = My.Settings.IGaySD,
-					.URLFile = If(My.Settings.CBURLGay, My.Settings.GayURLFile, ""),
+					.UrlFile = If(My.Settings.UrlFileGayEnabled, My.Settings.UrlFileGay, ""),
 					.SYS_NoPornAllowed = SysNoPornAllowed
 				})
 
@@ -420,7 +456,7 @@ NoneFound:
 					.Name = ImageGenre.Maledom,
 					.LocalDirectory = If(My.Settings.CBIMaledom, My.Settings.IMaledom, ""),
 					.LocalSubDirectories = My.Settings.IMaledomSD,
-					.URLFile = If(My.Settings.CBURLMaledom, My.Settings.MaledomURLFile, ""),
+					.UrlFile = If(My.Settings.UrlFileMaledomEnabled, My.Settings.UrlFileMaledom, ""),
 					.SYS_NoPornAllowed = SysNoPornAllowed
 				})
 
@@ -429,7 +465,7 @@ NoneFound:
 					.Name = ImageGenre.Captions,
 					.LocalDirectory = If(My.Settings.CBICaptions, My.Settings.ICaptions, ""),
 					.LocalSubDirectories = My.Settings.ICaptionsSD,
-					.URLFile = If(My.Settings.CBURLCaptions, My.Settings.CaptionsURLFile, ""),
+					.UrlFile = If(My.Settings.UrlFileCaptionsEnabled, My.Settings.UrlFileCaptions, ""),
 					.SYS_NoPornAllowed = SysNoPornAllowed
 				})
 
@@ -438,7 +474,7 @@ NoneFound:
 					.Name = ImageGenre.General,
 					.LocalDirectory = If(My.Settings.CBIGeneral, My.Settings.IGeneral, ""),
 					.LocalSubDirectories = My.Settings.IGeneralSD,
-					.URLFile = If(My.Settings.CBURLGeneral, My.Settings.GeneralURLFile, ""),
+					.UrlFile = If(My.Settings.UrlFileGeneralEnabled, My.Settings.UrlFileGeneral, ""),
 					.SYS_NoPornAllowed = SysNoPornAllowed
 				})
 		End With
@@ -606,7 +642,7 @@ NoNeFound:
 				End With
 
 			Catch ex As Exception
-				' Do nothing, Just for Debug.
+				Log.WriteError("Error loading Image: " & FetchContainer.ImageLocation, ex, "Error loading Image")
 				Throw
 			End Try
 			' Return the fetched data to the UI-Thread

--- a/Tease AI/Form2.Designer.vb
+++ b/Tease AI/Form2.Designer.vb
@@ -31,6 +31,7 @@ Partial Class FrmSettings
 		Me.BtnImportSettings = New System.Windows.Forms.Button()
 		Me.LblImportSettings = New System.Windows.Forms.Label()
 		Me.GroupBox64 = New System.Windows.Forms.GroupBox()
+		Me.CBMuteMedia = New System.Windows.Forms.CheckBox()
 		Me.GBDommeImages = New System.Windows.Forms.GroupBox()
 		Me.slideshowNumBox = New System.Windows.Forms.NumericUpDown()
 		Me.teaseRadio = New System.Windows.Forms.RadioButton()
@@ -289,46 +290,47 @@ Partial Class FrmSettings
 		Me.BTNURLFilesNone = New System.Windows.Forms.Button()
 		Me.URLFileList = New System.Windows.Forms.CheckedListBox()
 		Me.TabPage32 = New System.Windows.Forms.TabPage()
-		Me.GroupBox16 = New System.Windows.Forms.GroupBox()
-		Me.LBLBoobURL = New System.Windows.Forms.Label()
-		Me.BTNButtURL = New System.Windows.Forms.Button()
-		Me.BTNBoobURL = New System.Windows.Forms.Button()
-		Me.LBLButtURL = New System.Windows.Forms.Label()
-		Me.CBURLButts = New System.Windows.Forms.CheckBox()
-		Me.CBURLBoobs = New System.Windows.Forms.CheckBox()
-		Me.LBLURLFemdom = New System.Windows.Forms.Label()
-		Me.BTNURLGeneral = New System.Windows.Forms.Button()
-		Me.LBLURLHentai = New System.Windows.Forms.Label()
-		Me.CBURLLesbian = New System.Windows.Forms.CheckBox()
-		Me.BTNURLCaptions = New System.Windows.Forms.Button()
-		Me.CBURLBlowjob = New System.Windows.Forms.CheckBox()
-		Me.BTNURLMaledom = New System.Windows.Forms.Button()
-		Me.CBURLGay = New System.Windows.Forms.CheckBox()
-		Me.BTNURLGay = New System.Windows.Forms.Button()
-		Me.CBURLSoftcore = New System.Windows.Forms.CheckBox()
-		Me.CBURLHentai = New System.Windows.Forms.CheckBox()
-		Me.CBURLLezdom = New System.Windows.Forms.CheckBox()
-		Me.BTNURLHentai = New System.Windows.Forms.Button()
-		Me.LBLURLLezdom = New System.Windows.Forms.Label()
-		Me.BTNURLLezdom = New System.Windows.Forms.Button()
-		Me.CBURLFemdom = New System.Windows.Forms.CheckBox()
-		Me.BTNURLFemdom = New System.Windows.Forms.Button()
-		Me.LBLURLBlowjob = New System.Windows.Forms.Label()
-		Me.BTNURLBlowjob = New System.Windows.Forms.Button()
-		Me.LBLURLLesbian = New System.Windows.Forms.Label()
-		Me.CBURLCaptions = New System.Windows.Forms.CheckBox()
-		Me.BTNURLLesbian = New System.Windows.Forms.Button()
-		Me.LBLURLSoftcore = New System.Windows.Forms.Label()
-		Me.LBLURLGeneral = New System.Windows.Forms.Label()
-		Me.BTNURLSoftcore = New System.Windows.Forms.Button()
-		Me.LBLURLCaptions = New System.Windows.Forms.Label()
-		Me.LBLURLGay = New System.Windows.Forms.Label()
-		Me.CBURLGeneral = New System.Windows.Forms.CheckBox()
-		Me.BTNURLHardcore = New System.Windows.Forms.Button()
-		Me.LBLURLHardcore = New System.Windows.Forms.Label()
-		Me.LBLURLMaledom = New System.Windows.Forms.Label()
-		Me.CBURLHardcore = New System.Windows.Forms.CheckBox()
-		Me.CBURLMaledom = New System.Windows.Forms.CheckBox()
+		Me.GrbImageUrlFiles = New System.Windows.Forms.GroupBox()
+		Me.TlpImageUrls = New System.Windows.Forms.TableLayoutPanel()
+		Me.BtnImageUrlButt = New System.Windows.Forms.Button()
+		Me.BtnImageUrlBoobs = New System.Windows.Forms.Button()
+		Me.BtnImageUrlBlowjob = New System.Windows.Forms.Button()
+		Me.BtnImageUrlCaptions = New System.Windows.Forms.Button()
+		Me.BtnImageUrlHentai = New System.Windows.Forms.Button()
+		Me.BtnImageUrlGay = New System.Windows.Forms.Button()
+		Me.BtnImageUrlGeneral = New System.Windows.Forms.Button()
+		Me.BtnImageUrlHardcore = New System.Windows.Forms.Button()
+		Me.BtnImageUrlLesbian = New System.Windows.Forms.Button()
+		Me.BtnImageUrlLezdom = New System.Windows.Forms.Button()
+		Me.BtnImageUrlMaledom = New System.Windows.Forms.Button()
+		Me.BtnImageUrlFemdom = New System.Windows.Forms.Button()
+		Me.BtnImageUrlSoftcore = New System.Windows.Forms.Button()
+		Me.ChbImageUrlHardcore = New System.Windows.Forms.CheckBox()
+		Me.ChbImageUrlButts = New System.Windows.Forms.CheckBox()
+		Me.ChbImageUrlMaledom = New System.Windows.Forms.CheckBox()
+		Me.ChbImageUrlGay = New System.Windows.Forms.CheckBox()
+		Me.ChbImageUrlSoftcore = New System.Windows.Forms.CheckBox()
+		Me.ChbImageUrlBoobs = New System.Windows.Forms.CheckBox()
+		Me.ChbImageUrlLesbian = New System.Windows.Forms.CheckBox()
+		Me.ChbImageUrlBlowjob = New System.Windows.Forms.CheckBox()
+		Me.ChbImageUrlCaptions = New System.Windows.Forms.CheckBox()
+		Me.ChbImageUrlGeneral = New System.Windows.Forms.CheckBox()
+		Me.ChbImageUrlFemdom = New System.Windows.Forms.CheckBox()
+		Me.ChbImageUrlHentai = New System.Windows.Forms.CheckBox()
+		Me.ChbImageUrlLezdom = New System.Windows.Forms.CheckBox()
+		Me.TxbImageUrlBlowjob = New System.Windows.Forms.TextBox()
+		Me.TxbImageUrlSoftcore = New System.Windows.Forms.TextBox()
+		Me.TxbImageUrlLezdom = New System.Windows.Forms.TextBox()
+		Me.TxbImageUrlFemdom = New System.Windows.Forms.TextBox()
+		Me.TxbImageUrlHardcore = New System.Windows.Forms.TextBox()
+		Me.TxbImageUrlHentai = New System.Windows.Forms.TextBox()
+		Me.TxbImageUrlGay = New System.Windows.Forms.TextBox()
+		Me.TxbImageUrlLesbian = New System.Windows.Forms.TextBox()
+		Me.TxbImageUrlMaledom = New System.Windows.Forms.TextBox()
+		Me.TxbImageUrlCaptions = New System.Windows.Forms.TextBox()
+		Me.TxbImageUrlGeneral = New System.Windows.Forms.TextBox()
+		Me.TxbImageUrlBoobs = New System.Windows.Forms.TextBox()
+		Me.TxbImageUrlButts = New System.Windows.Forms.TextBox()
 		Me.GroupBox14 = New System.Windows.Forms.GroupBox()
 		Me.CBIButts = New System.Windows.Forms.CheckBox()
 		Me.CBIBoobs = New System.Windows.Forms.CheckBox()
@@ -809,6 +811,11 @@ Partial Class FrmSettings
 		Me.Label164 = New System.Windows.Forms.Label()
 		Me.TabPage4 = New System.Windows.Forms.TabPage()
 		Me.Panel6 = New System.Windows.Forms.Panel()
+		Me.GroupBox69 = New System.Windows.Forms.GroupBox()
+		Me.TypesSpeedVal = New System.Windows.Forms.Label()
+		Me.TypeSpeedLabel = New System.Windows.Forms.Label()
+		Me.TimedWriting = New System.Windows.Forms.CheckBox()
+		Me.TypeSpeedSlider = New System.Windows.Forms.TrackBar()
 		Me.GroupBox68 = New System.Windows.Forms.GroupBox()
 		Me.NBTasksMax = New System.Windows.Forms.NumericUpDown()
 		Me.NBTasksMin = New System.Windows.Forms.NumericUpDown()
@@ -816,16 +823,26 @@ Partial Class FrmSettings
 		Me.Label166 = New System.Windows.Forms.Label()
 		Me.GroupBox67 = New System.Windows.Forms.GroupBox()
 		Me.Label161 = New System.Windows.Forms.Label()
+		Me.NBTaskCBTTimeMax = New System.Windows.Forms.NumericUpDown()
+		Me.NBTaskCBTTimeMin = New System.Windows.Forms.NumericUpDown()
 		Me.Label162 = New System.Windows.Forms.Label()
 		Me.Label163 = New System.Windows.Forms.Label()
 		Me.Label158 = New System.Windows.Forms.Label()
+		Me.NBTaskEdgeHoldTimeMax = New System.Windows.Forms.NumericUpDown()
+		Me.NBTaskEdgeHoldTimeMin = New System.Windows.Forms.NumericUpDown()
 		Me.Label159 = New System.Windows.Forms.Label()
 		Me.Label160 = New System.Windows.Forms.Label()
+		Me.NBTaskEdgesMax = New System.Windows.Forms.NumericUpDown()
+		Me.NBTaskEdgesMin = New System.Windows.Forms.NumericUpDown()
 		Me.Label119 = New System.Windows.Forms.Label()
 		Me.Label157 = New System.Windows.Forms.Label()
 		Me.Label151 = New System.Windows.Forms.Label()
+		Me.NBTaskStrokingTimeMax = New System.Windows.Forms.NumericUpDown()
+		Me.NBTaskStrokingTimeMin = New System.Windows.Forms.NumericUpDown()
 		Me.Label154 = New System.Windows.Forms.Label()
 		Me.Label155 = New System.Windows.Forms.Label()
+		Me.NBTaskStrokesMax = New System.Windows.Forms.NumericUpDown()
+		Me.NBTaskStrokesMin = New System.Windows.Forms.NumericUpDown()
 		Me.Label146 = New System.Windows.Forms.Label()
 		Me.Label149 = New System.Windows.Forms.Label()
 		Me.GroupBox10 = New System.Windows.Forms.GroupBox()
@@ -1092,281 +1109,267 @@ Partial Class FrmSettings
 		Me.CheckBox1 = New System.Windows.Forms.CheckBox()
 		Me.Label135 = New System.Windows.Forms.Label()
 		Me.TrackBar2 = New System.Windows.Forms.TrackBar()
-		Me.BWURLFiles = New Tease_AI.URL_Files.URL_File_BGW()
-		Me.GroupBox69 = New System.Windows.Forms.GroupBox()
-		Me.TypesSpeedVal = New System.Windows.Forms.Label()
-		Me.TimedWriting = New System.Windows.Forms.CheckBox()
-		Me.TypeSpeedLabel = New System.Windows.Forms.Label()
-		Me.TypeSpeedSlider = New System.Windows.Forms.TrackBar()
-		Me.CBMuteMedia = New System.Windows.Forms.CheckBox()
-		Me.NBTaskCBTTimeMax = New System.Windows.Forms.NumericUpDown()
-		Me.NBTaskCBTTimeMin = New System.Windows.Forms.NumericUpDown()
-		Me.NBTaskEdgeHoldTimeMax = New System.Windows.Forms.NumericUpDown()
-		Me.NBTaskEdgeHoldTimeMin = New System.Windows.Forms.NumericUpDown()
-		Me.NBTaskEdgesMax = New System.Windows.Forms.NumericUpDown()
-		Me.NBTaskEdgesMin = New System.Windows.Forms.NumericUpDown()
-		Me.NBTaskStrokingTimeMax = New System.Windows.Forms.NumericUpDown()
-		Me.NBTaskStrokingTimeMin = New System.Windows.Forms.NumericUpDown()
-		Me.NBTaskStrokesMax = New System.Windows.Forms.NumericUpDown()
-		Me.NBTaskStrokesMin = New System.Windows.Forms.NumericUpDown()
-		Me.SettingsPanel.SuspendLayout
-		Me.SettingsTabs.SuspendLayout
-		Me.TabPage1.SuspendLayout
-		Me.PNLGeneralSettings.SuspendLayout
-		Me.GroupBox64.SuspendLayout
-		Me.GBDommeImages.SuspendLayout
-		CType(Me.slideshowNumBox,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GBGeneralTextToSpeech.SuspendLayout
-		CType(Me.SliderVRate,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.SliderVVolume,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GBSafeword.SuspendLayout
-		Me.GBGeneralSystem.SuspendLayout
-		Me.GBGeneralImages.SuspendLayout
-		CType(Me.PictureBox2,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GBGeneralSettings.SuspendLayout
-		Me.GBSubFont.SuspendLayout
-		CType(Me.NBFontSize,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GBDommeFont.SuspendLayout
-		CType(Me.NBFontSizeD,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.TabPage2.SuspendLayout
-		Me.Panel3.SuspendLayout
-		CType(Me.PictureBox4,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GBDomTypingStyle.SuspendLayout
-		CType(Me.NBTypoChance,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox63.SuspendLayout
-		Me.GBDomRanges.SuspendLayout
-		CType(Me.NBDomMoodMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBDomMoodMin,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBSubAgeMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBSubAgeMin,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBSelfAgeMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBSelfAgeMin,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBAvgCockMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBAvgCockMin,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GBDomStats.SuspendLayout
-		CType(Me.NBEmpathy,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBDomBirthdayDay,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.domageNumBox,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBDomBirthdayMonth,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.domlevelNumBox,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GBDomPersonality.SuspendLayout
-		Me.GBDomOrgasms.SuspendLayout
-		CType(Me.orgasmsPerNumBox,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GBDomPetNames.SuspendLayout
-		Me.TabPage10.SuspendLayout
-		Me.Panel2.SuspendLayout
-		Me.GroupBox22.SuspendLayout
-		CType(Me.NBWritingTaskMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBWritingTaskMin,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox45.SuspendLayout
-		CType(Me.CBTSlider,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox35.SuspendLayout
-		Me.GroupBox39.SuspendLayout
-		Me.GroupBox38.SuspendLayout
-		Me.GroupBox37.SuspendLayout
-		Me.GroupBox36.SuspendLayout
-		Me.GroupBox13.SuspendLayout
-		Me.GroupBox7.SuspendLayout
-		CType(Me.NBExtremeHoldMin,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBExtremeHoldMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBLongHoldMin,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBLongHoldMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBLongEdge,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBHoldTheEdgeMin,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBHoldTheEdgeMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.PictureBox12,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox32.SuspendLayout
-		CType(Me.NBBirthdayDay,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.subAgeNumBox,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBBirthdayMonth,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.CockSizeNumBox,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.TabPage16.SuspendLayout
-		Me.Panel9.SuspendLayout
-		Me.GroupBox31.SuspendLayout
-		Me.TCScripts.SuspendLayout
-		Me.TabPage21.SuspendLayout
-		Me.TabPage17.SuspendLayout
-		Me.TabPage18.SuspendLayout
-		Me.TabPage19.SuspendLayout
-		Me.GroupBox42.SuspendLayout
-		CType(Me.PictureBox1,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox43.SuspendLayout
-		Me.TabPage7.SuspendLayout
-		Me.TabControl4.SuspendLayout
-		Me.TabPage31.SuspendLayout
-		Me.GroupBox66.SuspendLayout
-		CType(Me.PBURLPreview,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.TabPage32.SuspendLayout
-		Me.GroupBox16.SuspendLayout
-		Me.GroupBox14.SuspendLayout
-		Me.TabPage12.SuspendLayout
-		Me.PNLImageTag.SuspendLayout
-		CType(Me.ImageTagPictureBox,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.PictureBox14,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.TabPage9.SuspendLayout
-		Me.Panel4.SuspendLayout
-		Me.GroupBox55.SuspendLayout
-		Me.GroupBox53.SuspendLayout
-		Me.GroupBox49.SuspendLayout
-		Me.GroupBox46.SuspendLayout
-		Me.GroupBox54.SuspendLayout
-		Me.GroupBox51.SuspendLayout
-		Me.GroupBox50.SuspendLayout
-		Me.GroupBox48.SuspendLayout
-		CType(Me.PictureBox7,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.TabPage11.SuspendLayout
-		Me.Panel7.SuspendLayout
-		CType(Me.PictureBox5,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.WebPictureBox,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.TabPage3.SuspendLayout
-		Me.Panel1.SuspendLayout
-		CType(Me.PictureBox6,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox25.SuspendLayout
-		Me.GroupBox24.SuspendLayout
-		Me.GroupBox23.SuspendLayout
-		Me.GroupBox8.SuspendLayout
-		Me.GroupBox4.SuspendLayout
-		Me.GroupBox3.SuspendLayout
-		Me.GroupBox2.SuspendLayout
-		Me.TabPage20.SuspendLayout
-		Me.TabControl1.SuspendLayout
-		Me.TabPage22.SuspendLayout
-		Me.PNLGlitter.SuspendLayout
-		Me.GBGlitterD.SuspendLayout
-		CType(Me.GlitterSlider,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.GlitterAV,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GBGlitter1.SuspendLayout
-		CType(Me.GlitterSlider1,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.GlitterAV1,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GBGlitter3.SuspendLayout
-		CType(Me.GlitterSlider3,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.GlitterAV3,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GBGlitter2.SuspendLayout
-		CType(Me.GlitterSlider2,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.GlitterAV2,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.TabPage23.SuspendLayout
-		Me.GroupBox61.SuspendLayout
-		CType(Me.GP6,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.GP2,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.GP5,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.GP1,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.GP3,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.GP4,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox60.SuspendLayout
-		CType(Me.CardBack,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox58.SuspendLayout
-		CType(Me.BP3,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.BP6,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.BP5,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.BP2,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.BP4,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.BP1,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox59.SuspendLayout
-		CType(Me.SP6,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.SP2,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.SP5,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.SP1,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.SP3,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.SP4,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.TabPage6.SuspendLayout
-		Me.Panel10.SuspendLayout
-		CType(Me.NBWishlistCost,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.PNLWishList.SuspendLayout
-		CType(Me.WishlistCostSilver,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.WishlistCostGold,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.WishlistPreview,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.TabPage26.SuspendLayout
-		Me.Panel12.SuspendLayout
-		Me.GroupBox9.SuspendLayout
-		CType(Me.PictureBox10,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox5.SuspendLayout
-		Me.GroupBox11.SuspendLayout
-		Me.GroupBox1.SuspendLayout
-		CType(Me.PBBackgroundPreview,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.TabPage4.SuspendLayout
-		Me.Panel6.SuspendLayout
-		Me.GroupBox68.SuspendLayout
-		CType(Me.NBTasksMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBTasksMin,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox67.SuspendLayout
-		Me.GroupBox10.SuspendLayout
-		CType(Me.NBNextImageChance,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox57.SuspendLayout
-		CType(Me.NBTauntEdging,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.SliderSTF,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.TauntSlider,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBTauntCycleMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBTauntCycleMin,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBTeaseLengthMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBTeaseLengthMin,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox56.SuspendLayout
-		CType(Me.NBRuinSometimes,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBRuinRarely,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBRuinOften,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox17.SuspendLayout
-		Me.GroupBox19.SuspendLayout
-		CType(Me.NBGreenLightMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBGreenLightMin,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBRedLightMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBRedLightMin,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox18.SuspendLayout
-		CType(Me.NBCensorShowMin,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBCensorHideMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBCensorHideMin,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBCensorShowMax,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox52.SuspendLayout
-		CType(Me.NBAllowSometimes,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBAllowRarely,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBAllowOften,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.PictureBox8,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.TabPage13.SuspendLayout
-		Me.TabControl2.SuspendLayout
-		Me.TabPage27.SuspendLayout
-		Me.TabPage14.SuspendLayout
-		Me.TabPage24.SuspendLayout
-		Me.TabPage8.SuspendLayout
-		Me.GroupBox29.SuspendLayout
-		Me.GroupBox28.SuspendLayout
-		Me.GroupBox30.SuspendLayout
-		Me.TabPage15.SuspendLayout
-		Me.GroupBox34.SuspendLayout
-		Me.TabPage25.SuspendLayout
-		Me.Panel11.SuspendLayout
-		Me.GroupBox62.SuspendLayout
-		Me.GroupBox33.SuspendLayout
-		Me.GroupBox27.SuspendLayout
-		Me.GroupBox20.SuspendLayout
-		Me.GroupBox15.SuspendLayout
-		CType(Me.PictureBox9,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.TabPage28.SuspendLayout
-		Me.TabControl3.SuspendLayout
-		Me.TabPage29.SuspendLayout
-		Me.GroupBox26.SuspendLayout
-		Me.TabPage5.SuspendLayout
-		Me.Panel5.SuspendLayout
-		CType(Me.PictureBox3,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox47.SuspendLayout
-		Me.GroupBox41.SuspendLayout
-		Me.GroupBox44.SuspendLayout
-		Me.GroupBox6.SuspendLayout
-		Me.GroupBox21.SuspendLayout
-		Me.GroupBox12.SuspendLayout
-		Me.GroupBox65.SuspendLayout
-		CType(Me.TrackBar1,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.TrackBar2,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.GroupBox69.SuspendLayout
-		CType(Me.TypeSpeedSlider,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBTaskCBTTimeMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBTaskCBTTimeMin,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBTaskEdgeHoldTimeMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBTaskEdgeHoldTimeMin,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBTaskEdgesMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBTaskEdgesMin,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBTaskStrokingTimeMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBTaskStrokingTimeMin,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBTaskStrokesMax,System.ComponentModel.ISupportInitialize).BeginInit
-		CType(Me.NBTaskStrokesMin,System.ComponentModel.ISupportInitialize).BeginInit
-		Me.SuspendLayout
+		Me.TxbImgUrlHardcore = New System.Windows.Forms.TextBox()
+		Me.TextBox2 = New System.Windows.Forms.TextBox()
+		Me.SettingsPanel.SuspendLayout()
+		Me.SettingsTabs.SuspendLayout()
+		Me.TabPage1.SuspendLayout()
+		Me.PNLGeneralSettings.SuspendLayout()
+		Me.GroupBox64.SuspendLayout()
+		Me.GBDommeImages.SuspendLayout()
+		CType(Me.slideshowNumBox, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GBGeneralTextToSpeech.SuspendLayout()
+		CType(Me.SliderVRate, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.SliderVVolume, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GBSafeword.SuspendLayout()
+		Me.GBGeneralSystem.SuspendLayout()
+		Me.GBGeneralImages.SuspendLayout()
+		CType(Me.PictureBox2, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GBGeneralSettings.SuspendLayout()
+		Me.GBSubFont.SuspendLayout()
+		CType(Me.NBFontSize, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GBDommeFont.SuspendLayout()
+		CType(Me.NBFontSizeD, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.TabPage2.SuspendLayout()
+		Me.Panel3.SuspendLayout()
+		CType(Me.PictureBox4, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GBDomTypingStyle.SuspendLayout()
+		CType(Me.NBTypoChance, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox63.SuspendLayout()
+		Me.GBDomRanges.SuspendLayout()
+		CType(Me.NBDomMoodMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBDomMoodMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBSubAgeMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBSubAgeMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBSelfAgeMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBSelfAgeMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBAvgCockMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBAvgCockMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GBDomStats.SuspendLayout()
+		CType(Me.NBEmpathy, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBDomBirthdayDay, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.domageNumBox, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBDomBirthdayMonth, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.domlevelNumBox, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GBDomPersonality.SuspendLayout()
+		Me.GBDomOrgasms.SuspendLayout()
+		CType(Me.orgasmsPerNumBox, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GBDomPetNames.SuspendLayout()
+		Me.TabPage10.SuspendLayout()
+		Me.Panel2.SuspendLayout()
+		Me.GroupBox22.SuspendLayout()
+		CType(Me.NBWritingTaskMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBWritingTaskMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox45.SuspendLayout()
+		CType(Me.CBTSlider, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox35.SuspendLayout()
+		Me.GroupBox39.SuspendLayout()
+		Me.GroupBox38.SuspendLayout()
+		Me.GroupBox37.SuspendLayout()
+		Me.GroupBox36.SuspendLayout()
+		Me.GroupBox13.SuspendLayout()
+		Me.GroupBox7.SuspendLayout()
+		CType(Me.NBExtremeHoldMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBExtremeHoldMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBLongHoldMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBLongHoldMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBLongEdge, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBHoldTheEdgeMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBHoldTheEdgeMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.PictureBox12, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox32.SuspendLayout()
+		CType(Me.NBBirthdayDay, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.subAgeNumBox, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBBirthdayMonth, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.CockSizeNumBox, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.TabPage16.SuspendLayout()
+		Me.Panel9.SuspendLayout()
+		Me.GroupBox31.SuspendLayout()
+		Me.TCScripts.SuspendLayout()
+		Me.TabPage21.SuspendLayout()
+		Me.TabPage17.SuspendLayout()
+		Me.TabPage18.SuspendLayout()
+		Me.TabPage19.SuspendLayout()
+		Me.GroupBox42.SuspendLayout()
+		CType(Me.PictureBox1, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox43.SuspendLayout()
+		Me.TabPage7.SuspendLayout()
+		Me.TabControl4.SuspendLayout()
+		Me.TabPage31.SuspendLayout()
+		Me.GroupBox66.SuspendLayout()
+		CType(Me.PBURLPreview, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.TabPage32.SuspendLayout()
+		Me.GrbImageUrlFiles.SuspendLayout()
+		Me.TlpImageUrls.SuspendLayout()
+		Me.GroupBox14.SuspendLayout()
+		Me.TabPage12.SuspendLayout()
+		Me.PNLImageTag.SuspendLayout()
+		CType(Me.ImageTagPictureBox, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.PictureBox14, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.TabPage9.SuspendLayout()
+		Me.Panel4.SuspendLayout()
+		Me.GroupBox55.SuspendLayout()
+		Me.GroupBox53.SuspendLayout()
+		Me.GroupBox49.SuspendLayout()
+		Me.GroupBox46.SuspendLayout()
+		Me.GroupBox54.SuspendLayout()
+		Me.GroupBox51.SuspendLayout()
+		Me.GroupBox50.SuspendLayout()
+		Me.GroupBox48.SuspendLayout()
+		CType(Me.PictureBox7, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.TabPage11.SuspendLayout()
+		Me.Panel7.SuspendLayout()
+		CType(Me.PictureBox5, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.WebPictureBox, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.TabPage3.SuspendLayout()
+		Me.Panel1.SuspendLayout()
+		CType(Me.PictureBox6, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox25.SuspendLayout()
+		Me.GroupBox24.SuspendLayout()
+		Me.GroupBox23.SuspendLayout()
+		Me.GroupBox8.SuspendLayout()
+		Me.GroupBox4.SuspendLayout()
+		Me.GroupBox3.SuspendLayout()
+		Me.GroupBox2.SuspendLayout()
+		Me.TabPage20.SuspendLayout()
+		Me.TabControl1.SuspendLayout()
+		Me.TabPage22.SuspendLayout()
+		Me.PNLGlitter.SuspendLayout()
+		Me.GBGlitterD.SuspendLayout()
+		CType(Me.GlitterSlider, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.GlitterAV, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GBGlitter1.SuspendLayout()
+		CType(Me.GlitterSlider1, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.GlitterAV1, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GBGlitter3.SuspendLayout()
+		CType(Me.GlitterSlider3, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.GlitterAV3, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GBGlitter2.SuspendLayout()
+		CType(Me.GlitterSlider2, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.GlitterAV2, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.TabPage23.SuspendLayout()
+		Me.GroupBox61.SuspendLayout()
+		CType(Me.GP6, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.GP2, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.GP5, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.GP1, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.GP3, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.GP4, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox60.SuspendLayout()
+		CType(Me.CardBack, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox58.SuspendLayout()
+		CType(Me.BP3, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.BP6, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.BP5, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.BP2, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.BP4, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.BP1, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox59.SuspendLayout()
+		CType(Me.SP6, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.SP2, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.SP5, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.SP1, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.SP3, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.SP4, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.TabPage6.SuspendLayout()
+		Me.Panel10.SuspendLayout()
+		CType(Me.NBWishlistCost, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.PNLWishList.SuspendLayout()
+		CType(Me.WishlistCostSilver, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.WishlistCostGold, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.WishlistPreview, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.TabPage26.SuspendLayout()
+		Me.Panel12.SuspendLayout()
+		Me.GroupBox9.SuspendLayout()
+		CType(Me.PictureBox10, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox5.SuspendLayout()
+		Me.GroupBox11.SuspendLayout()
+		Me.GroupBox1.SuspendLayout()
+		CType(Me.PBBackgroundPreview, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.TabPage4.SuspendLayout()
+		Me.Panel6.SuspendLayout()
+		Me.GroupBox69.SuspendLayout()
+		CType(Me.TypeSpeedSlider, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox68.SuspendLayout()
+		CType(Me.NBTasksMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBTasksMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox67.SuspendLayout()
+		CType(Me.NBTaskCBTTimeMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBTaskCBTTimeMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBTaskEdgeHoldTimeMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBTaskEdgeHoldTimeMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBTaskEdgesMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBTaskEdgesMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBTaskStrokingTimeMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBTaskStrokingTimeMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBTaskStrokesMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBTaskStrokesMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox10.SuspendLayout()
+		CType(Me.NBNextImageChance, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox57.SuspendLayout()
+		CType(Me.NBTauntEdging, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.SliderSTF, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.TauntSlider, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBTauntCycleMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBTauntCycleMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBTeaseLengthMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBTeaseLengthMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox56.SuspendLayout()
+		CType(Me.NBRuinSometimes, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBRuinRarely, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBRuinOften, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox17.SuspendLayout()
+		Me.GroupBox19.SuspendLayout()
+		CType(Me.NBGreenLightMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBGreenLightMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBRedLightMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBRedLightMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox18.SuspendLayout()
+		CType(Me.NBCensorShowMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBCensorHideMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBCensorHideMin, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBCensorShowMax, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox52.SuspendLayout()
+		CType(Me.NBAllowSometimes, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBAllowRarely, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.NBAllowOften, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.PictureBox8, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.TabPage13.SuspendLayout()
+		Me.TabControl2.SuspendLayout()
+		Me.TabPage27.SuspendLayout()
+		Me.TabPage14.SuspendLayout()
+		Me.TabPage24.SuspendLayout()
+		Me.TabPage8.SuspendLayout()
+		Me.GroupBox29.SuspendLayout()
+		Me.GroupBox28.SuspendLayout()
+		Me.GroupBox30.SuspendLayout()
+		Me.TabPage15.SuspendLayout()
+		Me.GroupBox34.SuspendLayout()
+		Me.TabPage25.SuspendLayout()
+		Me.Panel11.SuspendLayout()
+		Me.GroupBox62.SuspendLayout()
+		Me.GroupBox33.SuspendLayout()
+		Me.GroupBox27.SuspendLayout()
+		Me.GroupBox20.SuspendLayout()
+		Me.GroupBox15.SuspendLayout()
+		CType(Me.PictureBox9, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.TabPage28.SuspendLayout()
+		Me.TabControl3.SuspendLayout()
+		Me.TabPage29.SuspendLayout()
+		Me.GroupBox26.SuspendLayout()
+		Me.TabPage5.SuspendLayout()
+		Me.Panel5.SuspendLayout()
+		CType(Me.PictureBox3, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.GroupBox47.SuspendLayout()
+		Me.GroupBox41.SuspendLayout()
+		Me.GroupBox44.SuspendLayout()
+		Me.GroupBox6.SuspendLayout()
+		Me.GroupBox21.SuspendLayout()
+		Me.GroupBox12.SuspendLayout()
+		Me.GroupBox65.SuspendLayout()
+		CType(Me.TrackBar1, System.ComponentModel.ISupportInitialize).BeginInit()
+		CType(Me.TrackBar2, System.ComponentModel.ISupportInitialize).BeginInit()
+		Me.SuspendLayout()
 		'
 		'SettingsPanel
 		'
@@ -1436,24 +1439,24 @@ Partial Class FrmSettings
 		'BtnImportSettings
 		'
 		Me.BtnImportSettings.BackColor = System.Drawing.Color.Transparent
-		Me.BtnImportSettings.BackgroundImage = CType(resources.GetObject("BtnImportSettings.BackgroundImage"),System.Drawing.Image)
+		Me.BtnImportSettings.BackgroundImage = CType(resources.GetObject("BtnImportSettings.BackgroundImage"), System.Drawing.Image)
 		Me.BtnImportSettings.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch
 		Me.BtnImportSettings.FlatAppearance.BorderSize = 0
 		Me.BtnImportSettings.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Gray
 		Me.BtnImportSettings.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Silver
 		Me.BtnImportSettings.FlatStyle = System.Windows.Forms.FlatStyle.Flat
-		Me.BtnImportSettings.Font = New System.Drawing.Font("Arial", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BtnImportSettings.Font = New System.Drawing.Font("Arial", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BtnImportSettings.ForeColor = System.Drawing.Color.Black
 		Me.BtnImportSettings.Location = New System.Drawing.Point(669, 14)
 		Me.BtnImportSettings.Name = "BtnImportSettings"
 		Me.BtnImportSettings.Size = New System.Drawing.Size(30, 26)
 		Me.BtnImportSettings.TabIndex = 158
-		Me.BtnImportSettings.UseVisualStyleBackColor = false
+		Me.BtnImportSettings.UseVisualStyleBackColor = False
 		'
 		'LblImportSettings
 		'
-		Me.LblImportSettings.AutoSize = true
-		Me.LblImportSettings.Font = New System.Drawing.Font("Microsoft Sans Serif", 7!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblImportSettings.AutoSize = True
+		Me.LblImportSettings.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblImportSettings.ForeColor = System.Drawing.Color.Black
 		Me.LblImportSettings.Location = New System.Drawing.Point(664, 0)
 		Me.LblImportSettings.Name = "LblImportSettings"
@@ -1471,8 +1474,22 @@ Partial Class FrmSettings
 		Me.GroupBox64.Name = "GroupBox64"
 		Me.GroupBox64.Size = New System.Drawing.Size(259, 49)
 		Me.GroupBox64.TabIndex = 157
-		Me.GroupBox64.TabStop = false
+		Me.GroupBox64.TabStop = False
 		Me.GroupBox64.Text = "Media Options"
+		'
+		'CBMuteMedia
+		'
+		Me.CBMuteMedia.AutoSize = True
+		Me.CBMuteMedia.Checked = Global.Tease_AI.My.MySettings.Default.MuteMedia
+		Me.CBMuteMedia.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "MuteMedia", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.CBMuteMedia.ForeColor = System.Drawing.Color.Black
+		Me.CBMuteMedia.Location = New System.Drawing.Point(7, 21)
+		Me.CBMuteMedia.Name = "CBMuteMedia"
+		Me.CBMuteMedia.Size = New System.Drawing.Size(241, 17)
+		Me.CBMuteMedia.TabIndex = 6
+		Me.CBMuteMedia.TabStop = False
+		Me.CBMuteMedia.Text = "Mute Video and Audio Played in Media Player"
+		Me.CBMuteMedia.UseVisualStyleBackColor = True
 		'
 		'GBDommeImages
 		'
@@ -1489,13 +1506,13 @@ Partial Class FrmSettings
 		Me.GBDommeImages.Name = "GBDommeImages"
 		Me.GBDommeImages.Size = New System.Drawing.Size(210, 128)
 		Me.GBDommeImages.TabIndex = 156
-		Me.GBDommeImages.TabStop = false
+		Me.GBDommeImages.TabStop = False
 		Me.GBDommeImages.Text = "Slideshow Options"
 		'
 		'slideshowNumBox
 		'
 		Me.slideshowNumBox.BackColor = System.Drawing.Color.White
-		Me.slideshowNumBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.slideshowNumBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.slideshowNumBox.ForeColor = System.Drawing.Color.Black
 		Me.slideshowNumBox.Location = New System.Drawing.Point(93, 20)
 		Me.slideshowNumBox.Maximum = New Decimal(New Integer() {120, 0, 0, 0})
@@ -1507,72 +1524,72 @@ Partial Class FrmSettings
 		'
 		'teaseRadio
 		'
-		Me.teaseRadio.AutoSize = true
-		Me.teaseRadio.Checked = true
-		Me.teaseRadio.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.teaseRadio.AutoSize = True
+		Me.teaseRadio.Checked = True
+		Me.teaseRadio.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.teaseRadio.ForeColor = System.Drawing.Color.Black
 		Me.teaseRadio.Location = New System.Drawing.Point(149, 21)
 		Me.teaseRadio.Name = "teaseRadio"
 		Me.teaseRadio.Size = New System.Drawing.Size(55, 17)
 		Me.teaseRadio.TabIndex = 21
-		Me.teaseRadio.TabStop = true
+		Me.teaseRadio.TabStop = True
 		Me.teaseRadio.Text = "Tease"
-		Me.teaseRadio.UseVisualStyleBackColor = true
+		Me.teaseRadio.UseVisualStyleBackColor = True
 		'
 		'CBNewSlideshow
 		'
-		Me.CBNewSlideshow.AutoSize = true
-		Me.CBNewSlideshow.Checked = true
+		Me.CBNewSlideshow.AutoSize = True
+		Me.CBNewSlideshow.Checked = True
 		Me.CBNewSlideshow.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBNewSlideshow.ForeColor = System.Drawing.Color.Black
 		Me.CBNewSlideshow.Location = New System.Drawing.Point(6, 100)
 		Me.CBNewSlideshow.Name = "CBNewSlideshow"
 		Me.CBNewSlideshow.Size = New System.Drawing.Size(200, 17)
 		Me.CBNewSlideshow.TabIndex = 18
-		Me.CBNewSlideshow.TabStop = false
+		Me.CBNewSlideshow.TabStop = False
 		Me.CBNewSlideshow.Text = "Load New Slideshow When Finished"
-		Me.CBNewSlideshow.UseVisualStyleBackColor = true
+		Me.CBNewSlideshow.UseVisualStyleBackColor = True
 		'
 		'offRadio
 		'
-		Me.offRadio.AutoSize = true
-		Me.offRadio.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.offRadio.AutoSize = True
+		Me.offRadio.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.offRadio.ForeColor = System.Drawing.Color.Black
 		Me.offRadio.Location = New System.Drawing.Point(6, 21)
 		Me.offRadio.Name = "offRadio"
 		Me.offRadio.Size = New System.Drawing.Size(60, 17)
 		Me.offRadio.TabIndex = 18
 		Me.offRadio.Text = "Manual"
-		Me.offRadio.UseVisualStyleBackColor = true
+		Me.offRadio.UseVisualStyleBackColor = True
 		'
 		'BTNDomImageDir
 		'
 		Me.BTNDomImageDir.BackColor = System.Drawing.Color.LightGray
-		Me.BTNDomImageDir.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNDomImageDir.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNDomImageDir.ForeColor = System.Drawing.Color.Black
 		Me.BTNDomImageDir.Location = New System.Drawing.Point(6, 45)
 		Me.BTNDomImageDir.Name = "BTNDomImageDir"
 		Me.BTNDomImageDir.Size = New System.Drawing.Size(198, 22)
 		Me.BTNDomImageDir.TabIndex = 17
 		Me.BTNDomImageDir.Text = "Set Domme Images Directory"
-		Me.BTNDomImageDir.UseVisualStyleBackColor = false
+		Me.BTNDomImageDir.UseVisualStyleBackColor = False
 		'
 		'timedRadio
 		'
-		Me.timedRadio.AutoSize = true
-		Me.timedRadio.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.timedRadio.AutoSize = True
+		Me.timedRadio.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.timedRadio.ForeColor = System.Drawing.Color.Black
 		Me.timedRadio.Location = New System.Drawing.Point(72, 23)
 		Me.timedRadio.Name = "timedRadio"
 		Me.timedRadio.Size = New System.Drawing.Size(14, 13)
 		Me.timedRadio.TabIndex = 19
-		Me.timedRadio.UseVisualStyleBackColor = true
+		Me.timedRadio.UseVisualStyleBackColor = True
 		'
 		'LBLDomImageDir
 		'
 		Me.LBLDomImageDir.BackColor = System.Drawing.Color.Transparent
 		Me.LBLDomImageDir.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLDomImageDir.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLDomImageDir.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLDomImageDir.ForeColor = System.Drawing.Color.Black
 		Me.LBLDomImageDir.Location = New System.Drawing.Point(6, 73)
 		Me.LBLDomImageDir.Name = "LBLDomImageDir"
@@ -1597,7 +1614,7 @@ Partial Class FrmSettings
 		Me.GBGeneralTextToSpeech.Name = "GBGeneralTextToSpeech"
 		Me.GBGeneralTextToSpeech.Size = New System.Drawing.Size(259, 117)
 		Me.GBGeneralTextToSpeech.TabIndex = 0
-		Me.GBGeneralTextToSpeech.TabStop = false
+		Me.GBGeneralTextToSpeech.TabStop = False
 		Me.GBGeneralTextToSpeech.Text = "Text to Speech"
 		'
 		'LBLVRate
@@ -1611,7 +1628,7 @@ Partial Class FrmSettings
 		'
 		'Label93
 		'
-		Me.Label93.AutoSize = true
+		Me.Label93.AutoSize = True
 		Me.Label93.Location = New System.Drawing.Point(141, 52)
 		Me.Label93.Name = "Label93"
 		Me.Label93.Size = New System.Drawing.Size(33, 13)
@@ -1629,7 +1646,7 @@ Partial Class FrmSettings
 		'
 		'Label68
 		'
-		Me.Label68.AutoSize = true
+		Me.Label68.AutoSize = True
 		Me.Label68.Location = New System.Drawing.Point(14, 52)
 		Me.Label68.Name = "Label68"
 		Me.Label68.Size = New System.Drawing.Size(45, 13)
@@ -1655,27 +1672,27 @@ Partial Class FrmSettings
 		'
 		'TTSCheckBox
 		'
-		Me.TTSCheckBox.AutoSize = true
+		Me.TTSCheckBox.AutoSize = True
 		Me.TTSCheckBox.ForeColor = System.Drawing.Color.Black
 		Me.TTSCheckBox.Location = New System.Drawing.Point(10, 21)
 		Me.TTSCheckBox.Name = "TTSCheckBox"
 		Me.TTSCheckBox.Size = New System.Drawing.Size(59, 17)
 		Me.TTSCheckBox.TabIndex = 28
-		Me.TTSCheckBox.TabStop = false
+		Me.TTSCheckBox.TabStop = False
 		Me.TTSCheckBox.Text = "Enable"
-		Me.TTSCheckBox.UseVisualStyleBackColor = true
+		Me.TTSCheckBox.UseVisualStyleBackColor = True
 		'
 		'TTSComboBox
 		'
 		Me.TTSComboBox.BackColor = System.Drawing.SystemColors.Window
 		Me.TTSComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
 		Me.TTSComboBox.ForeColor = System.Drawing.SystemColors.WindowText
-		Me.TTSComboBox.FormattingEnabled = true
+		Me.TTSComboBox.FormattingEnabled = True
 		Me.TTSComboBox.Location = New System.Drawing.Point(71, 19)
 		Me.TTSComboBox.Name = "TTSComboBox"
 		Me.TTSComboBox.Size = New System.Drawing.Size(178, 21)
 		Me.TTSComboBox.TabIndex = 29
-		Me.TTSComboBox.TabStop = false
+		Me.TTSComboBox.TabStop = False
 		'
 		'GBSafeword
 		'
@@ -1687,7 +1704,7 @@ Partial Class FrmSettings
 		Me.GBSafeword.Name = "GBSafeword"
 		Me.GBSafeword.Size = New System.Drawing.Size(259, 74)
 		Me.GBSafeword.TabIndex = 0
-		Me.GBSafeword.TabStop = false
+		Me.GBSafeword.TabStop = False
 		Me.GBSafeword.Text = "Safeword"
 		'
 		'LBLSafeword
@@ -1696,8 +1713,8 @@ Partial Class FrmSettings
 		Me.LBLSafeword.Name = "LBLSafeword"
 		Me.LBLSafeword.Size = New System.Drawing.Size(225, 29)
 		Me.LBLSafeword.TabIndex = 0
-		Me.LBLSafeword.Text = "Enter a safeword that will stop all activity until the domme is sure you're able "& _ 
-    "to continue."
+		Me.LBLSafeword.Text = "Enter a safeword that will stop all activity until the domme is sure you're able " &
+	"to continue."
 		Me.LBLSafeword.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
 		'
 		'TBSafeword
@@ -1720,72 +1737,72 @@ Partial Class FrmSettings
 		Me.GBGeneralSystem.Name = "GBGeneralSystem"
 		Me.GBGeneralSystem.Size = New System.Drawing.Size(259, 140)
 		Me.GBGeneralSystem.TabIndex = 0
-		Me.GBGeneralSystem.TabStop = false
+		Me.GBGeneralSystem.TabStop = False
 		Me.GBGeneralSystem.Text = "System"
 		'
 		'CBAuditStartup
 		'
-		Me.CBAuditStartup.AutoSize = true
+		Me.CBAuditStartup.AutoSize = True
 		Me.CBAuditStartup.ForeColor = System.Drawing.Color.Black
 		Me.CBAuditStartup.Location = New System.Drawing.Point(7, 19)
 		Me.CBAuditStartup.Name = "CBAuditStartup"
 		Me.CBAuditStartup.Size = New System.Drawing.Size(137, 17)
 		Me.CBAuditStartup.TabIndex = 26
-		Me.CBAuditStartup.TabStop = false
+		Me.CBAuditStartup.TabStop = False
 		Me.CBAuditStartup.Text = "Audit Scripts on Startup"
-		Me.CBAuditStartup.UseVisualStyleBackColor = true
+		Me.CBAuditStartup.UseVisualStyleBackColor = True
 		'
 		'CBDomDel
 		'
-		Me.CBDomDel.AutoSize = true
+		Me.CBDomDel.AutoSize = True
 		Me.CBDomDel.ForeColor = System.Drawing.Color.Black
 		Me.CBDomDel.Location = New System.Drawing.Point(7, 110)
 		Me.CBDomDel.Name = "CBDomDel"
 		Me.CBDomDel.Size = New System.Drawing.Size(197, 17)
 		Me.CBDomDel.TabIndex = 27
-		Me.CBDomDel.TabStop = false
+		Me.CBDomDel.TabStop = False
 		Me.CBDomDel.Text = "Allow Domme to Delete Local Media"
-		Me.CBDomDel.UseVisualStyleBackColor = true
+		Me.CBDomDel.UseVisualStyleBackColor = True
 		'
 		'CBSettingsPause
 		'
-		Me.CBSettingsPause.AutoSize = true
+		Me.CBSettingsPause.AutoSize = True
 		Me.CBSettingsPause.ForeColor = System.Drawing.Color.Black
 		Me.CBSettingsPause.Location = New System.Drawing.Point(7, 41)
 		Me.CBSettingsPause.Name = "CBSettingsPause"
 		Me.CBSettingsPause.Size = New System.Drawing.Size(244, 17)
 		Me.CBSettingsPause.TabIndex = 22
-		Me.CBSettingsPause.TabStop = false
+		Me.CBSettingsPause.TabStop = False
 		Me.CBSettingsPause.Text = "Pause Program When Settings Menu is Visible"
-		Me.CBSettingsPause.UseVisualStyleBackColor = true
+		Me.CBSettingsPause.UseVisualStyleBackColor = True
 		'
 		'CBSaveChatlogExit
 		'
-		Me.CBSaveChatlogExit.AutoSize = true
-		Me.CBSaveChatlogExit.Checked = true
+		Me.CBSaveChatlogExit.AutoSize = True
+		Me.CBSaveChatlogExit.Checked = True
 		Me.CBSaveChatlogExit.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBSaveChatlogExit.ForeColor = System.Drawing.Color.Black
 		Me.CBSaveChatlogExit.Location = New System.Drawing.Point(7, 87)
 		Me.CBSaveChatlogExit.Name = "CBSaveChatlogExit"
 		Me.CBSaveChatlogExit.Size = New System.Drawing.Size(162, 17)
 		Me.CBSaveChatlogExit.TabIndex = 25
-		Me.CBSaveChatlogExit.TabStop = false
+		Me.CBSaveChatlogExit.TabStop = False
 		Me.CBSaveChatlogExit.Text = "Save Unique Chatlog on Exit"
-		Me.CBSaveChatlogExit.UseVisualStyleBackColor = true
+		Me.CBSaveChatlogExit.UseVisualStyleBackColor = True
 		'
 		'CBAutosaveChatlog
 		'
-		Me.CBAutosaveChatlog.AutoSize = true
-		Me.CBAutosaveChatlog.Checked = true
+		Me.CBAutosaveChatlog.AutoSize = True
+		Me.CBAutosaveChatlog.Checked = True
 		Me.CBAutosaveChatlog.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBAutosaveChatlog.ForeColor = System.Drawing.Color.Black
 		Me.CBAutosaveChatlog.Location = New System.Drawing.Point(7, 64)
 		Me.CBAutosaveChatlog.Name = "CBAutosaveChatlog"
 		Me.CBAutosaveChatlog.Size = New System.Drawing.Size(110, 17)
 		Me.CBAutosaveChatlog.TabIndex = 24
-		Me.CBAutosaveChatlog.TabStop = false
+		Me.CBAutosaveChatlog.TabStop = False
 		Me.CBAutosaveChatlog.Text = "Autosave Chatlog"
-		Me.CBAutosaveChatlog.UseVisualStyleBackColor = true
+		Me.CBAutosaveChatlog.UseVisualStyleBackColor = True
 		'
 		'GBGeneralImages
 		'
@@ -1798,83 +1815,83 @@ Partial Class FrmSettings
 		Me.GBGeneralImages.Name = "GBGeneralImages"
 		Me.GBGeneralImages.Size = New System.Drawing.Size(210, 140)
 		Me.GBGeneralImages.TabIndex = 0
-		Me.GBGeneralImages.TabStop = false
+		Me.GBGeneralImages.TabStop = False
 		Me.GBGeneralImages.Text = "Images"
 		'
 		'CBImageInfo
 		'
-		Me.CBImageInfo.AutoSize = true
+		Me.CBImageInfo.AutoSize = True
 		Me.CBImageInfo.ForeColor = System.Drawing.Color.Black
 		Me.CBImageInfo.Location = New System.Drawing.Point(6, 110)
 		Me.CBImageInfo.Name = "CBImageInfo"
 		Me.CBImageInfo.Size = New System.Drawing.Size(147, 17)
 		Me.CBImageInfo.TabIndex = 16
-		Me.CBImageInfo.TabStop = false
+		Me.CBImageInfo.TabStop = False
 		Me.CBImageInfo.Text = "Display Image Information"
-		Me.CBImageInfo.UseVisualStyleBackColor = true
+		Me.CBImageInfo.UseVisualStyleBackColor = True
 		'
 		'CBSlideshowRandom
 		'
-		Me.CBSlideshowRandom.AutoSize = true
+		Me.CBSlideshowRandom.AutoSize = True
 		Me.CBSlideshowRandom.ForeColor = System.Drawing.Color.Black
 		Me.CBSlideshowRandom.Location = New System.Drawing.Point(6, 64)
 		Me.CBSlideshowRandom.Name = "CBSlideshowRandom"
 		Me.CBSlideshowRandom.Size = New System.Drawing.Size(202, 17)
 		Me.CBSlideshowRandom.TabIndex = 14
-		Me.CBSlideshowRandom.TabStop = false
+		Me.CBSlideshowRandom.TabStop = False
 		Me.CBSlideshowRandom.Text = "Display Slideshow Pictures Randomly"
-		Me.CBSlideshowRandom.UseVisualStyleBackColor = true
+		Me.CBSlideshowRandom.UseVisualStyleBackColor = True
 		'
 		'landscapeCheckBox
 		'
-		Me.landscapeCheckBox.AutoSize = true
+		Me.landscapeCheckBox.AutoSize = True
 		Me.landscapeCheckBox.ForeColor = System.Drawing.Color.Black
 		Me.landscapeCheckBox.Location = New System.Drawing.Point(6, 87)
 		Me.landscapeCheckBox.Name = "landscapeCheckBox"
 		Me.landscapeCheckBox.Size = New System.Drawing.Size(153, 17)
 		Me.landscapeCheckBox.TabIndex = 15
-		Me.landscapeCheckBox.TabStop = false
+		Me.landscapeCheckBox.TabStop = False
 		Me.landscapeCheckBox.Text = "Stretch Landscape Images"
-		Me.landscapeCheckBox.UseVisualStyleBackColor = true
+		Me.landscapeCheckBox.UseVisualStyleBackColor = True
 		'
 		'CBBlogImageWindow
 		'
-		Me.CBBlogImageWindow.AutoSize = true
-		Me.CBBlogImageWindow.Checked = true
+		Me.CBBlogImageWindow.AutoSize = True
+		Me.CBBlogImageWindow.Checked = True
 		Me.CBBlogImageWindow.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBBlogImageWindow.ForeColor = System.Drawing.Color.Black
 		Me.CBBlogImageWindow.Location = New System.Drawing.Point(6, 18)
 		Me.CBBlogImageWindow.Name = "CBBlogImageWindow"
 		Me.CBBlogImageWindow.Size = New System.Drawing.Size(178, 17)
 		Me.CBBlogImageWindow.TabIndex = 12
-		Me.CBBlogImageWindow.TabStop = false
+		Me.CBBlogImageWindow.TabStop = False
 		Me.CBBlogImageWindow.Text = "Save Blog Images From Session"
-		Me.CBBlogImageWindow.UseVisualStyleBackColor = true
+		Me.CBBlogImageWindow.UseVisualStyleBackColor = True
 		'
 		'CBSlideshowSubDir
 		'
-		Me.CBSlideshowSubDir.AutoSize = true
-		Me.CBSlideshowSubDir.Checked = true
+		Me.CBSlideshowSubDir.AutoSize = True
+		Me.CBSlideshowSubDir.Checked = True
 		Me.CBSlideshowSubDir.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBSlideshowSubDir.ForeColor = System.Drawing.Color.Black
 		Me.CBSlideshowSubDir.Location = New System.Drawing.Point(6, 41)
 		Me.CBSlideshowSubDir.Name = "CBSlideshowSubDir"
 		Me.CBSlideshowSubDir.Size = New System.Drawing.Size(187, 17)
 		Me.CBSlideshowSubDir.TabIndex = 13
-		Me.CBSlideshowSubDir.TabStop = false
+		Me.CBSlideshowSubDir.TabStop = False
 		Me.CBSlideshowSubDir.Text = "Slideshow Includes Subdirectories"
-		Me.CBSlideshowSubDir.UseVisualStyleBackColor = true
+		Me.CBSlideshowSubDir.UseVisualStyleBackColor = True
 		'
 		'PictureBox2
 		'
 		Me.PictureBox2.BackColor = System.Drawing.Color.LightGray
-		Me.PictureBox2.Image = CType(resources.GetObject("PictureBox2.Image"),System.Drawing.Image)
+		Me.PictureBox2.Image = CType(resources.GetObject("PictureBox2.Image"), System.Drawing.Image)
 		Me.PictureBox2.Location = New System.Drawing.Point(9, 6)
 		Me.PictureBox2.Name = "PictureBox2"
 		Me.PictureBox2.Size = New System.Drawing.Size(160, 19)
 		Me.PictureBox2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage
 		Me.PictureBox2.TabIndex = 148
-		Me.PictureBox2.TabStop = false
+		Me.PictureBox2.TabStop = False
 		'
 		'GBGeneralSettings
 		'
@@ -1891,20 +1908,20 @@ Partial Class FrmSettings
 		Me.GBGeneralSettings.Name = "GBGeneralSettings"
 		Me.GBGeneralSettings.Size = New System.Drawing.Size(211, 326)
 		Me.GBGeneralSettings.TabIndex = 0
-		Me.GBGeneralSettings.TabStop = false
+		Me.GBGeneralSettings.TabStop = False
 		Me.GBGeneralSettings.Text = "Chat Window"
 		'
 		'CBWebtease
 		'
-		Me.CBWebtease.AutoSize = true
+		Me.CBWebtease.AutoSize = True
 		Me.CBWebtease.ForeColor = System.Drawing.Color.Black
 		Me.CBWebtease.Location = New System.Drawing.Point(6, 110)
 		Me.CBWebtease.Name = "CBWebtease"
 		Me.CBWebtease.Size = New System.Drawing.Size(105, 17)
 		Me.CBWebtease.TabIndex = 5
-		Me.CBWebtease.TabStop = false
+		Me.CBWebtease.TabStop = False
 		Me.CBWebtease.Text = "Webtease Mode"
-		Me.CBWebtease.UseVisualStyleBackColor = true
+		Me.CBWebtease.UseVisualStyleBackColor = True
 		'
 		'GBSubFont
 		'
@@ -1917,26 +1934,26 @@ Partial Class FrmSettings
 		Me.GBSubFont.Name = "GBSubFont"
 		Me.GBSubFont.Size = New System.Drawing.Size(200, 77)
 		Me.GBSubFont.TabIndex = 0
-		Me.GBSubFont.TabStop = false
+		Me.GBSubFont.TabStop = False
 		Me.GBSubFont.Text = "Sub Font Settings"
 		'
 		'BTNSubColor
 		'
 		Me.BTNSubColor.BackColor = System.Drawing.Color.LightGray
-		Me.BTNSubColor.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNSubColor.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNSubColor.ForeColor = System.Drawing.Color.Black
 		Me.BTNSubColor.Location = New System.Drawing.Point(6, 19)
 		Me.BTNSubColor.Name = "BTNSubColor"
 		Me.BTNSubColor.Size = New System.Drawing.Size(110, 25)
 		Me.BTNSubColor.TabIndex = 8
 		Me.BTNSubColor.Text = "Sub Name Color"
-		Me.BTNSubColor.UseVisualStyleBackColor = false
+		Me.BTNSubColor.UseVisualStyleBackColor = False
 		'
 		'LBLSubColor
 		'
 		Me.LBLSubColor.BackColor = System.Drawing.Color.White
 		Me.LBLSubColor.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLSubColor.Font = New System.Drawing.Font("Microsoft Sans Serif", 9!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLSubColor.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLSubColor.ForeColor = System.Drawing.Color.Black
 		Me.LBLSubColor.Location = New System.Drawing.Point(120, 20)
 		Me.LBLSubColor.Name = "LBLSubColor"
@@ -1948,7 +1965,7 @@ Partial Class FrmSettings
 		'NBFontSize
 		'
 		Me.NBFontSize.BackColor = System.Drawing.Color.White
-		Me.NBFontSize.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.NBFontSize.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.NBFontSize.ForeColor = System.Drawing.Color.Black
 		Me.NBFontSize.Location = New System.Drawing.Point(147, 47)
 		Me.NBFontSize.Maximum = New Decimal(New Integer() {5, 0, 0, 0})
@@ -1961,7 +1978,7 @@ Partial Class FrmSettings
 		'Label2
 		'
 		Me.Label2.BackColor = System.Drawing.Color.Transparent
-		Me.Label2.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label2.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label2.ForeColor = System.Drawing.Color.Black
 		Me.Label2.Location = New System.Drawing.Point(117, 45)
 		Me.Label2.Name = "Label2"
@@ -1972,7 +1989,7 @@ Partial Class FrmSettings
 		'
 		'FontComboBox
 		'
-		Me.FontComboBox.FormattingEnabled = true
+		Me.FontComboBox.FormattingEnabled = True
 		Me.FontComboBox.Location = New System.Drawing.Point(6, 46)
 		Me.FontComboBox.Name = "FontComboBox"
 		Me.FontComboBox.Size = New System.Drawing.Size(110, 21)
@@ -1989,26 +2006,26 @@ Partial Class FrmSettings
 		Me.GBDommeFont.Name = "GBDommeFont"
 		Me.GBDommeFont.Size = New System.Drawing.Size(200, 77)
 		Me.GBDommeFont.TabIndex = 0
-		Me.GBDommeFont.TabStop = false
+		Me.GBDommeFont.TabStop = False
 		Me.GBDommeFont.Text = "Domme Font Settings"
 		'
 		'BTNDomColor
 		'
 		Me.BTNDomColor.BackColor = System.Drawing.Color.LightGray
-		Me.BTNDomColor.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNDomColor.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNDomColor.ForeColor = System.Drawing.Color.Black
 		Me.BTNDomColor.Location = New System.Drawing.Point(6, 19)
 		Me.BTNDomColor.Name = "BTNDomColor"
 		Me.BTNDomColor.Size = New System.Drawing.Size(110, 25)
 		Me.BTNDomColor.TabIndex = 5
 		Me.BTNDomColor.Text = "Domme Name Color"
-		Me.BTNDomColor.UseVisualStyleBackColor = false
+		Me.BTNDomColor.UseVisualStyleBackColor = False
 		'
 		'LBLDomColor
 		'
 		Me.LBLDomColor.BackColor = System.Drawing.Color.White
 		Me.LBLDomColor.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLDomColor.Font = New System.Drawing.Font("Microsoft Sans Serif", 9!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLDomColor.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLDomColor.ForeColor = System.Drawing.Color.Black
 		Me.LBLDomColor.Location = New System.Drawing.Point(120, 20)
 		Me.LBLDomColor.Name = "LBLDomColor"
@@ -2019,7 +2036,7 @@ Partial Class FrmSettings
 		'
 		'FontComboBoxD
 		'
-		Me.FontComboBoxD.FormattingEnabled = true
+		Me.FontComboBoxD.FormattingEnabled = True
 		Me.FontComboBoxD.Location = New System.Drawing.Point(6, 46)
 		Me.FontComboBoxD.Name = "FontComboBoxD"
 		Me.FontComboBoxD.Size = New System.Drawing.Size(110, 21)
@@ -2028,7 +2045,7 @@ Partial Class FrmSettings
 		'NBFontSizeD
 		'
 		Me.NBFontSizeD.BackColor = System.Drawing.Color.White
-		Me.NBFontSizeD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.NBFontSizeD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.NBFontSizeD.ForeColor = System.Drawing.Color.Black
 		Me.NBFontSizeD.Location = New System.Drawing.Point(147, 47)
 		Me.NBFontSizeD.Maximum = New Decimal(New Integer() {5, 0, 0, 0})
@@ -2041,7 +2058,7 @@ Partial Class FrmSettings
 		'Label7
 		'
 		Me.Label7.BackColor = System.Drawing.Color.Transparent
-		Me.Label7.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label7.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label7.ForeColor = System.Drawing.Color.Black
 		Me.Label7.Location = New System.Drawing.Point(117, 45)
 		Me.Label7.Name = "Label7"
@@ -2052,62 +2069,62 @@ Partial Class FrmSettings
 		'
 		'CBInputIcon
 		'
-		Me.CBInputIcon.AutoSize = true
-		Me.CBInputIcon.Checked = true
+		Me.CBInputIcon.AutoSize = True
+		Me.CBInputIcon.Checked = True
 		Me.CBInputIcon.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBInputIcon.ForeColor = System.Drawing.Color.Black
 		Me.CBInputIcon.Location = New System.Drawing.Point(6, 87)
 		Me.CBInputIcon.Name = "CBInputIcon"
 		Me.CBInputIcon.Size = New System.Drawing.Size(188, 17)
 		Me.CBInputIcon.TabIndex = 4
-		Me.CBInputIcon.TabStop = false
+		Me.CBInputIcon.TabStop = False
 		Me.CBInputIcon.Text = "Show Icon During Input Questions"
-		Me.CBInputIcon.UseVisualStyleBackColor = true
+		Me.CBInputIcon.UseVisualStyleBackColor = True
 		'
 		'typeinstantlyCheckBox
 		'
-		Me.typeinstantlyCheckBox.AutoSize = true
+		Me.typeinstantlyCheckBox.AutoSize = True
 		Me.typeinstantlyCheckBox.ForeColor = System.Drawing.Color.Black
 		Me.typeinstantlyCheckBox.Location = New System.Drawing.Point(6, 64)
 		Me.typeinstantlyCheckBox.Name = "typeinstantlyCheckBox"
 		Me.typeinstantlyCheckBox.Size = New System.Drawing.Size(136, 17)
 		Me.typeinstantlyCheckBox.TabIndex = 3
-		Me.typeinstantlyCheckBox.TabStop = false
+		Me.typeinstantlyCheckBox.TabStop = False
 		Me.typeinstantlyCheckBox.Text = "Domme Types Instantly"
-		Me.typeinstantlyCheckBox.UseVisualStyleBackColor = true
+		Me.typeinstantlyCheckBox.UseVisualStyleBackColor = True
 		'
 		'timestampCheckBox
 		'
-		Me.timestampCheckBox.AutoSize = true
-		Me.timestampCheckBox.Checked = true
+		Me.timestampCheckBox.AutoSize = True
+		Me.timestampCheckBox.Checked = True
 		Me.timestampCheckBox.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.timestampCheckBox.ForeColor = System.Drawing.Color.Black
 		Me.timestampCheckBox.Location = New System.Drawing.Point(6, 18)
 		Me.timestampCheckBox.Name = "timestampCheckBox"
 		Me.timestampCheckBox.Size = New System.Drawing.Size(112, 17)
 		Me.timestampCheckBox.TabIndex = 1
-		Me.timestampCheckBox.TabStop = false
+		Me.timestampCheckBox.TabStop = False
 		Me.timestampCheckBox.Text = "Show Timestamps"
-		Me.timestampCheckBox.UseVisualStyleBackColor = true
+		Me.timestampCheckBox.UseVisualStyleBackColor = True
 		'
 		'shownamesCheckBox
 		'
-		Me.shownamesCheckBox.AutoSize = true
-		Me.shownamesCheckBox.Checked = true
+		Me.shownamesCheckBox.AutoSize = True
+		Me.shownamesCheckBox.Checked = True
 		Me.shownamesCheckBox.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.shownamesCheckBox.ForeColor = System.Drawing.Color.Black
 		Me.shownamesCheckBox.Location = New System.Drawing.Point(6, 41)
 		Me.shownamesCheckBox.Name = "shownamesCheckBox"
 		Me.shownamesCheckBox.Size = New System.Drawing.Size(125, 17)
 		Me.shownamesCheckBox.TabIndex = 2
-		Me.shownamesCheckBox.TabStop = false
+		Me.shownamesCheckBox.TabStop = False
 		Me.shownamesCheckBox.Text = "Always Show Names"
-		Me.shownamesCheckBox.UseVisualStyleBackColor = true
+		Me.shownamesCheckBox.UseVisualStyleBackColor = True
 		'
 		'LBLGeneralSettings
 		'
 		Me.LBLGeneralSettings.BackColor = System.Drawing.Color.Transparent
-		Me.LBLGeneralSettings.Font = New System.Drawing.Font("Microsoft Sans Serif", 12!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLGeneralSettings.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLGeneralSettings.ForeColor = System.Drawing.Color.Black
 		Me.LBLGeneralSettings.Location = New System.Drawing.Point(7, 6)
 		Me.LBLGeneralSettings.Name = "LBLGeneralSettings"
@@ -2151,41 +2168,41 @@ Partial Class FrmSettings
 		'BTNLoadDomSet
 		'
 		Me.BTNLoadDomSet.BackColor = System.Drawing.Color.LightGray
-		Me.BTNLoadDomSet.BackgroundImage = CType(resources.GetObject("BTNLoadDomSet.BackgroundImage"),System.Drawing.Image)
+		Me.BTNLoadDomSet.BackgroundImage = CType(resources.GetObject("BTNLoadDomSet.BackgroundImage"), System.Drawing.Image)
 		Me.BTNLoadDomSet.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch
 		Me.BTNLoadDomSet.FlatAppearance.BorderSize = 0
 		Me.BTNLoadDomSet.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Gray
 		Me.BTNLoadDomSet.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Silver
 		Me.BTNLoadDomSet.FlatStyle = System.Windows.Forms.FlatStyle.Flat
-		Me.BTNLoadDomSet.Font = New System.Drawing.Font("Arial", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNLoadDomSet.Font = New System.Drawing.Font("Arial", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNLoadDomSet.ForeColor = System.Drawing.Color.Black
 		Me.BTNLoadDomSet.Location = New System.Drawing.Point(671, 11)
 		Me.BTNLoadDomSet.Name = "BTNLoadDomSet"
 		Me.BTNLoadDomSet.Size = New System.Drawing.Size(30, 26)
 		Me.BTNLoadDomSet.TabIndex = 150
-		Me.BTNLoadDomSet.UseVisualStyleBackColor = false
+		Me.BTNLoadDomSet.UseVisualStyleBackColor = False
 		'
 		'BTNSaveDomSet
 		'
 		Me.BTNSaveDomSet.BackColor = System.Drawing.Color.LightGray
-		Me.BTNSaveDomSet.BackgroundImage = CType(resources.GetObject("BTNSaveDomSet.BackgroundImage"),System.Drawing.Image)
+		Me.BTNSaveDomSet.BackgroundImage = CType(resources.GetObject("BTNSaveDomSet.BackgroundImage"), System.Drawing.Image)
 		Me.BTNSaveDomSet.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch
 		Me.BTNSaveDomSet.FlatAppearance.BorderSize = 0
 		Me.BTNSaveDomSet.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Gray
 		Me.BTNSaveDomSet.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Silver
 		Me.BTNSaveDomSet.FlatStyle = System.Windows.Forms.FlatStyle.Flat
-		Me.BTNSaveDomSet.Font = New System.Drawing.Font("Arial", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNSaveDomSet.Font = New System.Drawing.Font("Arial", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNSaveDomSet.ForeColor = System.Drawing.Color.Black
 		Me.BTNSaveDomSet.Location = New System.Drawing.Point(636, 8)
 		Me.BTNSaveDomSet.Name = "BTNSaveDomSet"
 		Me.BTNSaveDomSet.Size = New System.Drawing.Size(30, 26)
 		Me.BTNSaveDomSet.TabIndex = 151
-		Me.BTNSaveDomSet.UseVisualStyleBackColor = false
+		Me.BTNSaveDomSet.UseVisualStyleBackColor = False
 		'
 		'Label127
 		'
-		Me.Label127.AutoSize = true
-		Me.Label127.Font = New System.Drawing.Font("Microsoft Sans Serif", 7!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label127.AutoSize = True
+		Me.Label127.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label127.ForeColor = System.Drawing.Color.Black
 		Me.Label127.Location = New System.Drawing.Point(670, -3)
 		Me.Label127.Name = "Label127"
@@ -2196,8 +2213,8 @@ Partial Class FrmSettings
 		'
 		'Label126
 		'
-		Me.Label126.AutoSize = true
-		Me.Label126.Font = New System.Drawing.Font("Microsoft Sans Serif", 7!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label126.AutoSize = True
+		Me.Label126.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label126.ForeColor = System.Drawing.Color.Black
 		Me.Label126.Location = New System.Drawing.Point(636, -3)
 		Me.Label126.Name = "Label126"
@@ -2209,13 +2226,13 @@ Partial Class FrmSettings
 		'PictureBox4
 		'
 		Me.PictureBox4.BackColor = System.Drawing.Color.LightGray
-		Me.PictureBox4.Image = CType(resources.GetObject("PictureBox4.Image"),System.Drawing.Image)
+		Me.PictureBox4.Image = CType(resources.GetObject("PictureBox4.Image"), System.Drawing.Image)
 		Me.PictureBox4.Location = New System.Drawing.Point(9, 6)
 		Me.PictureBox4.Name = "PictureBox4"
 		Me.PictureBox4.Size = New System.Drawing.Size(160, 19)
 		Me.PictureBox4.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage
 		Me.PictureBox4.TabIndex = 149
-		Me.PictureBox4.TabStop = false
+		Me.PictureBox4.TabStop = False
 		'
 		'GBDomTypingStyle
 		'
@@ -2227,19 +2244,19 @@ Partial Class FrmSettings
 		Me.GBDomTypingStyle.Controls.Add(Me.CBMeMyMine)
 		Me.GBDomTypingStyle.Controls.Add(Me.GroupBox63)
 		Me.GBDomTypingStyle.Controls.Add(Me.Label64)
-		Me.GBDomTypingStyle.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.GBDomTypingStyle.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.GBDomTypingStyle.ForeColor = System.Drawing.Color.Black
 		Me.GBDomTypingStyle.Location = New System.Drawing.Point(7, 299)
 		Me.GBDomTypingStyle.Name = "GBDomTypingStyle"
 		Me.GBDomTypingStyle.Size = New System.Drawing.Size(427, 124)
 		Me.GBDomTypingStyle.TabIndex = 138
-		Me.GBDomTypingStyle.TabStop = false
+		Me.GBDomTypingStyle.TabStop = False
 		Me.GBDomTypingStyle.Text = "Typing Style"
 		'
 		'TBEmoteEnd
 		'
 		Me.TBEmoteEnd.BackColor = System.Drawing.Color.White
-		Me.TBEmoteEnd.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.TBEmoteEnd.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.TBEmoteEnd.ForeColor = System.Drawing.Color.Black
 		Me.TBEmoteEnd.Location = New System.Drawing.Point(115, 91)
 		Me.TBEmoteEnd.Name = "TBEmoteEnd"
@@ -2250,8 +2267,8 @@ Partial Class FrmSettings
 		'
 		'Label67
 		'
-		Me.Label67.AutoSize = true
-		Me.Label67.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label67.AutoSize = True
+		Me.Label67.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label67.ForeColor = System.Drawing.Color.Black
 		Me.Label67.Location = New System.Drawing.Point(237, 77)
 		Me.Label67.Name = "Label67"
@@ -2263,7 +2280,7 @@ Partial Class FrmSettings
 		'TBEmote
 		'
 		Me.TBEmote.BackColor = System.Drawing.Color.White
-		Me.TBEmote.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.TBEmote.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.TBEmote.ForeColor = System.Drawing.Color.Black
 		Me.TBEmote.Location = New System.Drawing.Point(9, 91)
 		Me.TBEmote.Name = "TBEmote"
@@ -2282,8 +2299,8 @@ Partial Class FrmSettings
 		'
 		'Label66
 		'
-		Me.Label66.AutoSize = true
-		Me.Label66.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label66.AutoSize = True
+		Me.Label66.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label66.ForeColor = System.Drawing.Color.Black
 		Me.Label66.Location = New System.Drawing.Point(322, 77)
 		Me.Label66.Name = "Label66"
@@ -2294,15 +2311,15 @@ Partial Class FrmSettings
 		'
 		'CBMeMyMine
 		'
-		Me.CBMeMyMine.AutoSize = true
-		Me.CBMeMyMine.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.CBMeMyMine.AutoSize = True
+		Me.CBMeMyMine.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.CBMeMyMine.ForeColor = System.Drawing.Color.Black
 		Me.CBMeMyMine.Location = New System.Drawing.Point(325, 97)
 		Me.CBMeMyMine.Name = "CBMeMyMine"
 		Me.CBMeMyMine.Size = New System.Drawing.Size(88, 17)
 		Me.CBMeMyMine.TabIndex = 40
 		Me.CBMeMyMine.Text = "Me/My/Mine"
-		Me.CBMeMyMine.UseVisualStyleBackColor = true
+		Me.CBMeMyMine.UseVisualStyleBackColor = True
 		'
 		'GroupBox63
 		'
@@ -2314,61 +2331,61 @@ Partial Class FrmSettings
 		Me.GroupBox63.Name = "GroupBox63"
 		Me.GroupBox63.Size = New System.Drawing.Size(407, 48)
 		Me.GroupBox63.TabIndex = 41
-		Me.GroupBox63.TabStop = false
+		Me.GroupBox63.TabStop = False
 		Me.GroupBox63.Text = "Remove"
 		'
 		'LCaseCheckBox
 		'
-		Me.LCaseCheckBox.AutoSize = true
-		Me.LCaseCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LCaseCheckBox.AutoSize = True
+		Me.LCaseCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LCaseCheckBox.ForeColor = System.Drawing.Color.Black
 		Me.LCaseCheckBox.Location = New System.Drawing.Point(16, 19)
 		Me.LCaseCheckBox.Name = "LCaseCheckBox"
 		Me.LCaseCheckBox.Size = New System.Drawing.Size(88, 17)
 		Me.LCaseCheckBox.TabIndex = 38
 		Me.LCaseCheckBox.Text = "Capitalization"
-		Me.LCaseCheckBox.UseVisualStyleBackColor = true
+		Me.LCaseCheckBox.UseVisualStyleBackColor = True
 		'
 		'apostropheCheckBox
 		'
-		Me.apostropheCheckBox.AutoSize = true
-		Me.apostropheCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.apostropheCheckBox.AutoSize = True
+		Me.apostropheCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.apostropheCheckBox.ForeColor = System.Drawing.Color.Black
 		Me.apostropheCheckBox.Location = New System.Drawing.Point(116, 19)
 		Me.apostropheCheckBox.Name = "apostropheCheckBox"
 		Me.apostropheCheckBox.Size = New System.Drawing.Size(85, 17)
 		Me.apostropheCheckBox.TabIndex = 39
 		Me.apostropheCheckBox.Text = "Apostrophes"
-		Me.apostropheCheckBox.UseVisualStyleBackColor = true
+		Me.apostropheCheckBox.UseVisualStyleBackColor = True
 		'
 		'periodCheckBox
 		'
-		Me.periodCheckBox.AutoSize = true
-		Me.periodCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.periodCheckBox.AutoSize = True
+		Me.periodCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.periodCheckBox.ForeColor = System.Drawing.Color.Black
 		Me.periodCheckBox.Location = New System.Drawing.Point(316, 19)
 		Me.periodCheckBox.Name = "periodCheckBox"
 		Me.periodCheckBox.Size = New System.Drawing.Size(61, 17)
 		Me.periodCheckBox.TabIndex = 37
 		Me.periodCheckBox.Text = "Periods"
-		Me.periodCheckBox.UseVisualStyleBackColor = true
+		Me.periodCheckBox.UseVisualStyleBackColor = True
 		'
 		'commaCheckBox
 		'
-		Me.commaCheckBox.AutoSize = true
-		Me.commaCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.commaCheckBox.AutoSize = True
+		Me.commaCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.commaCheckBox.ForeColor = System.Drawing.Color.Black
 		Me.commaCheckBox.Location = New System.Drawing.Point(216, 19)
 		Me.commaCheckBox.Name = "commaCheckBox"
 		Me.commaCheckBox.Size = New System.Drawing.Size(66, 17)
 		Me.commaCheckBox.TabIndex = 36
 		Me.commaCheckBox.Text = "Commas"
-		Me.commaCheckBox.UseVisualStyleBackColor = true
+		Me.commaCheckBox.UseVisualStyleBackColor = True
 		'
 		'Label64
 		'
-		Me.Label64.AutoSize = true
-		Me.Label64.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label64.AutoSize = True
+		Me.Label64.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label64.ForeColor = System.Drawing.Color.Black
 		Me.Label64.Location = New System.Drawing.Point(8, 77)
 		Me.Label64.Name = "Label64"
@@ -2399,7 +2416,7 @@ Partial Class FrmSettings
 		Me.GBDomRanges.Name = "GBDomRanges"
 		Me.GBDomRanges.Size = New System.Drawing.Size(259, 92)
 		Me.GBDomRanges.TabIndex = 148
-		Me.GBDomRanges.TabStop = false
+		Me.GBDomRanges.TabStop = False
 		Me.GBDomRanges.Text = "Ranges"
 		'
 		'NBDomMoodMax
@@ -2425,7 +2442,7 @@ Partial Class FrmSettings
 		'Label37
 		'
 		Me.Label37.BackColor = System.Drawing.Color.Transparent
-		Me.Label37.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label37.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label37.ForeColor = System.Drawing.Color.Black
 		Me.Label37.Location = New System.Drawing.Point(184, 11)
 		Me.Label37.Name = "Label37"
@@ -2437,7 +2454,7 @@ Partial Class FrmSettings
 		'Label39
 		'
 		Me.Label39.BackColor = System.Drawing.Color.Transparent
-		Me.Label39.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label39.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label39.ForeColor = System.Drawing.Color.Black
 		Me.Label39.Location = New System.Drawing.Point(12, 11)
 		Me.Label39.Name = "Label39"
@@ -2469,7 +2486,7 @@ Partial Class FrmSettings
 		'Label31
 		'
 		Me.Label31.BackColor = System.Drawing.Color.Transparent
-		Me.Label31.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label31.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label31.ForeColor = System.Drawing.Color.Black
 		Me.Label31.Location = New System.Drawing.Point(184, 68)
 		Me.Label31.Name = "Label31"
@@ -2481,7 +2498,7 @@ Partial Class FrmSettings
 		'Label36
 		'
 		Me.Label36.BackColor = System.Drawing.Color.Transparent
-		Me.Label36.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label36.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label36.ForeColor = System.Drawing.Color.Black
 		Me.Label36.Location = New System.Drawing.Point(12, 68)
 		Me.Label36.Name = "Label36"
@@ -2513,7 +2530,7 @@ Partial Class FrmSettings
 		'Label21
 		'
 		Me.Label21.BackColor = System.Drawing.Color.Transparent
-		Me.Label21.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label21.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label21.ForeColor = System.Drawing.Color.Black
 		Me.Label21.Location = New System.Drawing.Point(184, 49)
 		Me.Label21.Name = "Label21"
@@ -2525,7 +2542,7 @@ Partial Class FrmSettings
 		'Label22
 		'
 		Me.Label22.BackColor = System.Drawing.Color.Transparent
-		Me.Label22.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label22.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label22.ForeColor = System.Drawing.Color.Black
 		Me.Label22.Location = New System.Drawing.Point(12, 49)
 		Me.Label22.Name = "Label22"
@@ -2557,7 +2574,7 @@ Partial Class FrmSettings
 		'Label23
 		'
 		Me.Label23.BackColor = System.Drawing.Color.Transparent
-		Me.Label23.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label23.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label23.ForeColor = System.Drawing.Color.Black
 		Me.Label23.Location = New System.Drawing.Point(184, 30)
 		Me.Label23.Name = "Label23"
@@ -2569,7 +2586,7 @@ Partial Class FrmSettings
 		'Label30
 		'
 		Me.Label30.BackColor = System.Drawing.Color.Transparent
-		Me.Label30.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label30.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label30.ForeColor = System.Drawing.Color.Black
 		Me.Label30.Location = New System.Drawing.Point(12, 30)
 		Me.Label30.Name = "Label30"
@@ -2611,13 +2628,13 @@ Partial Class FrmSettings
 		Me.GBDomStats.Name = "GBDomStats"
 		Me.GBDomStats.Size = New System.Drawing.Size(171, 263)
 		Me.GBDomStats.TabIndex = 62
-		Me.GBDomStats.TabStop = false
+		Me.GBDomStats.TabStop = False
 		Me.GBDomStats.Text = "Stats/Appearance"
 		'
 		'Label128
 		'
-		Me.Label128.AutoSize = true
-		Me.Label128.Font = New System.Drawing.Font("Microsoft Sans Serif", 7!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label128.AutoSize = True
+		Me.Label128.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label128.Location = New System.Drawing.Point(125, 68)
 		Me.Label128.Name = "Label128"
 		Me.Label128.Size = New System.Drawing.Size(38, 13)
@@ -2637,7 +2654,7 @@ Partial Class FrmSettings
 		'NBEmpathy
 		'
 		Me.NBEmpathy.BackColor = System.Drawing.Color.White
-		Me.NBEmpathy.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.NBEmpathy.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.NBEmpathy.ForeColor = System.Drawing.Color.Black
 		Me.NBEmpathy.Location = New System.Drawing.Point(73, 38)
 		Me.NBEmpathy.Maximum = New Decimal(New Integer() {5, 0, 0, 0})
@@ -2650,7 +2667,7 @@ Partial Class FrmSettings
 		'Label83
 		'
 		Me.Label83.BackColor = System.Drawing.Color.Transparent
-		Me.Label83.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label83.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label83.ForeColor = System.Drawing.Color.Black
 		Me.Label83.Location = New System.Drawing.Point(6, 37)
 		Me.Label83.Name = "Label83"
@@ -2662,7 +2679,7 @@ Partial Class FrmSettings
 		'NBDomBirthdayDay
 		'
 		Me.NBDomBirthdayDay.BackColor = System.Drawing.Color.White
-		Me.NBDomBirthdayDay.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.NBDomBirthdayDay.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.NBDomBirthdayDay.ForeColor = System.Drawing.Color.Black
 		Me.NBDomBirthdayDay.Location = New System.Drawing.Point(125, 83)
 		Me.NBDomBirthdayDay.Maximum = New Decimal(New Integer() {31, 0, 0, 0})
@@ -2675,7 +2692,7 @@ Partial Class FrmSettings
 		'TBDomEyeColor
 		'
 		Me.TBDomEyeColor.BackColor = System.Drawing.Color.White
-		Me.TBDomEyeColor.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.TBDomEyeColor.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.TBDomEyeColor.ForeColor = System.Drawing.Color.Black
 		Me.TBDomEyeColor.Location = New System.Drawing.Point(73, 155)
 		Me.TBDomEyeColor.Name = "TBDomEyeColor"
@@ -2686,7 +2703,7 @@ Partial Class FrmSettings
 		'TBDomHairColor
 		'
 		Me.TBDomHairColor.BackColor = System.Drawing.Color.White
-		Me.TBDomHairColor.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.TBDomHairColor.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.TBDomHairColor.ForeColor = System.Drawing.Color.Black
 		Me.TBDomHairColor.Location = New System.Drawing.Point(73, 105)
 		Me.TBDomHairColor.Name = "TBDomHairColor"
@@ -2698,7 +2715,7 @@ Partial Class FrmSettings
 		'
 		Me.domageNumBox.BackColor = System.Drawing.Color.White
 		Me.domageNumBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.domageNumBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.domageNumBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.domageNumBox.ForeColor = System.Drawing.Color.Black
 		Me.domageNumBox.Location = New System.Drawing.Point(73, 61)
 		Me.domageNumBox.Maximum = New Decimal(New Integer() {99, 0, 0, 0})
@@ -2711,7 +2728,7 @@ Partial Class FrmSettings
 		'Label47
 		'
 		Me.Label47.BackColor = System.Drawing.Color.Transparent
-		Me.Label47.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label47.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label47.ForeColor = System.Drawing.Color.Black
 		Me.Label47.Location = New System.Drawing.Point(6, 60)
 		Me.Label47.Name = "Label47"
@@ -2722,8 +2739,8 @@ Partial Class FrmSettings
 		'
 		'Label76
 		'
-		Me.Label76.AutoSize = true
-		Me.Label76.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label76.AutoSize = True
+		Me.Label76.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label76.ForeColor = System.Drawing.Color.Black
 		Me.Label76.Location = New System.Drawing.Point(113, 87)
 		Me.Label76.Name = "Label76"
@@ -2735,7 +2752,7 @@ Partial Class FrmSettings
 		'NBDomBirthdayMonth
 		'
 		Me.NBDomBirthdayMonth.BackColor = System.Drawing.Color.White
-		Me.NBDomBirthdayMonth.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.NBDomBirthdayMonth.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.NBDomBirthdayMonth.ForeColor = System.Drawing.Color.Black
 		Me.NBDomBirthdayMonth.Location = New System.Drawing.Point(73, 83)
 		Me.NBDomBirthdayMonth.Maximum = New Decimal(New Integer() {12, 0, 0, 0})
@@ -2748,7 +2765,7 @@ Partial Class FrmSettings
 		'Label84
 		'
 		Me.Label84.BackColor = System.Drawing.Color.Transparent
-		Me.Label84.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label84.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label84.ForeColor = System.Drawing.Color.Black
 		Me.Label84.Location = New System.Drawing.Point(6, 84)
 		Me.Label84.Name = "Label84"
@@ -2759,35 +2776,35 @@ Partial Class FrmSettings
 		'
 		'CBDomTattoos
 		'
-		Me.CBDomTattoos.AutoSize = true
-		Me.CBDomTattoos.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.CBDomTattoos.AutoSize = True
+		Me.CBDomTattoos.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.CBDomTattoos.ForeColor = System.Drawing.Color.Black
 		Me.CBDomTattoos.Location = New System.Drawing.Point(13, 237)
 		Me.CBDomTattoos.Name = "CBDomTattoos"
 		Me.CBDomTattoos.Size = New System.Drawing.Size(62, 17)
 		Me.CBDomTattoos.TabIndex = 148
 		Me.CBDomTattoos.Text = "Tattoos"
-		Me.CBDomTattoos.UseVisualStyleBackColor = true
+		Me.CBDomTattoos.UseVisualStyleBackColor = True
 		'
 		'CBDomFreckles
 		'
-		Me.CBDomFreckles.AutoSize = true
-		Me.CBDomFreckles.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.CBDomFreckles.AutoSize = True
+		Me.CBDomFreckles.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.CBDomFreckles.ForeColor = System.Drawing.Color.Black
 		Me.CBDomFreckles.Location = New System.Drawing.Point(88, 237)
 		Me.CBDomFreckles.Name = "CBDomFreckles"
 		Me.CBDomFreckles.Size = New System.Drawing.Size(66, 17)
 		Me.CBDomFreckles.TabIndex = 147
 		Me.CBDomFreckles.Text = "Freckles"
-		Me.CBDomFreckles.UseVisualStyleBackColor = true
+		Me.CBDomFreckles.UseVisualStyleBackColor = True
 		'
 		'domhairlengthComboBox
 		'
 		Me.domhairlengthComboBox.BackColor = System.Drawing.Color.White
 		Me.domhairlengthComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
-		Me.domhairlengthComboBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.domhairlengthComboBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.domhairlengthComboBox.ForeColor = System.Drawing.Color.Black
-		Me.domhairlengthComboBox.FormattingEnabled = true
+		Me.domhairlengthComboBox.FormattingEnabled = True
 		Me.domhairlengthComboBox.Items.AddRange(New Object() {"Shaved", "Buzz cut", "Short", "Medium", "Long", "Very Long"})
 		Me.domhairlengthComboBox.Location = New System.Drawing.Point(73, 132)
 		Me.domhairlengthComboBox.Name = "domhairlengthComboBox"
@@ -2797,7 +2814,7 @@ Partial Class FrmSettings
 		'Label10
 		'
 		Me.Label10.BackColor = System.Drawing.Color.Transparent
-		Me.Label10.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label10.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label10.ForeColor = System.Drawing.Color.Black
 		Me.Label10.Location = New System.Drawing.Point(6, 133)
 		Me.Label10.Name = "Label10"
@@ -2810,9 +2827,9 @@ Partial Class FrmSettings
 		'
 		Me.dompubichairComboBox.BackColor = System.Drawing.Color.White
 		Me.dompubichairComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
-		Me.dompubichairComboBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.dompubichairComboBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.dompubichairComboBox.ForeColor = System.Drawing.Color.Black
-		Me.dompubichairComboBox.FormattingEnabled = true
+		Me.dompubichairComboBox.FormattingEnabled = True
 		Me.dompubichairComboBox.Items.AddRange(New Object() {"Shaved", "Sparse", "Trimmed", "Natural", "Hairy"})
 		Me.dompubichairComboBox.Location = New System.Drawing.Point(73, 208)
 		Me.dompubichairComboBox.Name = "dompubichairComboBox"
@@ -2822,7 +2839,7 @@ Partial Class FrmSettings
 		'Label9
 		'
 		Me.Label9.BackColor = System.Drawing.Color.Transparent
-		Me.Label9.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label9.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label9.ForeColor = System.Drawing.Color.Black
 		Me.Label9.Location = New System.Drawing.Point(6, 209)
 		Me.Label9.Name = "Label9"
@@ -2835,9 +2852,9 @@ Partial Class FrmSettings
 		'
 		Me.boobComboBox.BackColor = System.Drawing.Color.White
 		Me.boobComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
-		Me.boobComboBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.boobComboBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.boobComboBox.ForeColor = System.Drawing.Color.Black
-		Me.boobComboBox.FormattingEnabled = true
+		Me.boobComboBox.FormattingEnabled = True
 		Me.boobComboBox.Items.AddRange(New Object() {"A", "B", "C", "D", "DD", "DDD+"})
 		Me.boobComboBox.Location = New System.Drawing.Point(73, 182)
 		Me.boobComboBox.Name = "boobComboBox"
@@ -2856,7 +2873,7 @@ Partial Class FrmSettings
 		'domlevelNumBox
 		'
 		Me.domlevelNumBox.BackColor = System.Drawing.Color.White
-		Me.domlevelNumBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.domlevelNumBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.domlevelNumBox.ForeColor = System.Drawing.Color.Black
 		Me.domlevelNumBox.Location = New System.Drawing.Point(73, 15)
 		Me.domlevelNumBox.Maximum = New Decimal(New Integer() {5, 0, 0, 0})
@@ -2869,7 +2886,7 @@ Partial Class FrmSettings
 		'Label43
 		'
 		Me.Label43.BackColor = System.Drawing.Color.Transparent
-		Me.Label43.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label43.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label43.ForeColor = System.Drawing.Color.Black
 		Me.Label43.Location = New System.Drawing.Point(6, 183)
 		Me.Label43.Name = "Label43"
@@ -2881,7 +2898,7 @@ Partial Class FrmSettings
 		'Label44
 		'
 		Me.Label44.BackColor = System.Drawing.Color.Transparent
-		Me.Label44.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label44.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label44.ForeColor = System.Drawing.Color.Black
 		Me.Label44.Location = New System.Drawing.Point(6, 158)
 		Me.Label44.Name = "Label44"
@@ -2893,7 +2910,7 @@ Partial Class FrmSettings
 		'Label45
 		'
 		Me.Label45.BackColor = System.Drawing.Color.Transparent
-		Me.Label45.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label45.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label45.ForeColor = System.Drawing.Color.Black
 		Me.Label45.Location = New System.Drawing.Point(6, 108)
 		Me.Label45.Name = "Label45"
@@ -2905,7 +2922,7 @@ Partial Class FrmSettings
 		'Label46
 		'
 		Me.Label46.BackColor = System.Drawing.Color.Transparent
-		Me.Label46.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label46.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label46.ForeColor = System.Drawing.Color.Black
 		Me.Label46.Location = New System.Drawing.Point(6, 15)
 		Me.Label46.Name = "Label46"
@@ -2922,85 +2939,85 @@ Partial Class FrmSettings
 		Me.GBDomPersonality.Controls.Add(Me.vulgarCheckBox)
 		Me.GBDomPersonality.Controls.Add(Me.crazyCheckBox)
 		Me.GBDomPersonality.Controls.Add(Me.condescendingCheckBox)
-		Me.GBDomPersonality.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.GBDomPersonality.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.GBDomPersonality.ForeColor = System.Drawing.Color.Black
 		Me.GBDomPersonality.Location = New System.Drawing.Point(184, 30)
 		Me.GBDomPersonality.Name = "GBDomPersonality"
 		Me.GBDomPersonality.Size = New System.Drawing.Size(250, 67)
 		Me.GBDomPersonality.TabIndex = 131
-		Me.GBDomPersonality.TabStop = false
+		Me.GBDomPersonality.TabStop = False
 		Me.GBDomPersonality.Text = "Personality"
 		'
 		'degradingCheckBox
 		'
-		Me.degradingCheckBox.AutoSize = true
-		Me.degradingCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.degradingCheckBox.AutoSize = True
+		Me.degradingCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.degradingCheckBox.ForeColor = System.Drawing.Color.Black
 		Me.degradingCheckBox.Location = New System.Drawing.Point(73, 43)
 		Me.degradingCheckBox.Name = "degradingCheckBox"
 		Me.degradingCheckBox.Size = New System.Drawing.Size(75, 17)
 		Me.degradingCheckBox.TabIndex = 40
 		Me.degradingCheckBox.Text = "Degrading"
-		Me.degradingCheckBox.UseVisualStyleBackColor = true
+		Me.degradingCheckBox.UseVisualStyleBackColor = True
 		'
 		'sadisticCheckBox
 		'
-		Me.sadisticCheckBox.AutoSize = true
-		Me.sadisticCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.sadisticCheckBox.AutoSize = True
+		Me.sadisticCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.sadisticCheckBox.ForeColor = System.Drawing.Color.Black
 		Me.sadisticCheckBox.Location = New System.Drawing.Point(11, 43)
 		Me.sadisticCheckBox.Name = "sadisticCheckBox"
 		Me.sadisticCheckBox.Size = New System.Drawing.Size(63, 17)
 		Me.sadisticCheckBox.TabIndex = 39
 		Me.sadisticCheckBox.Text = "Sadistic"
-		Me.sadisticCheckBox.UseVisualStyleBackColor = true
+		Me.sadisticCheckBox.UseVisualStyleBackColor = True
 		'
 		'supremacistCheckBox
 		'
-		Me.supremacistCheckBox.AutoSize = true
-		Me.supremacistCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.supremacistCheckBox.AutoSize = True
+		Me.supremacistCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.supremacistCheckBox.ForeColor = System.Drawing.Color.Black
 		Me.supremacistCheckBox.Location = New System.Drawing.Point(148, 20)
 		Me.supremacistCheckBox.Name = "supremacistCheckBox"
 		Me.supremacistCheckBox.Size = New System.Drawing.Size(84, 17)
 		Me.supremacistCheckBox.TabIndex = 38
 		Me.supremacistCheckBox.Text = "Supremacist"
-		Me.supremacistCheckBox.UseVisualStyleBackColor = true
+		Me.supremacistCheckBox.UseVisualStyleBackColor = True
 		'
 		'vulgarCheckBox
 		'
-		Me.vulgarCheckBox.AutoSize = true
-		Me.vulgarCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.vulgarCheckBox.AutoSize = True
+		Me.vulgarCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.vulgarCheckBox.ForeColor = System.Drawing.Color.Black
 		Me.vulgarCheckBox.Location = New System.Drawing.Point(73, 20)
 		Me.vulgarCheckBox.Name = "vulgarCheckBox"
 		Me.vulgarCheckBox.Size = New System.Drawing.Size(56, 17)
 		Me.vulgarCheckBox.TabIndex = 37
 		Me.vulgarCheckBox.Text = "Vulgar"
-		Me.vulgarCheckBox.UseVisualStyleBackColor = true
+		Me.vulgarCheckBox.UseVisualStyleBackColor = True
 		'
 		'crazyCheckBox
 		'
-		Me.crazyCheckBox.AutoSize = true
-		Me.crazyCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.crazyCheckBox.AutoSize = True
+		Me.crazyCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.crazyCheckBox.ForeColor = System.Drawing.Color.Black
 		Me.crazyCheckBox.Location = New System.Drawing.Point(11, 20)
 		Me.crazyCheckBox.Name = "crazyCheckBox"
 		Me.crazyCheckBox.Size = New System.Drawing.Size(52, 17)
 		Me.crazyCheckBox.TabIndex = 36
 		Me.crazyCheckBox.Text = "Crazy"
-		Me.crazyCheckBox.UseVisualStyleBackColor = true
+		Me.crazyCheckBox.UseVisualStyleBackColor = True
 		'
 		'condescendingCheckBox
 		'
-		Me.condescendingCheckBox.AutoSize = true
-		Me.condescendingCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.condescendingCheckBox.AutoSize = True
+		Me.condescendingCheckBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.condescendingCheckBox.ForeColor = System.Drawing.Color.Black
 		Me.condescendingCheckBox.Location = New System.Drawing.Point(148, 43)
 		Me.condescendingCheckBox.Name = "condescendingCheckBox"
 		Me.condescendingCheckBox.Size = New System.Drawing.Size(15, 14)
 		Me.condescendingCheckBox.TabIndex = 41
-		Me.condescendingCheckBox.UseVisualStyleBackColor = true
+		Me.condescendingCheckBox.UseVisualStyleBackColor = True
 		'
 		'GBDomOrgasms
 		'
@@ -3016,42 +3033,42 @@ Partial Class FrmSettings
 		Me.GBDomOrgasms.Controls.Add(Me.CBDomDenialEnds)
 		Me.GBDomOrgasms.Controls.Add(Me.alloworgasmComboBox)
 		Me.GBDomOrgasms.Controls.Add(Me.ruinorgasmComboBox)
-		Me.GBDomOrgasms.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.GBDomOrgasms.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.GBDomOrgasms.ForeColor = System.Drawing.Color.Black
 		Me.GBDomOrgasms.Location = New System.Drawing.Point(440, 30)
 		Me.GBDomOrgasms.Name = "GBDomOrgasms"
 		Me.GBDomOrgasms.Size = New System.Drawing.Size(259, 165)
 		Me.GBDomOrgasms.TabIndex = 132
-		Me.GBDomOrgasms.TabStop = false
+		Me.GBDomOrgasms.TabStop = False
 		Me.GBDomOrgasms.Text = "Orgasms"
 		'
 		'orgasmlockrandombutton
 		'
 		Me.orgasmlockrandombutton.BackColor = System.Drawing.Color.LightGray
-		Me.orgasmlockrandombutton.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.orgasmlockrandombutton.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.orgasmlockrandombutton.ForeColor = System.Drawing.Color.Black
 		Me.orgasmlockrandombutton.Location = New System.Drawing.Point(134, 137)
 		Me.orgasmlockrandombutton.Name = "orgasmlockrandombutton"
 		Me.orgasmlockrandombutton.Size = New System.Drawing.Size(110, 21)
 		Me.orgasmlockrandombutton.TabIndex = 145
 		Me.orgasmlockrandombutton.Text = "Lock Random"
-		Me.orgasmlockrandombutton.UseVisualStyleBackColor = false
+		Me.orgasmlockrandombutton.UseVisualStyleBackColor = False
 		'
 		'CBDomOrgasmEnds
 		'
-		Me.CBDomOrgasmEnds.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.CBDomOrgasmEnds.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.CBDomOrgasmEnds.ForeColor = System.Drawing.Color.Black
 		Me.CBDomOrgasmEnds.Location = New System.Drawing.Point(145, 71)
 		Me.CBDomOrgasmEnds.Name = "CBDomOrgasmEnds"
 		Me.CBDomOrgasmEnds.Size = New System.Drawing.Size(104, 37)
 		Me.CBDomOrgasmEnds.TabIndex = 144
 		Me.CBDomOrgasmEnds.Text = "Orgasm Always Ends Tease"
-		Me.CBDomOrgasmEnds.UseVisualStyleBackColor = true
+		Me.CBDomOrgasmEnds.UseVisualStyleBackColor = True
 		'
 		'Label16
 		'
 		Me.Label16.BackColor = System.Drawing.Color.Transparent
-		Me.Label16.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label16.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label16.ForeColor = System.Drawing.Color.Black
 		Me.Label16.Location = New System.Drawing.Point(12, 47)
 		Me.Label16.Name = "Label16"
@@ -3063,7 +3080,7 @@ Partial Class FrmSettings
 		'Label12
 		'
 		Me.Label12.BackColor = System.Drawing.Color.Transparent
-		Me.Label12.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label12.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label12.ForeColor = System.Drawing.Color.Black
 		Me.Label12.Location = New System.Drawing.Point(12, 19)
 		Me.Label12.Name = "Label12"
@@ -3075,23 +3092,23 @@ Partial Class FrmSettings
 		'orgasmsperlockButton
 		'
 		Me.orgasmsperlockButton.BackColor = System.Drawing.Color.LightGray
-		Me.orgasmsperlockButton.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.orgasmsperlockButton.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.orgasmsperlockButton.ForeColor = System.Drawing.Color.Black
 		Me.orgasmsperlockButton.Location = New System.Drawing.Point(15, 137)
 		Me.orgasmsperlockButton.Name = "orgasmsperlockButton"
 		Me.orgasmsperlockButton.Size = New System.Drawing.Size(110, 21)
 		Me.orgasmsperlockButton.TabIndex = 97
 		Me.orgasmsperlockButton.Text = "Lock Selected"
-		Me.orgasmsperlockButton.UseVisualStyleBackColor = false
+		Me.orgasmsperlockButton.UseVisualStyleBackColor = False
 		'
 		'orgasmsperComboBox
 		'
 		Me.orgasmsperComboBox.BackColor = System.Drawing.Color.White
 		Me.orgasmsperComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
 		Me.orgasmsperComboBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat
-		Me.orgasmsperComboBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.orgasmsperComboBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.orgasmsperComboBox.ForeColor = System.Drawing.Color.Black
-		Me.orgasmsperComboBox.FormattingEnabled = true
+		Me.orgasmsperComboBox.FormattingEnabled = True
 		Me.orgasmsperComboBox.Items.AddRange(New Object() {"Week", "2 Weeks", "Month", "2 Months", "3 Months", "6 Months", "9 Months", "Year", "2 Years", "3 Years", "5 Years", "10 Years", "25 Years", "Lifetime"})
 		Me.orgasmsperComboBox.Location = New System.Drawing.Point(143, 109)
 		Me.orgasmsperComboBox.Name = "orgasmsperComboBox"
@@ -3100,8 +3117,8 @@ Partial Class FrmSettings
 		'
 		'orgasmsperLabel
 		'
-		Me.orgasmsperLabel.AutoSize = true
-		Me.orgasmsperLabel.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.orgasmsperLabel.AutoSize = True
+		Me.orgasmsperLabel.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.orgasmsperLabel.ForeColor = System.Drawing.Color.Black
 		Me.orgasmsperLabel.Location = New System.Drawing.Point(115, 113)
 		Me.orgasmsperLabel.Name = "orgasmsperLabel"
@@ -3112,20 +3129,20 @@ Partial Class FrmSettings
 		'
 		'limitcheckbox
 		'
-		Me.limitcheckbox.AutoSize = true
-		Me.limitcheckbox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.limitcheckbox.AutoSize = True
+		Me.limitcheckbox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.limitcheckbox.ForeColor = System.Drawing.Color.Black
 		Me.limitcheckbox.Location = New System.Drawing.Point(15, 111)
 		Me.limitcheckbox.Name = "limitcheckbox"
 		Me.limitcheckbox.Size = New System.Drawing.Size(47, 17)
 		Me.limitcheckbox.TabIndex = 39
 		Me.limitcheckbox.Text = "Limit"
-		Me.limitcheckbox.UseVisualStyleBackColor = true
+		Me.limitcheckbox.UseVisualStyleBackColor = True
 		'
 		'orgasmsPerNumBox
 		'
 		Me.orgasmsPerNumBox.BackColor = System.Drawing.Color.White
-		Me.orgasmsPerNumBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.orgasmsPerNumBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.orgasmsPerNumBox.ForeColor = System.Drawing.Color.Black
 		Me.orgasmsPerNumBox.Location = New System.Drawing.Point(68, 110)
 		Me.orgasmsPerNumBox.Maximum = New Decimal(New Integer() {99, 0, 0, 0})
@@ -3137,23 +3154,23 @@ Partial Class FrmSettings
 		'
 		'CBDomDenialEnds
 		'
-		Me.CBDomDenialEnds.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.CBDomDenialEnds.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.CBDomDenialEnds.ForeColor = System.Drawing.Color.Black
 		Me.CBDomDenialEnds.Location = New System.Drawing.Point(15, 71)
 		Me.CBDomDenialEnds.Name = "CBDomDenialEnds"
 		Me.CBDomDenialEnds.Size = New System.Drawing.Size(94, 37)
 		Me.CBDomDenialEnds.TabIndex = 38
 		Me.CBDomDenialEnds.Text = "Denial Always Ends Tease"
-		Me.CBDomDenialEnds.UseVisualStyleBackColor = true
+		Me.CBDomDenialEnds.UseVisualStyleBackColor = True
 		'
 		'alloworgasmComboBox
 		'
 		Me.alloworgasmComboBox.BackColor = System.Drawing.Color.White
 		Me.alloworgasmComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
 		Me.alloworgasmComboBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat
-		Me.alloworgasmComboBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.alloworgasmComboBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.alloworgasmComboBox.ForeColor = System.Drawing.Color.Black
-		Me.alloworgasmComboBox.FormattingEnabled = true
+		Me.alloworgasmComboBox.FormattingEnabled = True
 		Me.alloworgasmComboBox.Items.AddRange(New Object() {"Never Allows", "Rarely Allows", "Sometimes Allows", "Often Allows", "Always Allows"})
 		Me.alloworgasmComboBox.Location = New System.Drawing.Point(98, 18)
 		Me.alloworgasmComboBox.Name = "alloworgasmComboBox"
@@ -3165,9 +3182,9 @@ Partial Class FrmSettings
 		Me.ruinorgasmComboBox.BackColor = System.Drawing.Color.White
 		Me.ruinorgasmComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
 		Me.ruinorgasmComboBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat
-		Me.ruinorgasmComboBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.ruinorgasmComboBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.ruinorgasmComboBox.ForeColor = System.Drawing.Color.Black
-		Me.ruinorgasmComboBox.FormattingEnabled = true
+		Me.ruinorgasmComboBox.FormattingEnabled = True
 		Me.ruinorgasmComboBox.Items.AddRange(New Object() {"Never Ruins", "Rarely Ruins", "Sometimes Ruins", "Often Ruins", "Always Ruins"})
 		Me.ruinorgasmComboBox.Location = New System.Drawing.Point(98, 46)
 		Me.ruinorgasmComboBox.Name = "ruinorgasmComboBox"
@@ -3188,18 +3205,18 @@ Partial Class FrmSettings
 		Me.GBDomPetNames.Controls.Add(Me.Label11)
 		Me.GBDomPetNames.Controls.Add(Me.petnameBox5)
 		Me.GBDomPetNames.Controls.Add(Me.petnameBox3)
-		Me.GBDomPetNames.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.GBDomPetNames.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.GBDomPetNames.ForeColor = System.Drawing.Color.Black
 		Me.GBDomPetNames.Location = New System.Drawing.Point(184, 103)
 		Me.GBDomPetNames.Name = "GBDomPetNames"
 		Me.GBDomPetNames.Size = New System.Drawing.Size(250, 190)
 		Me.GBDomPetNames.TabIndex = 134
-		Me.GBDomPetNames.TabStop = false
+		Me.GBDomPetNames.TabStop = False
 		Me.GBDomPetNames.Text = "Pet Names"
 		'
 		'Label74
 		'
-		Me.Label74.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label74.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label74.ForeColor = System.Drawing.Color.Black
 		Me.Label74.Location = New System.Drawing.Point(8, 14)
 		Me.Label74.Name = "Label74"
@@ -3211,7 +3228,7 @@ Partial Class FrmSettings
 		'petnameBox7
 		'
 		Me.petnameBox7.BackColor = System.Drawing.Color.White
-		Me.petnameBox7.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.petnameBox7.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.petnameBox7.ForeColor = System.Drawing.Color.Black
 		Me.petnameBox7.Location = New System.Drawing.Point(8, 154)
 		Me.petnameBox7.Name = "petnameBox7"
@@ -3223,7 +3240,7 @@ Partial Class FrmSettings
 		'petnameBox8
 		'
 		Me.petnameBox8.BackColor = System.Drawing.Color.White
-		Me.petnameBox8.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.petnameBox8.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.petnameBox8.ForeColor = System.Drawing.Color.Black
 		Me.petnameBox8.Location = New System.Drawing.Point(128, 154)
 		Me.petnameBox8.Name = "petnameBox8"
@@ -3235,7 +3252,7 @@ Partial Class FrmSettings
 		'petnameBox1
 		'
 		Me.petnameBox1.BackColor = System.Drawing.Color.White
-		Me.petnameBox1.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.petnameBox1.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.petnameBox1.ForeColor = System.Drawing.Color.Black
 		Me.petnameBox1.Location = New System.Drawing.Point(8, 32)
 		Me.petnameBox1.Name = "petnameBox1"
@@ -3246,7 +3263,7 @@ Partial Class FrmSettings
 		'
 		'Label15
 		'
-		Me.Label15.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label15.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label15.ForeColor = System.Drawing.Color.Black
 		Me.Label15.Location = New System.Drawing.Point(8, 136)
 		Me.Label15.Name = "Label15"
@@ -3258,7 +3275,7 @@ Partial Class FrmSettings
 		'petnameBox4
 		'
 		Me.petnameBox4.BackColor = System.Drawing.Color.White
-		Me.petnameBox4.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.petnameBox4.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.petnameBox4.ForeColor = System.Drawing.Color.Black
 		Me.petnameBox4.Location = New System.Drawing.Point(128, 81)
 		Me.petnameBox4.Name = "petnameBox4"
@@ -3270,7 +3287,7 @@ Partial Class FrmSettings
 		'petnameBox6
 		'
 		Me.petnameBox6.BackColor = System.Drawing.Color.White
-		Me.petnameBox6.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.petnameBox6.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.petnameBox6.ForeColor = System.Drawing.Color.Black
 		Me.petnameBox6.Location = New System.Drawing.Point(128, 107)
 		Me.petnameBox6.Name = "petnameBox6"
@@ -3282,7 +3299,7 @@ Partial Class FrmSettings
 		'petnameBox2
 		'
 		Me.petnameBox2.BackColor = System.Drawing.Color.White
-		Me.petnameBox2.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.petnameBox2.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.petnameBox2.ForeColor = System.Drawing.Color.Black
 		Me.petnameBox2.Location = New System.Drawing.Point(128, 32)
 		Me.petnameBox2.Name = "petnameBox2"
@@ -3293,7 +3310,7 @@ Partial Class FrmSettings
 		'
 		'Label11
 		'
-		Me.Label11.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label11.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label11.ForeColor = System.Drawing.Color.Black
 		Me.Label11.Location = New System.Drawing.Point(5, 63)
 		Me.Label11.Name = "Label11"
@@ -3305,7 +3322,7 @@ Partial Class FrmSettings
 		'petnameBox5
 		'
 		Me.petnameBox5.BackColor = System.Drawing.Color.White
-		Me.petnameBox5.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.petnameBox5.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.petnameBox5.ForeColor = System.Drawing.Color.Black
 		Me.petnameBox5.Location = New System.Drawing.Point(8, 107)
 		Me.petnameBox5.Name = "petnameBox5"
@@ -3317,7 +3334,7 @@ Partial Class FrmSettings
 		'petnameBox3
 		'
 		Me.petnameBox3.BackColor = System.Drawing.Color.White
-		Me.petnameBox3.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.petnameBox3.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.petnameBox3.ForeColor = System.Drawing.Color.Black
 		Me.petnameBox3.Location = New System.Drawing.Point(8, 81)
 		Me.petnameBox3.Name = "petnameBox3"
@@ -3329,7 +3346,7 @@ Partial Class FrmSettings
 		'Label54
 		'
 		Me.Label54.BackColor = System.Drawing.Color.Transparent
-		Me.Label54.Font = New System.Drawing.Font("Microsoft Sans Serif", 12!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label54.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label54.ForeColor = System.Drawing.Color.Black
 		Me.Label54.Location = New System.Drawing.Point(7, 6)
 		Me.Label54.Name = "Label54"
@@ -3378,7 +3395,7 @@ Partial Class FrmSettings
 		Me.GroupBox22.Name = "GroupBox22"
 		Me.GroupBox22.Size = New System.Drawing.Size(259, 39)
 		Me.GroupBox22.TabIndex = 158
-		Me.GroupBox22.TabStop = false
+		Me.GroupBox22.TabStop = False
 		Me.GroupBox22.Text = "Writing Tasks"
 		'
 		'NBWritingTaskMax
@@ -3406,7 +3423,7 @@ Partial Class FrmSettings
 		'Label75
 		'
 		Me.Label75.BackColor = System.Drawing.Color.Transparent
-		Me.Label75.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label75.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label75.ForeColor = System.Drawing.Color.Black
 		Me.Label75.Location = New System.Drawing.Point(184, 13)
 		Me.Label75.Name = "Label75"
@@ -3418,7 +3435,7 @@ Partial Class FrmSettings
 		'Label77
 		'
 		Me.Label77.BackColor = System.Drawing.Color.Transparent
-		Me.Label77.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label77.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label77.ForeColor = System.Drawing.Color.Black
 		Me.Label77.Location = New System.Drawing.Point(12, 15)
 		Me.Label77.Name = "Label77"
@@ -3440,13 +3457,13 @@ Partial Class FrmSettings
 		Me.GroupBox45.Name = "GroupBox45"
 		Me.GroupBox45.Size = New System.Drawing.Size(259, 50)
 		Me.GroupBox45.TabIndex = 155
-		Me.GroupBox45.TabStop = false
+		Me.GroupBox45.TabStop = False
 		Me.GroupBox45.Text = "CBT"
 		'
 		'LBLCBTSlider
 		'
 		Me.LBLCBTSlider.BackColor = System.Drawing.Color.Transparent
-		Me.LBLCBTSlider.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLCBTSlider.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLCBTSlider.ForeColor = System.Drawing.Color.Black
 		Me.LBLCBTSlider.Location = New System.Drawing.Point(134, 30)
 		Me.LBLCBTSlider.Name = "LBLCBTSlider"
@@ -3462,7 +3479,7 @@ Partial Class FrmSettings
 		Me.CBCBTBalls.Size = New System.Drawing.Size(66, 31)
 		Me.CBCBTBalls.TabIndex = 1
 		Me.CBCBTBalls.Text = "Ball Torture"
-		Me.CBCBTBalls.UseVisualStyleBackColor = true
+		Me.CBCBTBalls.UseVisualStyleBackColor = True
 		'
 		'CBCBTCock
 		'
@@ -3471,11 +3488,11 @@ Partial Class FrmSettings
 		Me.CBCBTCock.Size = New System.Drawing.Size(68, 31)
 		Me.CBCBTCock.TabIndex = 0
 		Me.CBCBTCock.Text = "Cock Torture"
-		Me.CBCBTCock.UseVisualStyleBackColor = true
+		Me.CBCBTCock.UseVisualStyleBackColor = True
 		'
 		'CBTSlider
 		'
-		Me.CBTSlider.AutoSize = false
+		Me.CBTSlider.AutoSize = False
 		Me.CBTSlider.LargeChange = 1
 		Me.CBTSlider.Location = New System.Drawing.Point(134, 13)
 		Me.CBTSlider.Maximum = 5
@@ -3497,7 +3514,7 @@ Partial Class FrmSettings
 		Me.GroupBox35.Name = "GroupBox35"
 		Me.GroupBox35.Size = New System.Drawing.Size(259, 263)
 		Me.GroupBox35.TabIndex = 154
-		Me.GroupBox35.TabStop = false
+		Me.GroupBox35.TabStop = False
 		Me.GroupBox35.Text = "Key Phrases"
 		'
 		'GroupBox39
@@ -3509,31 +3526,31 @@ Partial Class FrmSettings
 		Me.GroupBox39.Name = "GroupBox39"
 		Me.GroupBox39.Size = New System.Drawing.Size(247, 89)
 		Me.GroupBox39.TabIndex = 3
-		Me.GroupBox39.TabStop = false
+		Me.GroupBox39.TabStop = False
 		Me.GroupBox39.Tag = ""
 		Me.GroupBox39.Text = "Honorific"
 		'
 		'CBHonorificInclude
 		'
-		Me.CBHonorificInclude.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.CBHonorificInclude.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.CBHonorificInclude.ForeColor = System.Drawing.Color.Black
 		Me.CBHonorificInclude.Location = New System.Drawing.Point(9, 44)
 		Me.CBHonorificInclude.Name = "CBHonorificInclude"
 		Me.CBHonorificInclude.Size = New System.Drawing.Size(234, 21)
 		Me.CBHonorificInclude.TabIndex = 40
 		Me.CBHonorificInclude.Text = "Honorific Must Be Included w/ Key Phrases"
-		Me.CBHonorificInclude.UseVisualStyleBackColor = true
+		Me.CBHonorificInclude.UseVisualStyleBackColor = True
 		'
 		'CBHonorificCapitalized
 		'
-		Me.CBHonorificCapitalized.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.CBHonorificCapitalized.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.CBHonorificCapitalized.ForeColor = System.Drawing.Color.Black
 		Me.CBHonorificCapitalized.Location = New System.Drawing.Point(9, 66)
 		Me.CBHonorificCapitalized.Name = "CBHonorificCapitalized"
 		Me.CBHonorificCapitalized.Size = New System.Drawing.Size(179, 21)
 		Me.CBHonorificCapitalized.TabIndex = 39
 		Me.CBHonorificCapitalized.Text = "Honorific Must Be Capitalized"
-		Me.CBHonorificCapitalized.UseVisualStyleBackColor = true
+		Me.CBHonorificCapitalized.UseVisualStyleBackColor = True
 		'
 		'TBHonorific
 		'
@@ -3550,7 +3567,7 @@ Partial Class FrmSettings
 		Me.GroupBox38.Name = "GroupBox38"
 		Me.GroupBox38.Size = New System.Drawing.Size(247, 46)
 		Me.GroupBox38.TabIndex = 2
-		Me.GroupBox38.TabStop = false
+		Me.GroupBox38.TabStop = False
 		Me.GroupBox38.Tag = ""
 		Me.GroupBox38.Text = "No"
 		'
@@ -3569,7 +3586,7 @@ Partial Class FrmSettings
 		Me.GroupBox37.Name = "GroupBox37"
 		Me.GroupBox37.Size = New System.Drawing.Size(247, 46)
 		Me.GroupBox37.TabIndex = 1
-		Me.GroupBox37.TabStop = false
+		Me.GroupBox37.TabStop = False
 		Me.GroupBox37.Tag = ""
 		Me.GroupBox37.Text = "Yes"
 		'
@@ -3588,7 +3605,7 @@ Partial Class FrmSettings
 		Me.GroupBox36.Name = "GroupBox36"
 		Me.GroupBox36.Size = New System.Drawing.Size(247, 46)
 		Me.GroupBox36.TabIndex = 0
-		Me.GroupBox36.TabStop = false
+		Me.GroupBox36.TabStop = False
 		Me.GroupBox36.Tag = ""
 		Me.GroupBox36.Text = "Greeting"
 		'
@@ -3610,13 +3627,13 @@ Partial Class FrmSettings
 		Me.GroupBox13.Name = "GroupBox13"
 		Me.GroupBox13.Size = New System.Drawing.Size(259, 39)
 		Me.GroupBox13.TabIndex = 157
-		Me.GroupBox13.TabStop = false
+		Me.GroupBox13.TabStop = False
 		Me.GroupBox13.Text = "Routine"
 		'
 		'Label34
 		'
 		Me.Label34.BackColor = System.Drawing.Color.Transparent
-		Me.Label34.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label34.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label34.ForeColor = System.Drawing.Color.Black
 		Me.Label34.Location = New System.Drawing.Point(12, 15)
 		Me.Label34.Name = "Label34"
@@ -3630,7 +3647,7 @@ Partial Class FrmSettings
 		Me.TimeBoxWakeUp.Format = System.Windows.Forms.DateTimePickerFormat.Time
 		Me.TimeBoxWakeUp.Location = New System.Drawing.Point(134, 12)
 		Me.TimeBoxWakeUp.Name = "TimeBoxWakeUp"
-		Me.TimeBoxWakeUp.ShowUpDown = true
+		Me.TimeBoxWakeUp.ShowUpDown = True
 		Me.TimeBoxWakeUp.Size = New System.Drawing.Size(110, 20)
 		Me.TimeBoxWakeUp.TabIndex = 0
 		'
@@ -3664,12 +3681,12 @@ Partial Class FrmSettings
 		Me.GroupBox7.Name = "GroupBox7"
 		Me.GroupBox7.Size = New System.Drawing.Size(226, 226)
 		Me.GroupBox7.TabIndex = 152
-		Me.GroupBox7.TabStop = false
+		Me.GroupBox7.TabStop = False
 		Me.GroupBox7.Text = "Edging"
 		'
 		'LBLMaxExtremeHold
 		'
-		Me.LBLMaxExtremeHold.AutoSize = true
+		Me.LBLMaxExtremeHold.AutoSize = True
 		Me.LBLMaxExtremeHold.Location = New System.Drawing.Point(173, 128)
 		Me.LBLMaxExtremeHold.Name = "LBLMaxExtremeHold"
 		Me.LBLMaxExtremeHold.Size = New System.Drawing.Size(43, 13)
@@ -3679,7 +3696,7 @@ Partial Class FrmSettings
 		'
 		'LBLMinExtremeHold
 		'
-		Me.LBLMinExtremeHold.AutoSize = true
+		Me.LBLMinExtremeHold.AutoSize = True
 		Me.LBLMinExtremeHold.Location = New System.Drawing.Point(173, 106)
 		Me.LBLMinExtremeHold.Name = "LBLMinExtremeHold"
 		Me.LBLMinExtremeHold.Size = New System.Drawing.Size(43, 13)
@@ -3700,7 +3717,7 @@ Partial Class FrmSettings
 		'Label133
 		'
 		Me.Label133.BackColor = System.Drawing.Color.Transparent
-		Me.Label133.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label133.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label133.ForeColor = System.Drawing.Color.Black
 		Me.Label133.Location = New System.Drawing.Point(6, 105)
 		Me.Label133.Name = "Label133"
@@ -3721,7 +3738,7 @@ Partial Class FrmSettings
 		'
 		'LBLMaxLongHold
 		'
-		Me.LBLMaxLongHold.AutoSize = true
+		Me.LBLMaxLongHold.AutoSize = True
 		Me.LBLMaxLongHold.Location = New System.Drawing.Point(173, 84)
 		Me.LBLMaxLongHold.Name = "LBLMaxLongHold"
 		Me.LBLMaxLongHold.Size = New System.Drawing.Size(43, 13)
@@ -3732,7 +3749,7 @@ Partial Class FrmSettings
 		'Label78
 		'
 		Me.Label78.BackColor = System.Drawing.Color.Transparent
-		Me.Label78.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label78.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label78.ForeColor = System.Drawing.Color.Black
 		Me.Label78.Location = New System.Drawing.Point(6, 83)
 		Me.Label78.Name = "Label78"
@@ -3743,7 +3760,7 @@ Partial Class FrmSettings
 		'
 		'LBLMinLongHold
 		'
-		Me.LBLMinLongHold.AutoSize = true
+		Me.LBLMinLongHold.AutoSize = True
 		Me.LBLMinLongHold.Location = New System.Drawing.Point(173, 62)
 		Me.LBLMinLongHold.Name = "LBLMinLongHold"
 		Me.LBLMinLongHold.Size = New System.Drawing.Size(43, 13)
@@ -3764,7 +3781,7 @@ Partial Class FrmSettings
 		'Label129
 		'
 		Me.Label129.BackColor = System.Drawing.Color.Transparent
-		Me.Label129.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label129.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label129.ForeColor = System.Drawing.Color.Black
 		Me.Label129.Location = New System.Drawing.Point(6, 61)
 		Me.Label129.Name = "Label129"
@@ -3785,7 +3802,7 @@ Partial Class FrmSettings
 		'
 		'LBLMaxHold
 		'
-		Me.LBLMaxHold.AutoSize = true
+		Me.LBLMaxHold.AutoSize = True
 		Me.LBLMaxHold.Location = New System.Drawing.Point(173, 40)
 		Me.LBLMaxHold.Name = "LBLMaxHold"
 		Me.LBLMaxHold.Size = New System.Drawing.Size(43, 13)
@@ -3796,7 +3813,7 @@ Partial Class FrmSettings
 		'Label79
 		'
 		Me.Label79.BackColor = System.Drawing.Color.Transparent
-		Me.Label79.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label79.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label79.ForeColor = System.Drawing.Color.Black
 		Me.Label79.Location = New System.Drawing.Point(6, 39)
 		Me.Label79.Name = "Label79"
@@ -3817,7 +3834,7 @@ Partial Class FrmSettings
 		'
 		'LBLMinHold
 		'
-		Me.LBLMinHold.AutoSize = true
+		Me.LBLMinHold.AutoSize = True
 		Me.LBLMinHold.Location = New System.Drawing.Point(173, 18)
 		Me.LBLMinHold.Name = "LBLMinHold"
 		Me.LBLMinHold.Size = New System.Drawing.Size(47, 13)
@@ -3827,27 +3844,27 @@ Partial Class FrmSettings
 		'
 		'CBEdgeUseAvg
 		'
-		Me.CBEdgeUseAvg.AutoSize = true
-		Me.CBEdgeUseAvg.Enabled = false
+		Me.CBEdgeUseAvg.AutoSize = True
+		Me.CBEdgeUseAvg.Enabled = False
 		Me.CBEdgeUseAvg.Location = New System.Drawing.Point(9, 170)
 		Me.CBEdgeUseAvg.Name = "CBEdgeUseAvg"
 		Me.CBEdgeUseAvg.Size = New System.Drawing.Size(185, 17)
 		Me.CBEdgeUseAvg.TabIndex = 174
 		Me.CBEdgeUseAvg.Text = "Use Avg Edge Time as Threshold"
-		Me.CBEdgeUseAvg.UseVisualStyleBackColor = true
+		Me.CBEdgeUseAvg.UseVisualStyleBackColor = True
 		'
 		'CBLongEdgeInterrupts
 		'
-		Me.CBLongEdgeInterrupts.Checked = true
+		Me.CBLongEdgeInterrupts.Checked = True
 		Me.CBLongEdgeInterrupts.CheckState = System.Windows.Forms.CheckState.Checked
-		Me.CBLongEdgeInterrupts.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.CBLongEdgeInterrupts.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.CBLongEdgeInterrupts.ForeColor = System.Drawing.Color.Black
 		Me.CBLongEdgeInterrupts.Location = New System.Drawing.Point(9, 204)
 		Me.CBLongEdgeInterrupts.Name = "CBLongEdgeInterrupts"
 		Me.CBLongEdgeInterrupts.Size = New System.Drawing.Size(177, 21)
 		Me.CBLongEdgeInterrupts.TabIndex = 169
 		Me.CBLongEdgeInterrupts.Text = "Allow Long Edge Interrupts"
-		Me.CBLongEdgeInterrupts.UseVisualStyleBackColor = true
+		Me.CBLongEdgeInterrupts.UseVisualStyleBackColor = True
 		'
 		'NBHoldTheEdgeMin
 		'
@@ -3861,7 +3878,7 @@ Partial Class FrmSettings
 		'Label55
 		'
 		Me.Label55.BackColor = System.Drawing.Color.Transparent
-		Me.Label55.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label55.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label55.ForeColor = System.Drawing.Color.Black
 		Me.Label55.Location = New System.Drawing.Point(7, 149)
 		Me.Label55.Name = "Label55"
@@ -3873,7 +3890,7 @@ Partial Class FrmSettings
 		'Label81
 		'
 		Me.Label81.BackColor = System.Drawing.Color.Transparent
-		Me.Label81.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label81.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label81.ForeColor = System.Drawing.Color.Black
 		Me.Label81.Location = New System.Drawing.Point(6, 17)
 		Me.Label81.Name = "Label81"
@@ -3884,7 +3901,7 @@ Partial Class FrmSettings
 		'
 		'Label5
 		'
-		Me.Label5.AutoSize = true
+		Me.Label5.AutoSize = True
 		Me.Label5.Location = New System.Drawing.Point(174, 151)
 		Me.Label5.Name = "Label5"
 		Me.Label5.Size = New System.Drawing.Size(43, 13)
@@ -3903,21 +3920,21 @@ Partial Class FrmSettings
 		'
 		'CBLongEdgeTaunts
 		'
-		Me.CBLongEdgeTaunts.Checked = true
+		Me.CBLongEdgeTaunts.Checked = True
 		Me.CBLongEdgeTaunts.CheckState = System.Windows.Forms.CheckState.Checked
-		Me.CBLongEdgeTaunts.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.CBLongEdgeTaunts.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.CBLongEdgeTaunts.ForeColor = System.Drawing.Color.Black
 		Me.CBLongEdgeTaunts.Location = New System.Drawing.Point(9, 186)
 		Me.CBLongEdgeTaunts.Name = "CBLongEdgeTaunts"
 		Me.CBLongEdgeTaunts.Size = New System.Drawing.Size(163, 21)
 		Me.CBLongEdgeTaunts.TabIndex = 172
 		Me.CBLongEdgeTaunts.Text = "Allow Long Edge Taunts"
-		Me.CBLongEdgeTaunts.UseVisualStyleBackColor = true
+		Me.CBLongEdgeTaunts.UseVisualStyleBackColor = True
 		'
 		'Label131
 		'
 		Me.Label131.BackColor = System.Drawing.Color.Transparent
-		Me.Label131.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label131.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label131.ForeColor = System.Drawing.Color.Black
 		Me.Label131.Location = New System.Drawing.Point(6, 127)
 		Me.Label131.Name = "Label131"
@@ -3929,13 +3946,13 @@ Partial Class FrmSettings
 		'PictureBox12
 		'
 		Me.PictureBox12.BackColor = System.Drawing.Color.LightGray
-		Me.PictureBox12.Image = CType(resources.GetObject("PictureBox12.Image"),System.Drawing.Image)
+		Me.PictureBox12.Image = CType(resources.GetObject("PictureBox12.Image"), System.Drawing.Image)
 		Me.PictureBox12.Location = New System.Drawing.Point(9, 6)
 		Me.PictureBox12.Name = "PictureBox12"
 		Me.PictureBox12.Size = New System.Drawing.Size(160, 19)
 		Me.PictureBox12.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage
 		Me.PictureBox12.TabIndex = 149
-		Me.PictureBox12.TabStop = false
+		Me.PictureBox12.TabStop = False
 		'
 		'GroupBox32
 		'
@@ -3967,13 +3984,13 @@ Partial Class FrmSettings
 		Me.GroupBox32.Name = "GroupBox32"
 		Me.GroupBox32.Size = New System.Drawing.Size(427, 165)
 		Me.GroupBox32.TabIndex = 62
-		Me.GroupBox32.TabStop = false
+		Me.GroupBox32.TabStop = False
 		Me.GroupBox32.Text = "Stats && Information"
 		'
 		'LBLSubBdayFormat
 		'
-		Me.LBLSubBdayFormat.AutoSize = true
-		Me.LBLSubBdayFormat.Font = New System.Drawing.Font("Microsoft Sans Serif", 7!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLSubBdayFormat.AutoSize = True
+		Me.LBLSubBdayFormat.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLSubBdayFormat.Location = New System.Drawing.Point(125, 22)
 		Me.LBLSubBdayFormat.Name = "LBLSubBdayFormat"
 		Me.LBLSubBdayFormat.Size = New System.Drawing.Size(38, 13)
@@ -3983,70 +4000,70 @@ Partial Class FrmSettings
 		'
 		'CBChastitySpikes
 		'
-		Me.CBChastitySpikes.AutoSize = true
-		Me.CBChastitySpikes.Enabled = false
+		Me.CBChastitySpikes.AutoSize = True
+		Me.CBChastitySpikes.Enabled = False
 		Me.CBChastitySpikes.Location = New System.Drawing.Point(191, 140)
 		Me.CBChastitySpikes.Name = "CBChastitySpikes"
 		Me.CBChastitySpikes.Size = New System.Drawing.Size(179, 17)
 		Me.CBChastitySpikes.TabIndex = 4
 		Me.CBChastitySpikes.Text = "Chastity Device Contains Spikes"
-		Me.CBChastitySpikes.UseVisualStyleBackColor = true
+		Me.CBChastitySpikes.UseVisualStyleBackColor = True
 		'
 		'CBOwnChastity
 		'
-		Me.CBOwnChastity.AutoSize = true
+		Me.CBOwnChastity.AutoSize = True
 		Me.CBOwnChastity.Location = New System.Drawing.Point(191, 90)
 		Me.CBOwnChastity.Name = "CBOwnChastity"
 		Me.CBOwnChastity.Size = New System.Drawing.Size(171, 17)
 		Me.CBOwnChastity.TabIndex = 5
 		Me.CBOwnChastity.Text = "Own Device a Chastity Device"
-		Me.CBOwnChastity.UseVisualStyleBackColor = true
+		Me.CBOwnChastity.UseVisualStyleBackColor = True
 		'
 		'CBChastityPA
 		'
-		Me.CBChastityPA.AutoSize = true
-		Me.CBChastityPA.Enabled = false
+		Me.CBChastityPA.AutoSize = True
+		Me.CBChastityPA.Enabled = False
 		Me.CBChastityPA.Location = New System.Drawing.Point(191, 115)
 		Me.CBChastityPA.Name = "CBChastityPA"
 		Me.CBChastityPA.Size = New System.Drawing.Size(195, 17)
 		Me.CBChastityPA.TabIndex = 3
 		Me.CBChastityPA.Text = "Chastity Device Requires a Piercing"
-		Me.CBChastityPA.UseVisualStyleBackColor = true
+		Me.CBChastityPA.UseVisualStyleBackColor = True
 		'
 		'CBHimHer
 		'
-		Me.CBHimHer.AutoSize = true
+		Me.CBHimHer.AutoSize = True
 		Me.CBHimHer.Location = New System.Drawing.Point(191, 65)
 		Me.CBHimHer.Name = "CBHimHer"
 		Me.CBHimHer.Size = New System.Drawing.Size(219, 17)
 		Me.CBHimHer.TabIndex = 3
 		Me.CBHimHer.Text = "Replace Male Glitter Pronouns to Female"
-		Me.CBHimHer.UseVisualStyleBackColor = true
+		Me.CBHimHer.UseVisualStyleBackColor = True
 		'
 		'CBBallsToPussy
 		'
-		Me.CBBallsToPussy.AutoSize = true
+		Me.CBBallsToPussy.AutoSize = True
 		Me.CBBallsToPussy.Location = New System.Drawing.Point(191, 40)
 		Me.CBBallsToPussy.Name = "CBBallsToPussy"
 		Me.CBBallsToPussy.Size = New System.Drawing.Size(193, 17)
 		Me.CBBallsToPussy.TabIndex = 160
 		Me.CBBallsToPussy.Text = "Replace #Balls with #BallsToPussy"
-		Me.CBBallsToPussy.UseVisualStyleBackColor = true
+		Me.CBBallsToPussy.UseVisualStyleBackColor = True
 		'
 		'CBCockToClit
 		'
-		Me.CBCockToClit.AutoSize = true
+		Me.CBCockToClit.AutoSize = True
 		Me.CBCockToClit.Location = New System.Drawing.Point(191, 15)
 		Me.CBCockToClit.Name = "CBCockToClit"
 		Me.CBCockToClit.Size = New System.Drawing.Size(185, 17)
 		Me.CBCockToClit.TabIndex = 159
 		Me.CBCockToClit.Text = "Replace #Cock with #CockToClit"
-		Me.CBCockToClit.UseVisualStyleBackColor = true
+		Me.CBCockToClit.UseVisualStyleBackColor = True
 		'
 		'NBBirthdayDay
 		'
 		Me.NBBirthdayDay.BackColor = System.Drawing.Color.White
-		Me.NBBirthdayDay.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.NBBirthdayDay.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.NBBirthdayDay.ForeColor = System.Drawing.Color.Black
 		Me.NBBirthdayDay.Location = New System.Drawing.Point(125, 37)
 		Me.NBBirthdayDay.Maximum = New Decimal(New Integer() {31, 0, 0, 0})
@@ -4058,32 +4075,32 @@ Partial Class FrmSettings
 		'
 		'CBSubCircumcised
 		'
-		Me.CBSubCircumcised.AutoSize = true
-		Me.CBSubCircumcised.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.CBSubCircumcised.AutoSize = True
+		Me.CBSubCircumcised.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.CBSubCircumcised.ForeColor = System.Drawing.Color.Black
 		Me.CBSubCircumcised.Location = New System.Drawing.Point(9, 138)
 		Me.CBSubCircumcised.Name = "CBSubCircumcised"
 		Me.CBSubCircumcised.Size = New System.Drawing.Size(83, 17)
 		Me.CBSubCircumcised.TabIndex = 157
 		Me.CBSubCircumcised.Text = "Circumcised"
-		Me.CBSubCircumcised.UseVisualStyleBackColor = true
+		Me.CBSubCircumcised.UseVisualStyleBackColor = True
 		'
 		'CBSubPierced
 		'
-		Me.CBSubPierced.AutoSize = true
-		Me.CBSubPierced.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.CBSubPierced.AutoSize = True
+		Me.CBSubPierced.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.CBSubPierced.ForeColor = System.Drawing.Color.Black
 		Me.CBSubPierced.Location = New System.Drawing.Point(98, 138)
 		Me.CBSubPierced.Name = "CBSubPierced"
 		Me.CBSubPierced.Size = New System.Drawing.Size(62, 17)
 		Me.CBSubPierced.TabIndex = 156
 		Me.CBSubPierced.Text = "Pierced"
-		Me.CBSubPierced.UseVisualStyleBackColor = true
+		Me.CBSubPierced.UseVisualStyleBackColor = True
 		'
 		'TBSubEyeColor
 		'
 		Me.TBSubEyeColor.BackColor = System.Drawing.Color.White
-		Me.TBSubEyeColor.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.TBSubEyeColor.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.TBSubEyeColor.ForeColor = System.Drawing.Color.Black
 		Me.TBSubEyeColor.Location = New System.Drawing.Point(73, 87)
 		Me.TBSubEyeColor.Name = "TBSubEyeColor"
@@ -4094,7 +4111,7 @@ Partial Class FrmSettings
 		'TBSubHairColor
 		'
 		Me.TBSubHairColor.BackColor = System.Drawing.Color.White
-		Me.TBSubHairColor.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.TBSubHairColor.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.TBSubHairColor.ForeColor = System.Drawing.Color.Black
 		Me.TBSubHairColor.Location = New System.Drawing.Point(73, 60)
 		Me.TBSubHairColor.Name = "TBSubHairColor"
@@ -4104,8 +4121,8 @@ Partial Class FrmSettings
 		'
 		'Label63
 		'
-		Me.Label63.AutoSize = true
-		Me.Label63.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label63.AutoSize = True
+		Me.Label63.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label63.ForeColor = System.Drawing.Color.Black
 		Me.Label63.Location = New System.Drawing.Point(113, 41)
 		Me.Label63.Name = "Label63"
@@ -4116,7 +4133,7 @@ Partial Class FrmSettings
 		'
 		'LBLSubInches
 		'
-		Me.LBLSubInches.AutoSize = true
+		Me.LBLSubInches.AutoSize = True
 		Me.LBLSubInches.Location = New System.Drawing.Point(118, 118)
 		Me.LBLSubInches.Name = "LBLSubInches"
 		Me.LBLSubInches.Size = New System.Drawing.Size(38, 13)
@@ -4128,7 +4145,7 @@ Partial Class FrmSettings
 		'
 		Me.subAgeNumBox.BackColor = System.Drawing.Color.White
 		Me.subAgeNumBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.subAgeNumBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.subAgeNumBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.subAgeNumBox.ForeColor = System.Drawing.Color.Black
 		Me.subAgeNumBox.Location = New System.Drawing.Point(73, 14)
 		Me.subAgeNumBox.Maximum = New Decimal(New Integer() {99, 0, 0, 0})
@@ -4141,7 +4158,7 @@ Partial Class FrmSettings
 		'NBBirthdayMonth
 		'
 		Me.NBBirthdayMonth.BackColor = System.Drawing.Color.White
-		Me.NBBirthdayMonth.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.NBBirthdayMonth.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.NBBirthdayMonth.ForeColor = System.Drawing.Color.Black
 		Me.NBBirthdayMonth.Location = New System.Drawing.Point(73, 37)
 		Me.NBBirthdayMonth.Maximum = New Decimal(New Integer() {12, 0, 0, 0})
@@ -4154,7 +4171,7 @@ Partial Class FrmSettings
 		'LBLSubCockSize
 		'
 		Me.LBLSubCockSize.BackColor = System.Drawing.Color.Transparent
-		Me.LBLSubCockSize.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLSubCockSize.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLSubCockSize.ForeColor = System.Drawing.Color.Black
 		Me.LBLSubCockSize.Location = New System.Drawing.Point(6, 114)
 		Me.LBLSubCockSize.Name = "LBLSubCockSize"
@@ -4166,7 +4183,7 @@ Partial Class FrmSettings
 		'CockSizeNumBox
 		'
 		Me.CockSizeNumBox.BackColor = System.Drawing.Color.White
-		Me.CockSizeNumBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.CockSizeNumBox.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.CockSizeNumBox.ForeColor = System.Drawing.Color.Black
 		Me.CockSizeNumBox.Location = New System.Drawing.Point(73, 114)
 		Me.CockSizeNumBox.Maximum = New Decimal(New Integer() {15, 0, 0, 0})
@@ -4179,7 +4196,7 @@ Partial Class FrmSettings
 		'LBLSubEye
 		'
 		Me.LBLSubEye.BackColor = System.Drawing.Color.Transparent
-		Me.LBLSubEye.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLSubEye.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLSubEye.ForeColor = System.Drawing.Color.Black
 		Me.LBLSubEye.Location = New System.Drawing.Point(6, 90)
 		Me.LBLSubEye.Name = "LBLSubEye"
@@ -4191,7 +4208,7 @@ Partial Class FrmSettings
 		'LBLSubHair
 		'
 		Me.LBLSubHair.BackColor = System.Drawing.Color.Transparent
-		Me.LBLSubHair.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLSubHair.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLSubHair.ForeColor = System.Drawing.Color.Black
 		Me.LBLSubHair.Location = New System.Drawing.Point(6, 63)
 		Me.LBLSubHair.Name = "LBLSubHair"
@@ -4203,7 +4220,7 @@ Partial Class FrmSettings
 		'LBLSubBirthday
 		'
 		Me.LBLSubBirthday.BackColor = System.Drawing.Color.Transparent
-		Me.LBLSubBirthday.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLSubBirthday.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLSubBirthday.ForeColor = System.Drawing.Color.Black
 		Me.LBLSubBirthday.Location = New System.Drawing.Point(6, 37)
 		Me.LBLSubBirthday.Name = "LBLSubBirthday"
@@ -4215,7 +4232,7 @@ Partial Class FrmSettings
 		'LBLSubAge
 		'
 		Me.LBLSubAge.BackColor = System.Drawing.Color.Transparent
-		Me.LBLSubAge.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLSubAge.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLSubAge.ForeColor = System.Drawing.Color.Black
 		Me.LBLSubAge.Location = New System.Drawing.Point(6, 15)
 		Me.LBLSubAge.Name = "LBLSubAge"
@@ -4227,7 +4244,7 @@ Partial Class FrmSettings
 		'Label70
 		'
 		Me.Label70.BackColor = System.Drawing.Color.Transparent
-		Me.Label70.Font = New System.Drawing.Font("Microsoft Sans Serif", 12!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label70.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label70.ForeColor = System.Drawing.Color.Black
 		Me.Label70.Location = New System.Drawing.Point(7, 6)
 		Me.Label70.Name = "Label70"
@@ -4274,7 +4291,7 @@ Partial Class FrmSettings
 		Me.BTNScriptAvailable.Size = New System.Drawing.Size(100, 23)
 		Me.BTNScriptAvailable.TabIndex = 160
 		Me.BTNScriptAvailable.Text = "Select Available"
-		Me.BTNScriptAvailable.UseVisualStyleBackColor = true
+		Me.BTNScriptAvailable.UseVisualStyleBackColor = True
 		'
 		'BTNScriptNone
 		'
@@ -4283,7 +4300,7 @@ Partial Class FrmSettings
 		Me.BTNScriptNone.Size = New System.Drawing.Size(75, 23)
 		Me.BTNScriptNone.TabIndex = 159
 		Me.BTNScriptNone.Text = "Select None"
-		Me.BTNScriptNone.UseVisualStyleBackColor = true
+		Me.BTNScriptNone.UseVisualStyleBackColor = True
 		'
 		'BTNScriptAll
 		'
@@ -4292,7 +4309,7 @@ Partial Class FrmSettings
 		Me.BTNScriptAll.Size = New System.Drawing.Size(75, 23)
 		Me.BTNScriptAll.TabIndex = 158
 		Me.BTNScriptAll.Text = "Select All"
-		Me.BTNScriptAll.UseVisualStyleBackColor = true
+		Me.BTNScriptAll.UseVisualStyleBackColor = True
 		'
 		'BTNScriptOpen
 		'
@@ -4301,13 +4318,13 @@ Partial Class FrmSettings
 		Me.BTNScriptOpen.Size = New System.Drawing.Size(75, 23)
 		Me.BTNScriptOpen.TabIndex = 157
 		Me.BTNScriptOpen.Text = "Open Script"
-		Me.BTNScriptOpen.UseVisualStyleBackColor = true
+		Me.BTNScriptOpen.UseVisualStyleBackColor = True
 		'
 		'LBLScriptReq
 		'
 		Me.LBLScriptReq.BackColor = System.Drawing.Color.LightGray
 		Me.LBLScriptReq.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D
-		Me.LBLScriptReq.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLScriptReq.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLScriptReq.ForeColor = System.Drawing.Color.Green
 		Me.LBLScriptReq.Location = New System.Drawing.Point(314, 292)
 		Me.LBLScriptReq.Name = "LBLScriptReq"
@@ -4322,14 +4339,14 @@ Partial Class FrmSettings
 		Me.GroupBox31.Name = "GroupBox31"
 		Me.GroupBox31.Size = New System.Drawing.Size(385, 110)
 		Me.GroupBox31.TabIndex = 155
-		Me.GroupBox31.TabStop = false
+		Me.GroupBox31.TabStop = False
 		Me.GroupBox31.Text = "Requirements"
 		'
 		'RTBScriptReq
 		'
 		Me.RTBScriptReq.Location = New System.Drawing.Point(6, 16)
 		Me.RTBScriptReq.Name = "RTBScriptReq"
-		Me.RTBScriptReq.ReadOnly = true
+		Me.RTBScriptReq.ReadOnly = True
 		Me.RTBScriptReq.Size = New System.Drawing.Size(373, 85)
 		Me.RTBScriptReq.TabIndex = 0
 		Me.RTBScriptReq.Text = ""
@@ -4359,11 +4376,11 @@ Partial Class FrmSettings
 		'
 		'CLBStartList
 		'
-		Me.CLBStartList.FormattingEnabled = true
+		Me.CLBStartList.FormattingEnabled = True
 		Me.CLBStartList.Location = New System.Drawing.Point(4, 4)
 		Me.CLBStartList.Name = "CLBStartList"
 		Me.CLBStartList.Size = New System.Drawing.Size(283, 214)
-		Me.CLBStartList.Sorted = true
+		Me.CLBStartList.Sorted = True
 		Me.CLBStartList.TabIndex = 155
 		'
 		'TabPage17
@@ -4379,11 +4396,11 @@ Partial Class FrmSettings
 		'
 		'CLBModuleList
 		'
-		Me.CLBModuleList.FormattingEnabled = true
+		Me.CLBModuleList.FormattingEnabled = True
 		Me.CLBModuleList.Location = New System.Drawing.Point(4, 4)
 		Me.CLBModuleList.Name = "CLBModuleList"
 		Me.CLBModuleList.Size = New System.Drawing.Size(283, 214)
-		Me.CLBModuleList.Sorted = true
+		Me.CLBModuleList.Sorted = True
 		Me.CLBModuleList.TabIndex = 156
 		'
 		'TabPage18
@@ -4399,11 +4416,11 @@ Partial Class FrmSettings
 		'
 		'CLBLinkList
 		'
-		Me.CLBLinkList.FormattingEnabled = true
+		Me.CLBLinkList.FormattingEnabled = True
 		Me.CLBLinkList.Location = New System.Drawing.Point(4, 4)
 		Me.CLBLinkList.Name = "CLBLinkList"
 		Me.CLBLinkList.Size = New System.Drawing.Size(283, 214)
-		Me.CLBLinkList.Sorted = true
+		Me.CLBLinkList.Sorted = True
 		Me.CLBLinkList.TabIndex = 156
 		'
 		'TabPage19
@@ -4419,11 +4436,11 @@ Partial Class FrmSettings
 		'
 		'CLBEndList
 		'
-		Me.CLBEndList.FormattingEnabled = true
+		Me.CLBEndList.FormattingEnabled = True
 		Me.CLBEndList.Location = New System.Drawing.Point(4, 4)
 		Me.CLBEndList.Name = "CLBEndList"
 		Me.CLBEndList.Size = New System.Drawing.Size(283, 214)
-		Me.CLBEndList.Sorted = true
+		Me.CLBEndList.Sorted = True
 		Me.CLBEndList.TabIndex = 156
 		'
 		'GroupBox42
@@ -4433,14 +4450,14 @@ Partial Class FrmSettings
 		Me.GroupBox42.Name = "GroupBox42"
 		Me.GroupBox42.Size = New System.Drawing.Size(385, 110)
 		Me.GroupBox42.TabIndex = 153
-		Me.GroupBox42.TabStop = false
+		Me.GroupBox42.TabStop = False
 		Me.GroupBox42.Text = "Description"
 		'
 		'RTBScriptDesc
 		'
 		Me.RTBScriptDesc.Location = New System.Drawing.Point(6, 16)
 		Me.RTBScriptDesc.Name = "RTBScriptDesc"
-		Me.RTBScriptDesc.ReadOnly = true
+		Me.RTBScriptDesc.ReadOnly = True
 		Me.RTBScriptDesc.Size = New System.Drawing.Size(373, 85)
 		Me.RTBScriptDesc.TabIndex = 0
 		Me.RTBScriptDesc.Text = ""
@@ -4448,13 +4465,13 @@ Partial Class FrmSettings
 		'PictureBox1
 		'
 		Me.PictureBox1.BackColor = System.Drawing.Color.LightGray
-		Me.PictureBox1.Image = CType(resources.GetObject("PictureBox1.Image"),System.Drawing.Image)
+		Me.PictureBox1.Image = CType(resources.GetObject("PictureBox1.Image"), System.Drawing.Image)
 		Me.PictureBox1.Location = New System.Drawing.Point(9, 6)
 		Me.PictureBox1.Name = "PictureBox1"
 		Me.PictureBox1.Size = New System.Drawing.Size(160, 19)
 		Me.PictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage
 		Me.PictureBox1.TabIndex = 151
-		Me.PictureBox1.TabStop = false
+		Me.PictureBox1.TabStop = False
 		'
 		'GroupBox43
 		'
@@ -4465,13 +4482,13 @@ Partial Class FrmSettings
 		Me.GroupBox43.Name = "GroupBox43"
 		Me.GroupBox43.Size = New System.Drawing.Size(692, 92)
 		Me.GroupBox43.TabIndex = 65
-		Me.GroupBox43.TabStop = false
+		Me.GroupBox43.TabStop = False
 		Me.GroupBox43.Text = "Description"
 		'
 		'Label98
 		'
 		Me.Label98.BackColor = System.Drawing.Color.Transparent
-		Me.Label98.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label98.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label98.ForeColor = System.Drawing.Color.Black
 		Me.Label98.Location = New System.Drawing.Point(6, 16)
 		Me.Label98.Name = "Label98"
@@ -4483,7 +4500,7 @@ Partial Class FrmSettings
 		'Label104
 		'
 		Me.Label104.BackColor = System.Drawing.Color.Transparent
-		Me.Label104.Font = New System.Drawing.Font("Microsoft Sans Serif", 12!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label104.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label104.ForeColor = System.Drawing.Color.Black
 		Me.Label104.Location = New System.Drawing.Point(7, 6)
 		Me.Label104.Name = "Label104"
@@ -4530,15 +4547,15 @@ Partial Class FrmSettings
 		'
 		'CBURLPreview
 		'
-		Me.CBURLPreview.AutoSize = true
-		Me.CBURLPreview.Checked = true
+		Me.CBURLPreview.AutoSize = True
+		Me.CBURLPreview.Checked = True
 		Me.CBURLPreview.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBURLPreview.Location = New System.Drawing.Point(344, 323)
 		Me.CBURLPreview.Name = "CBURLPreview"
 		Me.CBURLPreview.Size = New System.Drawing.Size(240, 17)
 		Me.CBURLPreview.TabIndex = 163
 		Me.CBURLPreview.Text = "Show Previews When A URL File is Selected"
-		Me.CBURLPreview.UseVisualStyleBackColor = true
+		Me.CBURLPreview.UseVisualStyleBackColor = True
 		'
 		'GroupBox66
 		'
@@ -4547,7 +4564,7 @@ Partial Class FrmSettings
 		Me.GroupBox66.Name = "GroupBox66"
 		Me.GroupBox66.Size = New System.Drawing.Size(350, 309)
 		Me.GroupBox66.TabIndex = 162
-		Me.GroupBox66.TabStop = false
+		Me.GroupBox66.TabStop = False
 		Me.GroupBox66.Text = "Example Preview"
 		'
 		'PBURLPreview
@@ -4558,7 +4575,7 @@ Partial Class FrmSettings
 		Me.PBURLPreview.Size = New System.Drawing.Size(338, 284)
 		Me.PBURLPreview.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
 		Me.PBURLPreview.TabIndex = 0
-		Me.PBURLPreview.TabStop = false
+		Me.PBURLPreview.TabStop = False
 		'
 		'BTNURLFilesAll
 		'
@@ -4567,7 +4584,7 @@ Partial Class FrmSettings
 		Me.BTNURLFilesAll.Size = New System.Drawing.Size(75, 23)
 		Me.BTNURLFilesAll.TabIndex = 160
 		Me.BTNURLFilesAll.Text = "Select All"
-		Me.BTNURLFilesAll.UseVisualStyleBackColor = true
+		Me.BTNURLFilesAll.UseVisualStyleBackColor = True
 		'
 		'BTNURLFilesNone
 		'
@@ -4576,22 +4593,22 @@ Partial Class FrmSettings
 		Me.BTNURLFilesNone.Size = New System.Drawing.Size(75, 23)
 		Me.BTNURLFilesNone.TabIndex = 161
 		Me.BTNURLFilesNone.Text = "Select None"
-		Me.BTNURLFilesNone.UseVisualStyleBackColor = true
+		Me.BTNURLFilesNone.UseVisualStyleBackColor = True
 		'
 		'URLFileList
 		'
-		Me.URLFileList.CheckOnClick = true
-		Me.URLFileList.FormattingEnabled = true
+		Me.URLFileList.CheckOnClick = True
+		Me.URLFileList.FormattingEnabled = True
 		Me.URLFileList.Location = New System.Drawing.Point(6, 9)
 		Me.URLFileList.Name = "URLFileList"
 		Me.URLFileList.Size = New System.Drawing.Size(332, 394)
-		Me.URLFileList.Sorted = true
+		Me.URLFileList.Sorted = True
 		Me.URLFileList.TabIndex = 154
 		'
 		'TabPage32
 		'
 		Me.TabPage32.BackColor = System.Drawing.Color.LightGray
-		Me.TabPage32.Controls.Add(Me.GroupBox16)
+		Me.TabPage32.Controls.Add(Me.GrbImageUrlFiles)
 		Me.TabPage32.Controls.Add(Me.GroupBox14)
 		Me.TabPage32.Location = New System.Drawing.Point(4, 22)
 		Me.TabPage32.Name = "TabPage32"
@@ -4600,521 +4617,616 @@ Partial Class FrmSettings
 		Me.TabPage32.TabIndex = 1
 		Me.TabPage32.Text = "Genre Images"
 		'
-		'GroupBox16
-		'
-		Me.GroupBox16.Controls.Add(Me.LBLBoobURL)
-		Me.GroupBox16.Controls.Add(Me.BTNButtURL)
-		Me.GroupBox16.Controls.Add(Me.BTNBoobURL)
-		Me.GroupBox16.Controls.Add(Me.LBLButtURL)
-		Me.GroupBox16.Controls.Add(Me.CBURLButts)
-		Me.GroupBox16.Controls.Add(Me.CBURLBoobs)
-		Me.GroupBox16.Controls.Add(Me.LBLURLFemdom)
-		Me.GroupBox16.Controls.Add(Me.BTNURLGeneral)
-		Me.GroupBox16.Controls.Add(Me.LBLURLHentai)
-		Me.GroupBox16.Controls.Add(Me.CBURLLesbian)
-		Me.GroupBox16.Controls.Add(Me.BTNURLCaptions)
-		Me.GroupBox16.Controls.Add(Me.CBURLBlowjob)
-		Me.GroupBox16.Controls.Add(Me.BTNURLMaledom)
-		Me.GroupBox16.Controls.Add(Me.CBURLGay)
-		Me.GroupBox16.Controls.Add(Me.BTNURLGay)
-		Me.GroupBox16.Controls.Add(Me.CBURLSoftcore)
-		Me.GroupBox16.Controls.Add(Me.CBURLHentai)
-		Me.GroupBox16.Controls.Add(Me.CBURLLezdom)
-		Me.GroupBox16.Controls.Add(Me.BTNURLHentai)
-		Me.GroupBox16.Controls.Add(Me.LBLURLLezdom)
-		Me.GroupBox16.Controls.Add(Me.BTNURLLezdom)
-		Me.GroupBox16.Controls.Add(Me.CBURLFemdom)
-		Me.GroupBox16.Controls.Add(Me.BTNURLFemdom)
-		Me.GroupBox16.Controls.Add(Me.LBLURLBlowjob)
-		Me.GroupBox16.Controls.Add(Me.BTNURLBlowjob)
-		Me.GroupBox16.Controls.Add(Me.LBLURLLesbian)
-		Me.GroupBox16.Controls.Add(Me.CBURLCaptions)
-		Me.GroupBox16.Controls.Add(Me.BTNURLLesbian)
-		Me.GroupBox16.Controls.Add(Me.LBLURLSoftcore)
-		Me.GroupBox16.Controls.Add(Me.LBLURLGeneral)
-		Me.GroupBox16.Controls.Add(Me.BTNURLSoftcore)
-		Me.GroupBox16.Controls.Add(Me.LBLURLCaptions)
-		Me.GroupBox16.Controls.Add(Me.LBLURLGay)
-		Me.GroupBox16.Controls.Add(Me.CBURLGeneral)
-		Me.GroupBox16.Controls.Add(Me.BTNURLHardcore)
-		Me.GroupBox16.Controls.Add(Me.LBLURLHardcore)
-		Me.GroupBox16.Controls.Add(Me.LBLURLMaledom)
-		Me.GroupBox16.Controls.Add(Me.CBURLHardcore)
-		Me.GroupBox16.Controls.Add(Me.CBURLMaledom)
-		Me.GroupBox16.Location = New System.Drawing.Point(383, 8)
-		Me.GroupBox16.Name = "GroupBox16"
-		Me.GroupBox16.Size = New System.Drawing.Size(311, 400)
-		Me.GroupBox16.TabIndex = 156
-		Me.GroupBox16.TabStop = false
-		Me.GroupBox16.Text = "URL Files"
-		'
-		'LBLBoobURL
-		'
-		Me.LBLBoobURL.BackColor = System.Drawing.Color.Transparent
-		Me.LBLBoobURL.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLBoobURL.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
-		Me.LBLBoobURL.ForeColor = System.Drawing.Color.Black
-		Me.LBLBoobURL.Location = New System.Drawing.Point(122, 341)
-		Me.LBLBoobURL.Name = "LBLBoobURL"
-		Me.LBLBoobURL.Size = New System.Drawing.Size(173, 17)
-		Me.LBLBoobURL.TabIndex = 139
-		Me.LBLBoobURL.Text = "No path selected"
-		Me.LBLBoobURL.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
-		'
-		'BTNButtURL
-		'
-		Me.BTNButtURL.BackColor = System.Drawing.Color.LightGray
-		Me.BTNButtURL.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold)
-		Me.BTNButtURL.ForeColor = System.Drawing.Color.Black
-		Me.BTNButtURL.Location = New System.Drawing.Point(82, 364)
-		Me.BTNButtURL.Name = "BTNButtURL"
-		Me.BTNButtURL.Size = New System.Drawing.Size(34, 28)
-		Me.BTNButtURL.TabIndex = 137
-		Me.BTNButtURL.Text = "1"
-		Me.BTNButtURL.UseVisualStyleBackColor = false
-		'
-		'BTNBoobURL
-		'
-		Me.BTNBoobURL.BackColor = System.Drawing.Color.LightGray
-		Me.BTNBoobURL.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold)
-		Me.BTNBoobURL.ForeColor = System.Drawing.Color.Black
-		Me.BTNBoobURL.Location = New System.Drawing.Point(82, 335)
-		Me.BTNBoobURL.Name = "BTNBoobURL"
-		Me.BTNBoobURL.Size = New System.Drawing.Size(34, 28)
-		Me.BTNBoobURL.TabIndex = 137
-		Me.BTNBoobURL.Text = "1"
-		Me.BTNBoobURL.UseVisualStyleBackColor = false
-		'
-		'LBLButtURL
-		'
-		Me.LBLButtURL.BackColor = System.Drawing.Color.Transparent
-		Me.LBLButtURL.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLButtURL.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
-		Me.LBLButtURL.ForeColor = System.Drawing.Color.Black
-		Me.LBLButtURL.Location = New System.Drawing.Point(122, 370)
-		Me.LBLButtURL.Name = "LBLButtURL"
-		Me.LBLButtURL.Size = New System.Drawing.Size(173, 17)
-		Me.LBLButtURL.TabIndex = 139
-		Me.LBLButtURL.Text = "No path selected"
-		Me.LBLButtURL.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
-		'
-		'CBURLButts
-		'
-		Me.CBURLButts.AutoSize = true
-		Me.CBURLButts.ForeColor = System.Drawing.Color.Black
-		Me.CBURLButts.Location = New System.Drawing.Point(15, 371)
-		Me.CBURLButts.Name = "CBURLButts"
-		Me.CBURLButts.Size = New System.Drawing.Size(50, 17)
-		Me.CBURLButts.TabIndex = 184
-		Me.CBURLButts.Text = "Butts"
-		Me.CBURLButts.UseVisualStyleBackColor = true
-		'
-		'CBURLBoobs
-		'
-		Me.CBURLBoobs.AutoSize = true
-		Me.CBURLBoobs.ForeColor = System.Drawing.Color.Black
-		Me.CBURLBoobs.Location = New System.Drawing.Point(15, 342)
-		Me.CBURLBoobs.Name = "CBURLBoobs"
-		Me.CBURLBoobs.Size = New System.Drawing.Size(56, 17)
-		Me.CBURLBoobs.TabIndex = 183
-		Me.CBURLBoobs.Text = "Boobs"
-		Me.CBURLBoobs.UseVisualStyleBackColor = true
-		'
-		'LBLURLFemdom
-		'
-		Me.LBLURLFemdom.BackColor = System.Drawing.Color.Transparent
-		Me.LBLURLFemdom.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLURLFemdom.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
-		Me.LBLURLFemdom.ForeColor = System.Drawing.Color.Black
-		Me.LBLURLFemdom.Location = New System.Drawing.Point(122, 138)
-		Me.LBLURLFemdom.Name = "LBLURLFemdom"
-		Me.LBLURLFemdom.Size = New System.Drawing.Size(173, 17)
-		Me.LBLURLFemdom.TabIndex = 154
-		Me.LBLURLFemdom.Text = "No path selected"
-		Me.LBLURLFemdom.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
-		'
-		'BTNURLGeneral
-		'
-		Me.BTNURLGeneral.BackColor = System.Drawing.Color.LightGray
-		Me.BTNURLGeneral.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
-		Me.BTNURLGeneral.ForeColor = System.Drawing.Color.Black
-		Me.BTNURLGeneral.Location = New System.Drawing.Point(82, 306)
-		Me.BTNURLGeneral.Name = "BTNURLGeneral"
-		Me.BTNURLGeneral.Size = New System.Drawing.Size(34, 28)
-		Me.BTNURLGeneral.TabIndex = 166
-		Me.BTNURLGeneral.Text = "1"
-		Me.BTNURLGeneral.UseVisualStyleBackColor = false
-		'
-		'LBLURLHentai
-		'
-		Me.LBLURLHentai.BackColor = System.Drawing.Color.Transparent
-		Me.LBLURLHentai.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLURLHentai.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
-		Me.LBLURLHentai.ForeColor = System.Drawing.Color.Black
-		Me.LBLURLHentai.Location = New System.Drawing.Point(122, 196)
-		Me.LBLURLHentai.Name = "LBLURLHentai"
-		Me.LBLURLHentai.Size = New System.Drawing.Size(173, 17)
-		Me.LBLURLHentai.TabIndex = 162
-		Me.LBLURLHentai.Text = "No path selected"
-		Me.LBLURLHentai.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
-		'
-		'CBURLLesbian
-		'
-		Me.CBURLLesbian.AutoSize = true
-		Me.CBURLLesbian.ForeColor = System.Drawing.Color.Black
-		Me.CBURLLesbian.Location = New System.Drawing.Point(15, 81)
-		Me.CBURLLesbian.Name = "CBURLLesbian"
-		Me.CBURLLesbian.Size = New System.Drawing.Size(63, 17)
-		Me.CBURLLesbian.TabIndex = 140
-		Me.CBURLLesbian.Text = "Lesbian"
-		Me.CBURLLesbian.UseVisualStyleBackColor = true
-		'
-		'BTNURLCaptions
-		'
-		Me.BTNURLCaptions.BackColor = System.Drawing.Color.LightGray
-		Me.BTNURLCaptions.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
-		Me.BTNURLCaptions.ForeColor = System.Drawing.Color.Black
-		Me.BTNURLCaptions.Location = New System.Drawing.Point(82, 277)
-		Me.BTNURLCaptions.Name = "BTNURLCaptions"
-		Me.BTNURLCaptions.Size = New System.Drawing.Size(34, 28)
-		Me.BTNURLCaptions.TabIndex = 178
-		Me.BTNURLCaptions.Text = "1"
-		Me.BTNURLCaptions.UseVisualStyleBackColor = false
-		'
-		'CBURLBlowjob
-		'
-		Me.CBURLBlowjob.AutoSize = true
-		Me.CBURLBlowjob.ForeColor = System.Drawing.Color.Black
-		Me.CBURLBlowjob.Location = New System.Drawing.Point(15, 110)
-		Me.CBURLBlowjob.Name = "CBURLBlowjob"
-		Me.CBURLBlowjob.Size = New System.Drawing.Size(63, 17)
-		Me.CBURLBlowjob.TabIndex = 141
-		Me.CBURLBlowjob.Text = "Blowjob"
-		Me.CBURLBlowjob.UseVisualStyleBackColor = true
-		'
-		'BTNURLMaledom
-		'
-		Me.BTNURLMaledom.BackColor = System.Drawing.Color.LightGray
-		Me.BTNURLMaledom.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
-		Me.BTNURLMaledom.ForeColor = System.Drawing.Color.Black
-		Me.BTNURLMaledom.Location = New System.Drawing.Point(82, 248)
-		Me.BTNURLMaledom.Name = "BTNURLMaledom"
-		Me.BTNURLMaledom.Size = New System.Drawing.Size(34, 28)
-		Me.BTNURLMaledom.TabIndex = 161
-		Me.BTNURLMaledom.Text = "1"
-		Me.BTNURLMaledom.UseVisualStyleBackColor = false
-		'
-		'CBURLGay
-		'
-		Me.CBURLGay.AutoSize = true
-		Me.CBURLGay.ForeColor = System.Drawing.Color.Black
-		Me.CBURLGay.Location = New System.Drawing.Point(15, 226)
-		Me.CBURLGay.Name = "CBURLGay"
-		Me.CBURLGay.Size = New System.Drawing.Size(45, 17)
-		Me.CBURLGay.TabIndex = 157
-		Me.CBURLGay.Text = "Gay"
-		Me.CBURLGay.UseVisualStyleBackColor = true
-		'
-		'BTNURLGay
-		'
-		Me.BTNURLGay.BackColor = System.Drawing.Color.LightGray
-		Me.BTNURLGay.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
-		Me.BTNURLGay.ForeColor = System.Drawing.Color.Black
-		Me.BTNURLGay.Location = New System.Drawing.Point(82, 219)
-		Me.BTNURLGay.Name = "BTNURLGay"
-		Me.BTNURLGay.Size = New System.Drawing.Size(34, 28)
-		Me.BTNURLGay.TabIndex = 160
-		Me.BTNURLGay.Text = "1"
-		Me.BTNURLGay.UseVisualStyleBackColor = false
-		'
-		'CBURLSoftcore
-		'
-		Me.CBURLSoftcore.AutoSize = true
-		Me.CBURLSoftcore.ForeColor = System.Drawing.Color.Black
-		Me.CBURLSoftcore.Location = New System.Drawing.Point(15, 52)
-		Me.CBURLSoftcore.Name = "CBURLSoftcore"
-		Me.CBURLSoftcore.Size = New System.Drawing.Size(66, 17)
-		Me.CBURLSoftcore.TabIndex = 139
-		Me.CBURLSoftcore.Text = "Softcore"
-		Me.CBURLSoftcore.UseVisualStyleBackColor = true
-		'
-		'CBURLHentai
-		'
-		Me.CBURLHentai.AutoSize = true
-		Me.CBURLHentai.ForeColor = System.Drawing.Color.Black
-		Me.CBURLHentai.Location = New System.Drawing.Point(15, 197)
-		Me.CBURLHentai.Name = "CBURLHentai"
-		Me.CBURLHentai.Size = New System.Drawing.Size(57, 17)
-		Me.CBURLHentai.TabIndex = 156
-		Me.CBURLHentai.Text = "Hentai"
-		Me.CBURLHentai.UseVisualStyleBackColor = true
-		'
-		'CBURLLezdom
-		'
-		Me.CBURLLezdom.AutoSize = true
-		Me.CBURLLezdom.ForeColor = System.Drawing.Color.Black
-		Me.CBURLLezdom.Location = New System.Drawing.Point(15, 168)
-		Me.CBURLLezdom.Name = "CBURLLezdom"
-		Me.CBURLLezdom.Size = New System.Drawing.Size(63, 17)
-		Me.CBURLLezdom.TabIndex = 143
-		Me.CBURLLezdom.Text = "Lezdom"
-		Me.CBURLLezdom.UseVisualStyleBackColor = true
-		'
-		'BTNURLHentai
-		'
-		Me.BTNURLHentai.BackColor = System.Drawing.Color.LightGray
-		Me.BTNURLHentai.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
-		Me.BTNURLHentai.ForeColor = System.Drawing.Color.Black
-		Me.BTNURLHentai.Location = New System.Drawing.Point(82, 190)
-		Me.BTNURLHentai.Name = "BTNURLHentai"
-		Me.BTNURLHentai.Size = New System.Drawing.Size(34, 28)
-		Me.BTNURLHentai.TabIndex = 159
-		Me.BTNURLHentai.Text = "1"
-		Me.BTNURLHentai.UseVisualStyleBackColor = false
-		'
-		'LBLURLLezdom
-		'
-		Me.LBLURLLezdom.BackColor = System.Drawing.Color.Transparent
-		Me.LBLURLLezdom.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLURLLezdom.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
-		Me.LBLURLLezdom.ForeColor = System.Drawing.Color.Black
-		Me.LBLURLLezdom.Location = New System.Drawing.Point(122, 167)
-		Me.LBLURLLezdom.Name = "LBLURLLezdom"
-		Me.LBLURLLezdom.Size = New System.Drawing.Size(173, 17)
-		Me.LBLURLLezdom.TabIndex = 155
-		Me.LBLURLLezdom.Text = "No path selected"
-		Me.LBLURLLezdom.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
-		'
-		'BTNURLLezdom
-		'
-		Me.BTNURLLezdom.BackColor = System.Drawing.Color.LightGray
-		Me.BTNURLLezdom.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
-		Me.BTNURLLezdom.ForeColor = System.Drawing.Color.Black
-		Me.BTNURLLezdom.Location = New System.Drawing.Point(82, 161)
-		Me.BTNURLLezdom.Name = "BTNURLLezdom"
-		Me.BTNURLLezdom.Size = New System.Drawing.Size(34, 28)
-		Me.BTNURLLezdom.TabIndex = 149
-		Me.BTNURLLezdom.Text = "1"
-		Me.BTNURLLezdom.UseVisualStyleBackColor = false
-		'
-		'CBURLFemdom
-		'
-		Me.CBURLFemdom.AutoSize = true
-		Me.CBURLFemdom.ForeColor = System.Drawing.Color.Black
-		Me.CBURLFemdom.Location = New System.Drawing.Point(15, 139)
-		Me.CBURLFemdom.Name = "CBURLFemdom"
-		Me.CBURLFemdom.Size = New System.Drawing.Size(66, 17)
-		Me.CBURLFemdom.TabIndex = 142
-		Me.CBURLFemdom.Text = "Femdom"
-		Me.CBURLFemdom.UseVisualStyleBackColor = true
-		'
-		'BTNURLFemdom
-		'
-		Me.BTNURLFemdom.BackColor = System.Drawing.Color.LightGray
-		Me.BTNURLFemdom.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
-		Me.BTNURLFemdom.ForeColor = System.Drawing.Color.Black
-		Me.BTNURLFemdom.Location = New System.Drawing.Point(82, 132)
-		Me.BTNURLFemdom.Name = "BTNURLFemdom"
-		Me.BTNURLFemdom.Size = New System.Drawing.Size(34, 28)
-		Me.BTNURLFemdom.TabIndex = 148
-		Me.BTNURLFemdom.Text = "1"
-		Me.BTNURLFemdom.UseVisualStyleBackColor = false
-		'
-		'LBLURLBlowjob
-		'
-		Me.LBLURLBlowjob.BackColor = System.Drawing.Color.Transparent
-		Me.LBLURLBlowjob.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLURLBlowjob.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
-		Me.LBLURLBlowjob.ForeColor = System.Drawing.Color.Black
-		Me.LBLURLBlowjob.Location = New System.Drawing.Point(122, 109)
-		Me.LBLURLBlowjob.Name = "LBLURLBlowjob"
-		Me.LBLURLBlowjob.Size = New System.Drawing.Size(173, 17)
-		Me.LBLURLBlowjob.TabIndex = 153
-		Me.LBLURLBlowjob.Text = "No URL File selected"
-		Me.LBLURLBlowjob.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
-		'
-		'BTNURLBlowjob
-		'
-		Me.BTNURLBlowjob.BackColor = System.Drawing.Color.LightGray
-		Me.BTNURLBlowjob.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
-		Me.BTNURLBlowjob.ForeColor = System.Drawing.Color.Black
-		Me.BTNURLBlowjob.Location = New System.Drawing.Point(82, 103)
-		Me.BTNURLBlowjob.Name = "BTNURLBlowjob"
-		Me.BTNURLBlowjob.Size = New System.Drawing.Size(34, 28)
-		Me.BTNURLBlowjob.TabIndex = 147
-		Me.BTNURLBlowjob.Text = "1"
-		Me.BTNURLBlowjob.UseVisualStyleBackColor = false
-		'
-		'LBLURLLesbian
-		'
-		Me.LBLURLLesbian.BackColor = System.Drawing.Color.Transparent
-		Me.LBLURLLesbian.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLURLLesbian.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
-		Me.LBLURLLesbian.ForeColor = System.Drawing.Color.Black
-		Me.LBLURLLesbian.Location = New System.Drawing.Point(122, 80)
-		Me.LBLURLLesbian.Name = "LBLURLLesbian"
-		Me.LBLURLLesbian.Size = New System.Drawing.Size(173, 17)
-		Me.LBLURLLesbian.TabIndex = 152
-		Me.LBLURLLesbian.Text = "No path selected"
-		Me.LBLURLLesbian.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
-		'
-		'CBURLCaptions
-		'
-		Me.CBURLCaptions.AutoSize = true
-		Me.CBURLCaptions.ForeColor = System.Drawing.Color.Black
-		Me.CBURLCaptions.Location = New System.Drawing.Point(15, 284)
-		Me.CBURLCaptions.Name = "CBURLCaptions"
-		Me.CBURLCaptions.Size = New System.Drawing.Size(67, 17)
-		Me.CBURLCaptions.TabIndex = 177
-		Me.CBURLCaptions.Text = "Captions"
-		Me.CBURLCaptions.UseVisualStyleBackColor = true
-		'
-		'BTNURLLesbian
-		'
-		Me.BTNURLLesbian.BackColor = System.Drawing.Color.LightGray
-		Me.BTNURLLesbian.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
-		Me.BTNURLLesbian.ForeColor = System.Drawing.Color.Black
-		Me.BTNURLLesbian.Location = New System.Drawing.Point(82, 74)
-		Me.BTNURLLesbian.Name = "BTNURLLesbian"
-		Me.BTNURLLesbian.Size = New System.Drawing.Size(34, 28)
-		Me.BTNURLLesbian.TabIndex = 146
-		Me.BTNURLLesbian.Text = "1"
-		Me.BTNURLLesbian.UseVisualStyleBackColor = false
-		'
-		'LBLURLSoftcore
-		'
-		Me.LBLURLSoftcore.BackColor = System.Drawing.Color.Transparent
-		Me.LBLURLSoftcore.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLURLSoftcore.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
-		Me.LBLURLSoftcore.ForeColor = System.Drawing.Color.Black
-		Me.LBLURLSoftcore.Location = New System.Drawing.Point(122, 51)
-		Me.LBLURLSoftcore.Name = "LBLURLSoftcore"
-		Me.LBLURLSoftcore.Size = New System.Drawing.Size(173, 17)
-		Me.LBLURLSoftcore.TabIndex = 151
-		Me.LBLURLSoftcore.Text = "No path selected"
-		Me.LBLURLSoftcore.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
-		'
-		'LBLURLGeneral
-		'
-		Me.LBLURLGeneral.BackColor = System.Drawing.Color.Transparent
-		Me.LBLURLGeneral.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLURLGeneral.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
-		Me.LBLURLGeneral.ForeColor = System.Drawing.Color.Black
-		Me.LBLURLGeneral.Location = New System.Drawing.Point(122, 312)
-		Me.LBLURLGeneral.Name = "LBLURLGeneral"
-		Me.LBLURLGeneral.Size = New System.Drawing.Size(173, 17)
-		Me.LBLURLGeneral.TabIndex = 167
-		Me.LBLURLGeneral.Text = "No path selected"
-		Me.LBLURLGeneral.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
-		'
-		'BTNURLSoftcore
-		'
-		Me.BTNURLSoftcore.BackColor = System.Drawing.Color.LightGray
-		Me.BTNURLSoftcore.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
-		Me.BTNURLSoftcore.ForeColor = System.Drawing.Color.Black
-		Me.BTNURLSoftcore.Location = New System.Drawing.Point(82, 45)
-		Me.BTNURLSoftcore.Name = "BTNURLSoftcore"
-		Me.BTNURLSoftcore.Size = New System.Drawing.Size(34, 28)
-		Me.BTNURLSoftcore.TabIndex = 145
-		Me.BTNURLSoftcore.Text = "1"
-		Me.BTNURLSoftcore.UseVisualStyleBackColor = false
-		'
-		'LBLURLCaptions
-		'
-		Me.LBLURLCaptions.BackColor = System.Drawing.Color.Transparent
-		Me.LBLURLCaptions.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLURLCaptions.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
-		Me.LBLURLCaptions.ForeColor = System.Drawing.Color.Black
-		Me.LBLURLCaptions.Location = New System.Drawing.Point(122, 283)
-		Me.LBLURLCaptions.Name = "LBLURLCaptions"
-		Me.LBLURLCaptions.Size = New System.Drawing.Size(173, 17)
-		Me.LBLURLCaptions.TabIndex = 179
-		Me.LBLURLCaptions.Text = "No path selected"
-		Me.LBLURLCaptions.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
-		'
-		'LBLURLGay
-		'
-		Me.LBLURLGay.BackColor = System.Drawing.Color.Transparent
-		Me.LBLURLGay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLURLGay.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
-		Me.LBLURLGay.ForeColor = System.Drawing.Color.Black
-		Me.LBLURLGay.Location = New System.Drawing.Point(122, 225)
-		Me.LBLURLGay.Name = "LBLURLGay"
-		Me.LBLURLGay.Size = New System.Drawing.Size(173, 17)
-		Me.LBLURLGay.TabIndex = 163
-		Me.LBLURLGay.Text = "No path selected"
-		Me.LBLURLGay.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
-		'
-		'CBURLGeneral
-		'
-		Me.CBURLGeneral.AutoSize = true
-		Me.CBURLGeneral.ForeColor = System.Drawing.Color.Black
-		Me.CBURLGeneral.Location = New System.Drawing.Point(15, 313)
-		Me.CBURLGeneral.Name = "CBURLGeneral"
-		Me.CBURLGeneral.Size = New System.Drawing.Size(63, 17)
-		Me.CBURLGeneral.TabIndex = 165
-		Me.CBURLGeneral.Text = "General"
-		Me.CBURLGeneral.UseVisualStyleBackColor = true
-		'
-		'BTNURLHardcore
-		'
-		Me.BTNURLHardcore.BackColor = System.Drawing.Color.LightGray
-		Me.BTNURLHardcore.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
-		Me.BTNURLHardcore.ForeColor = System.Drawing.Color.Black
-		Me.BTNURLHardcore.Location = New System.Drawing.Point(82, 16)
-		Me.BTNURLHardcore.Name = "BTNURLHardcore"
-		Me.BTNURLHardcore.Size = New System.Drawing.Size(34, 28)
-		Me.BTNURLHardcore.TabIndex = 144
-		Me.BTNURLHardcore.Text = "1"
-		Me.BTNURLHardcore.UseVisualStyleBackColor = false
-		'
-		'LBLURLHardcore
-		'
-		Me.LBLURLHardcore.BackColor = System.Drawing.Color.Transparent
-		Me.LBLURLHardcore.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLURLHardcore.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
-		Me.LBLURLHardcore.ForeColor = System.Drawing.Color.Black
-		Me.LBLURLHardcore.Location = New System.Drawing.Point(122, 23)
-		Me.LBLURLHardcore.Name = "LBLURLHardcore"
-		Me.LBLURLHardcore.Size = New System.Drawing.Size(173, 17)
-		Me.LBLURLHardcore.TabIndex = 150
-		Me.LBLURLHardcore.Text = "No path selected"
-		Me.LBLURLHardcore.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
-		'
-		'LBLURLMaledom
-		'
-		Me.LBLURLMaledom.BackColor = System.Drawing.Color.Transparent
-		Me.LBLURLMaledom.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLURLMaledom.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
-		Me.LBLURLMaledom.ForeColor = System.Drawing.Color.Black
-		Me.LBLURLMaledom.Location = New System.Drawing.Point(122, 254)
-		Me.LBLURLMaledom.Name = "LBLURLMaledom"
-		Me.LBLURLMaledom.Size = New System.Drawing.Size(173, 17)
-		Me.LBLURLMaledom.TabIndex = 164
-		Me.LBLURLMaledom.Text = "No path selected"
-		Me.LBLURLMaledom.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
-		'
-		'CBURLHardcore
-		'
-		Me.CBURLHardcore.AutoSize = true
-		Me.CBURLHardcore.ForeColor = System.Drawing.Color.Black
-		Me.CBURLHardcore.Location = New System.Drawing.Point(15, 23)
-		Me.CBURLHardcore.Name = "CBURLHardcore"
-		Me.CBURLHardcore.Size = New System.Drawing.Size(70, 17)
-		Me.CBURLHardcore.TabIndex = 138
-		Me.CBURLHardcore.Text = "Hardcore"
-		Me.CBURLHardcore.UseVisualStyleBackColor = true
-		'
-		'CBURLMaledom
-		'
-		Me.CBURLMaledom.AutoSize = true
-		Me.CBURLMaledom.ForeColor = System.Drawing.Color.Black
-		Me.CBURLMaledom.Location = New System.Drawing.Point(15, 255)
-		Me.CBURLMaledom.Name = "CBURLMaledom"
-		Me.CBURLMaledom.Size = New System.Drawing.Size(69, 17)
-		Me.CBURLMaledom.TabIndex = 158
-		Me.CBURLMaledom.Text = "Maledom"
-		Me.CBURLMaledom.UseVisualStyleBackColor = true
+		'GrbImageUrlFiles
+		'
+		Me.GrbImageUrlFiles.Controls.Add(Me.TlpImageUrls)
+		Me.GrbImageUrlFiles.Location = New System.Drawing.Point(383, 8)
+		Me.GrbImageUrlFiles.Name = "GrbImageUrlFiles"
+		Me.GrbImageUrlFiles.Size = New System.Drawing.Size(311, 400)
+		Me.GrbImageUrlFiles.TabIndex = 156
+		Me.GrbImageUrlFiles.TabStop = False
+		Me.GrbImageUrlFiles.Text = "URL Files"
+		'
+		'TlpImageUrls
+		'
+		Me.TlpImageUrls.BackColor = System.Drawing.Color.LightGray
+		Me.TlpImageUrls.ColumnCount = 3
+		Me.TlpImageUrls.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle())
+		Me.TlpImageUrls.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle())
+		Me.TlpImageUrls.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle())
+		Me.TlpImageUrls.Controls.Add(Me.BtnImageUrlButt, 1, 13)
+		Me.TlpImageUrls.Controls.Add(Me.BtnImageUrlBoobs, 1, 12)
+		Me.TlpImageUrls.Controls.Add(Me.BtnImageUrlBlowjob, 1, 4)
+		Me.TlpImageUrls.Controls.Add(Me.BtnImageUrlCaptions, 1, 10)
+		Me.TlpImageUrls.Controls.Add(Me.BtnImageUrlHentai, 1, 7)
+		Me.TlpImageUrls.Controls.Add(Me.BtnImageUrlGay, 1, 8)
+		Me.TlpImageUrls.Controls.Add(Me.BtnImageUrlGeneral, 1, 11)
+		Me.TlpImageUrls.Controls.Add(Me.BtnImageUrlHardcore, 1, 0)
+		Me.TlpImageUrls.Controls.Add(Me.BtnImageUrlLesbian, 1, 2)
+		Me.TlpImageUrls.Controls.Add(Me.BtnImageUrlLezdom, 1, 6)
+		Me.TlpImageUrls.Controls.Add(Me.BtnImageUrlMaledom, 1, 9)
+		Me.TlpImageUrls.Controls.Add(Me.BtnImageUrlFemdom, 1, 5)
+		Me.TlpImageUrls.Controls.Add(Me.BtnImageUrlSoftcore, 1, 1)
+		Me.TlpImageUrls.Controls.Add(Me.ChbImageUrlHardcore, 0, 0)
+		Me.TlpImageUrls.Controls.Add(Me.ChbImageUrlButts, 0, 13)
+		Me.TlpImageUrls.Controls.Add(Me.ChbImageUrlMaledom, 0, 9)
+		Me.TlpImageUrls.Controls.Add(Me.ChbImageUrlGay, 0, 8)
+		Me.TlpImageUrls.Controls.Add(Me.ChbImageUrlSoftcore, 0, 1)
+		Me.TlpImageUrls.Controls.Add(Me.ChbImageUrlBoobs, 0, 12)
+		Me.TlpImageUrls.Controls.Add(Me.ChbImageUrlLesbian, 0, 2)
+		Me.TlpImageUrls.Controls.Add(Me.ChbImageUrlBlowjob, 0, 4)
+		Me.TlpImageUrls.Controls.Add(Me.ChbImageUrlCaptions, 0, 10)
+		Me.TlpImageUrls.Controls.Add(Me.ChbImageUrlGeneral, 0, 11)
+		Me.TlpImageUrls.Controls.Add(Me.ChbImageUrlFemdom, 0, 5)
+		Me.TlpImageUrls.Controls.Add(Me.ChbImageUrlHentai, 0, 7)
+		Me.TlpImageUrls.Controls.Add(Me.ChbImageUrlLezdom, 0, 6)
+		Me.TlpImageUrls.Controls.Add(Me.TxbImageUrlBlowjob, 2, 4)
+		Me.TlpImageUrls.Controls.Add(Me.TxbImageUrlSoftcore, 2, 1)
+		Me.TlpImageUrls.Controls.Add(Me.TxbImageUrlLezdom, 2, 6)
+		Me.TlpImageUrls.Controls.Add(Me.TxbImageUrlFemdom, 2, 5)
+		Me.TlpImageUrls.Controls.Add(Me.TxbImageUrlHardcore, 2, 0)
+		Me.TlpImageUrls.Controls.Add(Me.TxbImageUrlHentai, 2, 7)
+		Me.TlpImageUrls.Controls.Add(Me.TxbImageUrlGay, 2, 8)
+		Me.TlpImageUrls.Controls.Add(Me.TxbImageUrlLesbian, 2, 2)
+		Me.TlpImageUrls.Controls.Add(Me.TxbImageUrlMaledom, 2, 9)
+		Me.TlpImageUrls.Controls.Add(Me.TxbImageUrlCaptions, 2, 10)
+		Me.TlpImageUrls.Controls.Add(Me.TxbImageUrlGeneral, 2, 11)
+		Me.TlpImageUrls.Controls.Add(Me.TxbImageUrlBoobs, 2, 12)
+		Me.TlpImageUrls.Controls.Add(Me.TxbImageUrlButts, 2, 13)
+		Me.TlpImageUrls.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.TlpImageUrls.GrowStyle = System.Windows.Forms.TableLayoutPanelGrowStyle.FixedSize
+		Me.TlpImageUrls.Location = New System.Drawing.Point(3, 16)
+		Me.TlpImageUrls.Name = "TlpImageUrls"
+		Me.TlpImageUrls.RowCount = 14
+		Me.TlpImageUrls.RowStyles.Add(New System.Windows.Forms.RowStyle())
+		Me.TlpImageUrls.RowStyles.Add(New System.Windows.Forms.RowStyle())
+		Me.TlpImageUrls.RowStyles.Add(New System.Windows.Forms.RowStyle())
+		Me.TlpImageUrls.RowStyles.Add(New System.Windows.Forms.RowStyle())
+		Me.TlpImageUrls.RowStyles.Add(New System.Windows.Forms.RowStyle())
+		Me.TlpImageUrls.RowStyles.Add(New System.Windows.Forms.RowStyle())
+		Me.TlpImageUrls.RowStyles.Add(New System.Windows.Forms.RowStyle())
+		Me.TlpImageUrls.RowStyles.Add(New System.Windows.Forms.RowStyle())
+		Me.TlpImageUrls.RowStyles.Add(New System.Windows.Forms.RowStyle())
+		Me.TlpImageUrls.RowStyles.Add(New System.Windows.Forms.RowStyle())
+		Me.TlpImageUrls.RowStyles.Add(New System.Windows.Forms.RowStyle())
+		Me.TlpImageUrls.RowStyles.Add(New System.Windows.Forms.RowStyle())
+		Me.TlpImageUrls.RowStyles.Add(New System.Windows.Forms.RowStyle())
+		Me.TlpImageUrls.RowStyles.Add(New System.Windows.Forms.RowStyle())
+		Me.TlpImageUrls.Size = New System.Drawing.Size(305, 381)
+		Me.TlpImageUrls.TabIndex = 0
+		'
+		'BtnImageUrlButt
+		'
+		Me.BtnImageUrlButt.BackColor = System.Drawing.Color.LightGray
+		Me.BtnImageUrlButt.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold)
+		Me.BtnImageUrlButt.ForeColor = System.Drawing.Color.Black
+		Me.BtnImageUrlButt.Location = New System.Drawing.Point(76, 348)
+		Me.BtnImageUrlButt.Margin = New System.Windows.Forms.Padding(0, 0, 0, 1)
+		Me.BtnImageUrlButt.Name = "BtnImageUrlButt"
+		Me.BtnImageUrlButt.Size = New System.Drawing.Size(34, 28)
+		Me.BtnImageUrlButt.TabIndex = 38
+		Me.BtnImageUrlButt.Text = "1"
+		Me.BtnImageUrlButt.UseVisualStyleBackColor = False
+		'
+		'BtnImageUrlBoobs
+		'
+		Me.BtnImageUrlBoobs.BackColor = System.Drawing.Color.LightGray
+		Me.BtnImageUrlBoobs.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold)
+		Me.BtnImageUrlBoobs.ForeColor = System.Drawing.Color.Black
+		Me.BtnImageUrlBoobs.Location = New System.Drawing.Point(76, 319)
+		Me.BtnImageUrlBoobs.Margin = New System.Windows.Forms.Padding(0, 0, 0, 1)
+		Me.BtnImageUrlBoobs.Name = "BtnImageUrlBoobs"
+		Me.BtnImageUrlBoobs.Size = New System.Drawing.Size(34, 28)
+		Me.BtnImageUrlBoobs.TabIndex = 35
+		Me.BtnImageUrlBoobs.Text = "1"
+		Me.BtnImageUrlBoobs.UseVisualStyleBackColor = False
+		'
+		'BtnImageUrlBlowjob
+		'
+		Me.BtnImageUrlBlowjob.BackColor = System.Drawing.Color.LightGray
+		Me.BtnImageUrlBlowjob.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
+		Me.BtnImageUrlBlowjob.ForeColor = System.Drawing.Color.Black
+		Me.BtnImageUrlBlowjob.Location = New System.Drawing.Point(76, 87)
+		Me.BtnImageUrlBlowjob.Margin = New System.Windows.Forms.Padding(0, 0, 0, 1)
+		Me.BtnImageUrlBlowjob.Name = "BtnImageUrlBlowjob"
+		Me.BtnImageUrlBlowjob.Size = New System.Drawing.Size(34, 28)
+		Me.BtnImageUrlBlowjob.TabIndex = 11
+		Me.BtnImageUrlBlowjob.Text = "1"
+		Me.BtnImageUrlBlowjob.UseVisualStyleBackColor = False
+		'
+		'BtnImageUrlCaptions
+		'
+		Me.BtnImageUrlCaptions.BackColor = System.Drawing.Color.LightGray
+		Me.BtnImageUrlCaptions.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
+		Me.BtnImageUrlCaptions.ForeColor = System.Drawing.Color.Black
+		Me.BtnImageUrlCaptions.Location = New System.Drawing.Point(76, 261)
+		Me.BtnImageUrlCaptions.Margin = New System.Windows.Forms.Padding(0, 0, 0, 1)
+		Me.BtnImageUrlCaptions.Name = "BtnImageUrlCaptions"
+		Me.BtnImageUrlCaptions.Size = New System.Drawing.Size(34, 28)
+		Me.BtnImageUrlCaptions.TabIndex = 29
+		Me.BtnImageUrlCaptions.Text = "1"
+		Me.BtnImageUrlCaptions.UseVisualStyleBackColor = False
+		'
+		'BtnImageUrlHentai
+		'
+		Me.BtnImageUrlHentai.BackColor = System.Drawing.Color.LightGray
+		Me.BtnImageUrlHentai.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
+		Me.BtnImageUrlHentai.ForeColor = System.Drawing.Color.Black
+		Me.BtnImageUrlHentai.Location = New System.Drawing.Point(76, 174)
+		Me.BtnImageUrlHentai.Margin = New System.Windows.Forms.Padding(0, 0, 0, 1)
+		Me.BtnImageUrlHentai.Name = "BtnImageUrlHentai"
+		Me.BtnImageUrlHentai.Size = New System.Drawing.Size(34, 28)
+		Me.BtnImageUrlHentai.TabIndex = 20
+		Me.BtnImageUrlHentai.Text = "1"
+		Me.BtnImageUrlHentai.UseVisualStyleBackColor = False
+		'
+		'BtnImageUrlGay
+		'
+		Me.BtnImageUrlGay.BackColor = System.Drawing.Color.LightGray
+		Me.BtnImageUrlGay.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
+		Me.BtnImageUrlGay.ForeColor = System.Drawing.Color.Black
+		Me.BtnImageUrlGay.Location = New System.Drawing.Point(76, 203)
+		Me.BtnImageUrlGay.Margin = New System.Windows.Forms.Padding(0, 0, 0, 1)
+		Me.BtnImageUrlGay.Name = "BtnImageUrlGay"
+		Me.BtnImageUrlGay.Size = New System.Drawing.Size(34, 28)
+		Me.BtnImageUrlGay.TabIndex = 23
+		Me.BtnImageUrlGay.Text = "1"
+		Me.BtnImageUrlGay.UseVisualStyleBackColor = False
+		'
+		'BtnImageUrlGeneral
+		'
+		Me.BtnImageUrlGeneral.BackColor = System.Drawing.Color.LightGray
+		Me.BtnImageUrlGeneral.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
+		Me.BtnImageUrlGeneral.ForeColor = System.Drawing.Color.Black
+		Me.BtnImageUrlGeneral.Location = New System.Drawing.Point(76, 290)
+		Me.BtnImageUrlGeneral.Margin = New System.Windows.Forms.Padding(0, 0, 0, 1)
+		Me.BtnImageUrlGeneral.Name = "BtnImageUrlGeneral"
+		Me.BtnImageUrlGeneral.Size = New System.Drawing.Size(34, 28)
+		Me.BtnImageUrlGeneral.TabIndex = 32
+		Me.BtnImageUrlGeneral.Text = "1"
+		Me.BtnImageUrlGeneral.UseVisualStyleBackColor = False
+		'
+		'BtnImageUrlHardcore
+		'
+		Me.BtnImageUrlHardcore.BackColor = System.Drawing.Color.LightGray
+		Me.BtnImageUrlHardcore.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
+		Me.BtnImageUrlHardcore.ForeColor = System.Drawing.Color.Black
+		Me.BtnImageUrlHardcore.Location = New System.Drawing.Point(76, 0)
+		Me.BtnImageUrlHardcore.Margin = New System.Windows.Forms.Padding(0, 0, 0, 1)
+		Me.BtnImageUrlHardcore.Name = "BtnImageUrlHardcore"
+		Me.BtnImageUrlHardcore.Size = New System.Drawing.Size(34, 28)
+		Me.BtnImageUrlHardcore.TabIndex = 1
+		Me.BtnImageUrlHardcore.Text = "1"
+		Me.BtnImageUrlHardcore.UseVisualStyleBackColor = False
+		'
+		'BtnImageUrlLesbian
+		'
+		Me.BtnImageUrlLesbian.BackColor = System.Drawing.Color.LightGray
+		Me.BtnImageUrlLesbian.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
+		Me.BtnImageUrlLesbian.ForeColor = System.Drawing.Color.Black
+		Me.BtnImageUrlLesbian.Location = New System.Drawing.Point(76, 58)
+		Me.BtnImageUrlLesbian.Margin = New System.Windows.Forms.Padding(0, 0, 0, 1)
+		Me.BtnImageUrlLesbian.Name = "BtnImageUrlLesbian"
+		Me.BtnImageUrlLesbian.Size = New System.Drawing.Size(34, 28)
+		Me.BtnImageUrlLesbian.TabIndex = 8
+		Me.BtnImageUrlLesbian.Text = "1"
+		Me.BtnImageUrlLesbian.UseVisualStyleBackColor = False
+		'
+		'BtnImageUrlLezdom
+		'
+		Me.BtnImageUrlLezdom.BackColor = System.Drawing.Color.LightGray
+		Me.BtnImageUrlLezdom.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
+		Me.BtnImageUrlLezdom.ForeColor = System.Drawing.Color.Black
+		Me.BtnImageUrlLezdom.Location = New System.Drawing.Point(76, 145)
+		Me.BtnImageUrlLezdom.Margin = New System.Windows.Forms.Padding(0, 0, 0, 1)
+		Me.BtnImageUrlLezdom.Name = "BtnImageUrlLezdom"
+		Me.BtnImageUrlLezdom.Size = New System.Drawing.Size(34, 28)
+		Me.BtnImageUrlLezdom.TabIndex = 17
+		Me.BtnImageUrlLezdom.Text = "1"
+		Me.BtnImageUrlLezdom.UseVisualStyleBackColor = False
+		'
+		'BtnImageUrlMaledom
+		'
+		Me.BtnImageUrlMaledom.BackColor = System.Drawing.Color.LightGray
+		Me.BtnImageUrlMaledom.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
+		Me.BtnImageUrlMaledom.ForeColor = System.Drawing.Color.Black
+		Me.BtnImageUrlMaledom.Location = New System.Drawing.Point(76, 232)
+		Me.BtnImageUrlMaledom.Margin = New System.Windows.Forms.Padding(0, 0, 0, 1)
+		Me.BtnImageUrlMaledom.Name = "BtnImageUrlMaledom"
+		Me.BtnImageUrlMaledom.Size = New System.Drawing.Size(34, 28)
+		Me.BtnImageUrlMaledom.TabIndex = 26
+		Me.BtnImageUrlMaledom.Text = "1"
+		Me.BtnImageUrlMaledom.UseVisualStyleBackColor = False
+		'
+		'BtnImageUrlFemdom
+		'
+		Me.BtnImageUrlFemdom.BackColor = System.Drawing.Color.LightGray
+		Me.BtnImageUrlFemdom.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
+		Me.BtnImageUrlFemdom.ForeColor = System.Drawing.Color.Black
+		Me.BtnImageUrlFemdom.Location = New System.Drawing.Point(76, 116)
+		Me.BtnImageUrlFemdom.Margin = New System.Windows.Forms.Padding(0, 0, 0, 1)
+		Me.BtnImageUrlFemdom.Name = "BtnImageUrlFemdom"
+		Me.BtnImageUrlFemdom.Size = New System.Drawing.Size(34, 28)
+		Me.BtnImageUrlFemdom.TabIndex = 14
+		Me.BtnImageUrlFemdom.Text = "1"
+		Me.BtnImageUrlFemdom.UseVisualStyleBackColor = False
+		'
+		'BtnImageUrlSoftcore
+		'
+		Me.BtnImageUrlSoftcore.BackColor = System.Drawing.Color.LightGray
+		Me.BtnImageUrlSoftcore.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
+		Me.BtnImageUrlSoftcore.ForeColor = System.Drawing.Color.Black
+		Me.BtnImageUrlSoftcore.Location = New System.Drawing.Point(76, 29)
+		Me.BtnImageUrlSoftcore.Margin = New System.Windows.Forms.Padding(0, 0, 0, 1)
+		Me.BtnImageUrlSoftcore.Name = "BtnImageUrlSoftcore"
+		Me.BtnImageUrlSoftcore.Size = New System.Drawing.Size(34, 28)
+		Me.BtnImageUrlSoftcore.TabIndex = 5
+		Me.BtnImageUrlSoftcore.Text = "1"
+		Me.BtnImageUrlSoftcore.UseVisualStyleBackColor = False
+		'
+		'ChbImageUrlHardcore
+		'
+		Me.ChbImageUrlHardcore.AutoSize = True
+		Me.ChbImageUrlHardcore.Checked = Global.Tease_AI.My.MySettings.Default.UrlFileHardcoreEnabled
+		Me.ChbImageUrlHardcore.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "UrlFileHardcoreEnabled", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.ChbImageUrlHardcore.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.ChbImageUrlHardcore.ForeColor = System.Drawing.Color.Black
+		Me.ChbImageUrlHardcore.Location = New System.Drawing.Point(3, 3)
+		Me.ChbImageUrlHardcore.Name = "ChbImageUrlHardcore"
+		Me.ChbImageUrlHardcore.Size = New System.Drawing.Size(70, 23)
+		Me.ChbImageUrlHardcore.TabIndex = 0
+		Me.ChbImageUrlHardcore.Text = "Hardcore"
+		Me.ChbImageUrlHardcore.UseVisualStyleBackColor = True
+		'
+		'ChbImageUrlButts
+		'
+		Me.ChbImageUrlButts.AutoSize = True
+		Me.ChbImageUrlButts.Checked = Global.Tease_AI.My.MySettings.Default.UrlFileButtEnabled
+		Me.ChbImageUrlButts.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "UrlFileButtEnabled", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.ChbImageUrlButts.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.ChbImageUrlButts.ForeColor = System.Drawing.Color.Black
+		Me.ChbImageUrlButts.Location = New System.Drawing.Point(3, 351)
+		Me.ChbImageUrlButts.Name = "ChbImageUrlButts"
+		Me.ChbImageUrlButts.Size = New System.Drawing.Size(70, 27)
+		Me.ChbImageUrlButts.TabIndex = 37
+		Me.ChbImageUrlButts.Text = "Butts"
+		Me.ChbImageUrlButts.UseVisualStyleBackColor = True
+		'
+		'ChbImageUrlMaledom
+		'
+		Me.ChbImageUrlMaledom.AutoSize = True
+		Me.ChbImageUrlMaledom.Checked = Global.Tease_AI.My.MySettings.Default.UrlFileMaledomEnabled
+		Me.ChbImageUrlMaledom.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "UrlFileMaledomEnabled", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.ChbImageUrlMaledom.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.ChbImageUrlMaledom.ForeColor = System.Drawing.Color.Black
+		Me.ChbImageUrlMaledom.Location = New System.Drawing.Point(3, 235)
+		Me.ChbImageUrlMaledom.Name = "ChbImageUrlMaledom"
+		Me.ChbImageUrlMaledom.Size = New System.Drawing.Size(70, 23)
+		Me.ChbImageUrlMaledom.TabIndex = 25
+		Me.ChbImageUrlMaledom.Text = "Maledom"
+		Me.ChbImageUrlMaledom.UseVisualStyleBackColor = True
+		'
+		'ChbImageUrlGay
+		'
+		Me.ChbImageUrlGay.AutoSize = True
+		Me.ChbImageUrlGay.Checked = Global.Tease_AI.My.MySettings.Default.UrlFileGayEnabled
+		Me.ChbImageUrlGay.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "UrlFileGayEnabled", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.ChbImageUrlGay.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.ChbImageUrlGay.ForeColor = System.Drawing.Color.Black
+		Me.ChbImageUrlGay.Location = New System.Drawing.Point(3, 206)
+		Me.ChbImageUrlGay.Name = "ChbImageUrlGay"
+		Me.ChbImageUrlGay.Size = New System.Drawing.Size(70, 23)
+		Me.ChbImageUrlGay.TabIndex = 22
+		Me.ChbImageUrlGay.Text = "Gay"
+		Me.ChbImageUrlGay.UseVisualStyleBackColor = True
+		'
+		'ChbImageUrlSoftcore
+		'
+		Me.ChbImageUrlSoftcore.AutoSize = True
+		Me.ChbImageUrlSoftcore.Checked = Global.Tease_AI.My.MySettings.Default.UrlFileSoftcoreEnabled
+		Me.ChbImageUrlSoftcore.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "UrlFileSoftcoreEnabled", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.ChbImageUrlSoftcore.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.ChbImageUrlSoftcore.ForeColor = System.Drawing.Color.Black
+		Me.ChbImageUrlSoftcore.Location = New System.Drawing.Point(3, 32)
+		Me.ChbImageUrlSoftcore.Name = "ChbImageUrlSoftcore"
+		Me.ChbImageUrlSoftcore.Size = New System.Drawing.Size(70, 23)
+		Me.ChbImageUrlSoftcore.TabIndex = 4
+		Me.ChbImageUrlSoftcore.Text = "Softcore"
+		Me.ChbImageUrlSoftcore.UseVisualStyleBackColor = True
+		'
+		'ChbImageUrlBoobs
+		'
+		Me.ChbImageUrlBoobs.AutoSize = True
+		Me.ChbImageUrlBoobs.Checked = Global.Tease_AI.My.MySettings.Default.UrlFileBoobsEnabled
+		Me.ChbImageUrlBoobs.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "UrlFileBoobsEnabled", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.ChbImageUrlBoobs.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.ChbImageUrlBoobs.ForeColor = System.Drawing.Color.Black
+		Me.ChbImageUrlBoobs.Location = New System.Drawing.Point(3, 322)
+		Me.ChbImageUrlBoobs.Name = "ChbImageUrlBoobs"
+		Me.ChbImageUrlBoobs.Size = New System.Drawing.Size(70, 23)
+		Me.ChbImageUrlBoobs.TabIndex = 34
+		Me.ChbImageUrlBoobs.Text = "Boobs"
+		Me.ChbImageUrlBoobs.UseVisualStyleBackColor = True
+		'
+		'ChbImageUrlLesbian
+		'
+		Me.ChbImageUrlLesbian.AutoSize = True
+		Me.ChbImageUrlLesbian.Checked = Global.Tease_AI.My.MySettings.Default.UrlFileLesbianEnabled
+		Me.ChbImageUrlLesbian.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "UrlFileLesbianEnabled", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.ChbImageUrlLesbian.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.ChbImageUrlLesbian.ForeColor = System.Drawing.Color.Black
+		Me.ChbImageUrlLesbian.Location = New System.Drawing.Point(3, 61)
+		Me.ChbImageUrlLesbian.Name = "ChbImageUrlLesbian"
+		Me.ChbImageUrlLesbian.Size = New System.Drawing.Size(70, 23)
+		Me.ChbImageUrlLesbian.TabIndex = 7
+		Me.ChbImageUrlLesbian.Text = "Lesbian"
+		Me.ChbImageUrlLesbian.UseVisualStyleBackColor = True
+		'
+		'ChbImageUrlBlowjob
+		'
+		Me.ChbImageUrlBlowjob.AutoSize = True
+		Me.ChbImageUrlBlowjob.Checked = Global.Tease_AI.My.MySettings.Default.UrlFileBlowjobEnabled
+		Me.ChbImageUrlBlowjob.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "UrlFileBlowjobEnabled", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.ChbImageUrlBlowjob.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.ChbImageUrlBlowjob.ForeColor = System.Drawing.Color.Black
+		Me.ChbImageUrlBlowjob.Location = New System.Drawing.Point(3, 90)
+		Me.ChbImageUrlBlowjob.Name = "ChbImageUrlBlowjob"
+		Me.ChbImageUrlBlowjob.Size = New System.Drawing.Size(70, 23)
+		Me.ChbImageUrlBlowjob.TabIndex = 10
+		Me.ChbImageUrlBlowjob.Text = "Blowjob"
+		Me.ChbImageUrlBlowjob.UseVisualStyleBackColor = True
+		'
+		'ChbImageUrlCaptions
+		'
+		Me.ChbImageUrlCaptions.AutoSize = True
+		Me.ChbImageUrlCaptions.Checked = Global.Tease_AI.My.MySettings.Default.UrlFileCaptionsEnabled
+		Me.ChbImageUrlCaptions.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "UrlFileCaptionsEnabled", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.ChbImageUrlCaptions.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.ChbImageUrlCaptions.ForeColor = System.Drawing.Color.Black
+		Me.ChbImageUrlCaptions.Location = New System.Drawing.Point(3, 264)
+		Me.ChbImageUrlCaptions.Name = "ChbImageUrlCaptions"
+		Me.ChbImageUrlCaptions.Size = New System.Drawing.Size(70, 23)
+		Me.ChbImageUrlCaptions.TabIndex = 28
+		Me.ChbImageUrlCaptions.Text = "Captions"
+		Me.ChbImageUrlCaptions.UseVisualStyleBackColor = True
+		'
+		'ChbImageUrlGeneral
+		'
+		Me.ChbImageUrlGeneral.AutoSize = True
+		Me.ChbImageUrlGeneral.Checked = Global.Tease_AI.My.MySettings.Default.UrlFileGeneralEnabled
+		Me.ChbImageUrlGeneral.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "UrlFileGeneralEnabled", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.ChbImageUrlGeneral.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.ChbImageUrlGeneral.ForeColor = System.Drawing.Color.Black
+		Me.ChbImageUrlGeneral.Location = New System.Drawing.Point(3, 293)
+		Me.ChbImageUrlGeneral.Name = "ChbImageUrlGeneral"
+		Me.ChbImageUrlGeneral.Size = New System.Drawing.Size(70, 23)
+		Me.ChbImageUrlGeneral.TabIndex = 31
+		Me.ChbImageUrlGeneral.Text = "General"
+		Me.ChbImageUrlGeneral.UseVisualStyleBackColor = True
+		'
+		'ChbImageUrlFemdom
+		'
+		Me.ChbImageUrlFemdom.AutoSize = True
+		Me.ChbImageUrlFemdom.Checked = Global.Tease_AI.My.MySettings.Default.UrlFileFemdomEnabled
+		Me.ChbImageUrlFemdom.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "UrlFileFemdomEnabled", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.ChbImageUrlFemdom.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.ChbImageUrlFemdom.ForeColor = System.Drawing.Color.Black
+		Me.ChbImageUrlFemdom.Location = New System.Drawing.Point(3, 119)
+		Me.ChbImageUrlFemdom.Name = "ChbImageUrlFemdom"
+		Me.ChbImageUrlFemdom.Size = New System.Drawing.Size(70, 23)
+		Me.ChbImageUrlFemdom.TabIndex = 13
+		Me.ChbImageUrlFemdom.Text = "Femdom"
+		Me.ChbImageUrlFemdom.UseVisualStyleBackColor = True
+		'
+		'ChbImageUrlHentai
+		'
+		Me.ChbImageUrlHentai.AutoSize = True
+		Me.ChbImageUrlHentai.Checked = Global.Tease_AI.My.MySettings.Default.UrlFileHentaiEnabled
+		Me.ChbImageUrlHentai.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "UrlFileHentaiEnabled", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.ChbImageUrlHentai.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.ChbImageUrlHentai.ForeColor = System.Drawing.Color.Black
+		Me.ChbImageUrlHentai.Location = New System.Drawing.Point(3, 177)
+		Me.ChbImageUrlHentai.Name = "ChbImageUrlHentai"
+		Me.ChbImageUrlHentai.Size = New System.Drawing.Size(70, 23)
+		Me.ChbImageUrlHentai.TabIndex = 19
+		Me.ChbImageUrlHentai.Text = "Hentai"
+		Me.ChbImageUrlHentai.UseVisualStyleBackColor = True
+		'
+		'ChbImageUrlLezdom
+		'
+		Me.ChbImageUrlLezdom.AutoSize = True
+		Me.ChbImageUrlLezdom.Checked = Global.Tease_AI.My.MySettings.Default.UrlFileLezdomEnabled
+		Me.ChbImageUrlLezdom.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "UrlFileLezdomEnabled", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.ChbImageUrlLezdom.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.ChbImageUrlLezdom.ForeColor = System.Drawing.Color.Black
+		Me.ChbImageUrlLezdom.Location = New System.Drawing.Point(3, 148)
+		Me.ChbImageUrlLezdom.Name = "ChbImageUrlLezdom"
+		Me.ChbImageUrlLezdom.Size = New System.Drawing.Size(70, 23)
+		Me.ChbImageUrlLezdom.TabIndex = 16
+		Me.ChbImageUrlLezdom.Text = "Lezdom"
+		Me.ChbImageUrlLezdom.UseVisualStyleBackColor = True
+		'
+		'TxbImageUrlBlowjob
+		'
+		Me.TxbImageUrlBlowjob.BackColor = System.Drawing.Color.LightGray
+		Me.TxbImageUrlBlowjob.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+		Me.TxbImageUrlBlowjob.DataBindings.Add(New System.Windows.Forms.Binding("Text", Global.Tease_AI.My.MySettings.Default, "UrlFileBlowjob", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.TxbImageUrlBlowjob.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.TxbImageUrlBlowjob.Location = New System.Drawing.Point(115, 92)
+		Me.TxbImageUrlBlowjob.Margin = New System.Windows.Forms.Padding(5, 5, 8, 3)
+		Me.TxbImageUrlBlowjob.Name = "TxbImageUrlBlowjob"
+		Me.TxbImageUrlBlowjob.ReadOnly = True
+		Me.TxbImageUrlBlowjob.Size = New System.Drawing.Size(182, 20)
+		Me.TxbImageUrlBlowjob.TabIndex = 12
+		Me.TxbImageUrlBlowjob.Text = Global.Tease_AI.My.MySettings.Default.UrlFileBlowjob
+		'
+		'TxbImageUrlSoftcore
+		'
+		Me.TxbImageUrlSoftcore.BackColor = System.Drawing.Color.LightGray
+		Me.TxbImageUrlSoftcore.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+		Me.TxbImageUrlSoftcore.DataBindings.Add(New System.Windows.Forms.Binding("Text", Global.Tease_AI.My.MySettings.Default, "UrlFileSoftcore", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.TxbImageUrlSoftcore.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.TxbImageUrlSoftcore.Location = New System.Drawing.Point(115, 34)
+		Me.TxbImageUrlSoftcore.Margin = New System.Windows.Forms.Padding(5, 5, 8, 3)
+		Me.TxbImageUrlSoftcore.Name = "TxbImageUrlSoftcore"
+		Me.TxbImageUrlSoftcore.ReadOnly = True
+		Me.TxbImageUrlSoftcore.Size = New System.Drawing.Size(182, 20)
+		Me.TxbImageUrlSoftcore.TabIndex = 6
+		Me.TxbImageUrlSoftcore.Text = Global.Tease_AI.My.MySettings.Default.UrlFileSoftcore
+		'
+		'TxbImageUrlLezdom
+		'
+		Me.TxbImageUrlLezdom.BackColor = System.Drawing.Color.LightGray
+		Me.TxbImageUrlLezdom.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+		Me.TxbImageUrlLezdom.DataBindings.Add(New System.Windows.Forms.Binding("Text", Global.Tease_AI.My.MySettings.Default, "UrlFileLezdom", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.TxbImageUrlLezdom.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.TxbImageUrlLezdom.Location = New System.Drawing.Point(115, 150)
+		Me.TxbImageUrlLezdom.Margin = New System.Windows.Forms.Padding(5, 5, 8, 3)
+		Me.TxbImageUrlLezdom.Name = "TxbImageUrlLezdom"
+		Me.TxbImageUrlLezdom.ReadOnly = True
+		Me.TxbImageUrlLezdom.Size = New System.Drawing.Size(182, 20)
+		Me.TxbImageUrlLezdom.TabIndex = 18
+		Me.TxbImageUrlLezdom.Text = Global.Tease_AI.My.MySettings.Default.UrlFileLezdom
+		'
+		'TxbImageUrlFemdom
+		'
+		Me.TxbImageUrlFemdom.BackColor = System.Drawing.Color.LightGray
+		Me.TxbImageUrlFemdom.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+		Me.TxbImageUrlFemdom.DataBindings.Add(New System.Windows.Forms.Binding("Text", Global.Tease_AI.My.MySettings.Default, "UrlFileFemdom", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.TxbImageUrlFemdom.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.TxbImageUrlFemdom.Location = New System.Drawing.Point(115, 121)
+		Me.TxbImageUrlFemdom.Margin = New System.Windows.Forms.Padding(5, 5, 8, 3)
+		Me.TxbImageUrlFemdom.Name = "TxbImageUrlFemdom"
+		Me.TxbImageUrlFemdom.ReadOnly = True
+		Me.TxbImageUrlFemdom.Size = New System.Drawing.Size(182, 20)
+		Me.TxbImageUrlFemdom.TabIndex = 15
+		Me.TxbImageUrlFemdom.Text = Global.Tease_AI.My.MySettings.Default.UrlFileFemdom
+		'
+		'TxbImageUrlHardcore
+		'
+		Me.TxbImageUrlHardcore.BackColor = System.Drawing.Color.LightGray
+		Me.TxbImageUrlHardcore.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+		Me.TxbImageUrlHardcore.DataBindings.Add(New System.Windows.Forms.Binding("Text", Global.Tease_AI.My.MySettings.Default, "UrlFileHardcore", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.TxbImageUrlHardcore.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.TxbImageUrlHardcore.Location = New System.Drawing.Point(115, 5)
+		Me.TxbImageUrlHardcore.Margin = New System.Windows.Forms.Padding(5, 5, 8, 3)
+		Me.TxbImageUrlHardcore.Name = "TxbImageUrlHardcore"
+		Me.TxbImageUrlHardcore.ReadOnly = True
+		Me.TxbImageUrlHardcore.Size = New System.Drawing.Size(182, 20)
+		Me.TxbImageUrlHardcore.TabIndex = 3
+		Me.TxbImageUrlHardcore.Text = Global.Tease_AI.My.MySettings.Default.UrlFileHardcore
+		'
+		'TxbImageUrlHentai
+		'
+		Me.TxbImageUrlHentai.BackColor = System.Drawing.Color.LightGray
+		Me.TxbImageUrlHentai.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+		Me.TxbImageUrlHentai.DataBindings.Add(New System.Windows.Forms.Binding("Text", Global.Tease_AI.My.MySettings.Default, "UrlFileHentai", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.TxbImageUrlHentai.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.TxbImageUrlHentai.Location = New System.Drawing.Point(115, 179)
+		Me.TxbImageUrlHentai.Margin = New System.Windows.Forms.Padding(5, 5, 8, 3)
+		Me.TxbImageUrlHentai.Name = "TxbImageUrlHentai"
+		Me.TxbImageUrlHentai.ReadOnly = True
+		Me.TxbImageUrlHentai.Size = New System.Drawing.Size(182, 20)
+		Me.TxbImageUrlHentai.TabIndex = 21
+		Me.TxbImageUrlHentai.Text = Global.Tease_AI.My.MySettings.Default.UrlFileHentai
+		'
+		'TxbImageUrlGay
+		'
+		Me.TxbImageUrlGay.BackColor = System.Drawing.Color.LightGray
+		Me.TxbImageUrlGay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+		Me.TxbImageUrlGay.DataBindings.Add(New System.Windows.Forms.Binding("Text", Global.Tease_AI.My.MySettings.Default, "UrlFileGay", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.TxbImageUrlGay.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.TxbImageUrlGay.Location = New System.Drawing.Point(115, 208)
+		Me.TxbImageUrlGay.Margin = New System.Windows.Forms.Padding(5, 5, 8, 3)
+		Me.TxbImageUrlGay.Name = "TxbImageUrlGay"
+		Me.TxbImageUrlGay.ReadOnly = True
+		Me.TxbImageUrlGay.Size = New System.Drawing.Size(182, 20)
+		Me.TxbImageUrlGay.TabIndex = 24
+		Me.TxbImageUrlGay.Text = Global.Tease_AI.My.MySettings.Default.UrlFileGay
+		'
+		'TxbImageUrlLesbian
+		'
+		Me.TxbImageUrlLesbian.BackColor = System.Drawing.Color.LightGray
+		Me.TxbImageUrlLesbian.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+		Me.TxbImageUrlLesbian.DataBindings.Add(New System.Windows.Forms.Binding("Text", Global.Tease_AI.My.MySettings.Default, "UrlFileLesbian", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.TxbImageUrlLesbian.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.TxbImageUrlLesbian.Location = New System.Drawing.Point(115, 63)
+		Me.TxbImageUrlLesbian.Margin = New System.Windows.Forms.Padding(5, 5, 8, 3)
+		Me.TxbImageUrlLesbian.Name = "TxbImageUrlLesbian"
+		Me.TxbImageUrlLesbian.ReadOnly = True
+		Me.TxbImageUrlLesbian.Size = New System.Drawing.Size(182, 20)
+		Me.TxbImageUrlLesbian.TabIndex = 9
+		Me.TxbImageUrlLesbian.Text = Global.Tease_AI.My.MySettings.Default.UrlFileLesbian
+		'
+		'TxbImageUrlMaledom
+		'
+		Me.TxbImageUrlMaledom.BackColor = System.Drawing.Color.LightGray
+		Me.TxbImageUrlMaledom.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+		Me.TxbImageUrlMaledom.DataBindings.Add(New System.Windows.Forms.Binding("Text", Global.Tease_AI.My.MySettings.Default, "UrlFileMaledom", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.TxbImageUrlMaledom.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.TxbImageUrlMaledom.Location = New System.Drawing.Point(115, 237)
+		Me.TxbImageUrlMaledom.Margin = New System.Windows.Forms.Padding(5, 5, 8, 3)
+		Me.TxbImageUrlMaledom.Name = "TxbImageUrlMaledom"
+		Me.TxbImageUrlMaledom.ReadOnly = True
+		Me.TxbImageUrlMaledom.Size = New System.Drawing.Size(182, 20)
+		Me.TxbImageUrlMaledom.TabIndex = 27
+		Me.TxbImageUrlMaledom.Text = Global.Tease_AI.My.MySettings.Default.UrlFileMaledom
+		'
+		'TxbImageUrlCaptions
+		'
+		Me.TxbImageUrlCaptions.BackColor = System.Drawing.Color.LightGray
+		Me.TxbImageUrlCaptions.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+		Me.TxbImageUrlCaptions.DataBindings.Add(New System.Windows.Forms.Binding("Text", Global.Tease_AI.My.MySettings.Default, "UrlFileCaptions", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.TxbImageUrlCaptions.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.TxbImageUrlCaptions.Location = New System.Drawing.Point(115, 266)
+		Me.TxbImageUrlCaptions.Margin = New System.Windows.Forms.Padding(5, 5, 8, 3)
+		Me.TxbImageUrlCaptions.Name = "TxbImageUrlCaptions"
+		Me.TxbImageUrlCaptions.ReadOnly = True
+		Me.TxbImageUrlCaptions.Size = New System.Drawing.Size(182, 20)
+		Me.TxbImageUrlCaptions.TabIndex = 30
+		Me.TxbImageUrlCaptions.Text = Global.Tease_AI.My.MySettings.Default.UrlFileCaptions
+		'
+		'TxbImageUrlGeneral
+		'
+		Me.TxbImageUrlGeneral.BackColor = System.Drawing.Color.LightGray
+		Me.TxbImageUrlGeneral.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+		Me.TxbImageUrlGeneral.DataBindings.Add(New System.Windows.Forms.Binding("Text", Global.Tease_AI.My.MySettings.Default, "UrlFileGeneral", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.TxbImageUrlGeneral.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.TxbImageUrlGeneral.Location = New System.Drawing.Point(115, 295)
+		Me.TxbImageUrlGeneral.Margin = New System.Windows.Forms.Padding(5, 5, 8, 3)
+		Me.TxbImageUrlGeneral.Name = "TxbImageUrlGeneral"
+		Me.TxbImageUrlGeneral.ReadOnly = True
+		Me.TxbImageUrlGeneral.Size = New System.Drawing.Size(182, 20)
+		Me.TxbImageUrlGeneral.TabIndex = 33
+		Me.TxbImageUrlGeneral.Text = Global.Tease_AI.My.MySettings.Default.UrlFileGeneral
+		'
+		'TxbImageUrlBoobs
+		'
+		Me.TxbImageUrlBoobs.BackColor = System.Drawing.Color.LightGray
+		Me.TxbImageUrlBoobs.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+		Me.TxbImageUrlBoobs.DataBindings.Add(New System.Windows.Forms.Binding("Text", Global.Tease_AI.My.MySettings.Default, "UrlFileBoobs", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.TxbImageUrlBoobs.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.TxbImageUrlBoobs.Location = New System.Drawing.Point(115, 324)
+		Me.TxbImageUrlBoobs.Margin = New System.Windows.Forms.Padding(5, 5, 8, 3)
+		Me.TxbImageUrlBoobs.Name = "TxbImageUrlBoobs"
+		Me.TxbImageUrlBoobs.ReadOnly = True
+		Me.TxbImageUrlBoobs.Size = New System.Drawing.Size(182, 20)
+		Me.TxbImageUrlBoobs.TabIndex = 36
+		Me.TxbImageUrlBoobs.Text = Global.Tease_AI.My.MySettings.Default.UrlFileBoobs
+		'
+		'TxbImageUrlButts
+		'
+		Me.TxbImageUrlButts.BackColor = System.Drawing.Color.LightGray
+		Me.TxbImageUrlButts.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+		Me.TxbImageUrlButts.DataBindings.Add(New System.Windows.Forms.Binding("Text", Global.Tease_AI.My.MySettings.Default, "UrlFileButt", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.TxbImageUrlButts.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.TxbImageUrlButts.Location = New System.Drawing.Point(115, 353)
+		Me.TxbImageUrlButts.Margin = New System.Windows.Forms.Padding(5, 5, 8, 3)
+		Me.TxbImageUrlButts.Name = "TxbImageUrlButts"
+		Me.TxbImageUrlButts.ReadOnly = True
+		Me.TxbImageUrlButts.Size = New System.Drawing.Size(182, 20)
+		Me.TxbImageUrlButts.TabIndex = 39
+		Me.TxbImageUrlButts.Text = Global.Tease_AI.My.MySettings.Default.UrlFileButt
 		'
 		'GroupBox14
 		'
@@ -5174,46 +5286,46 @@ Partial Class FrmSettings
 		Me.GroupBox14.Name = "GroupBox14"
 		Me.GroupBox14.Size = New System.Drawing.Size(371, 400)
 		Me.GroupBox14.TabIndex = 155
-		Me.GroupBox14.TabStop = false
+		Me.GroupBox14.TabStop = False
 		Me.GroupBox14.Text = "Local Images"
 		'
 		'CBIButts
 		'
-		Me.CBIButts.AutoSize = true
+		Me.CBIButts.AutoSize = True
 		Me.CBIButts.ForeColor = System.Drawing.Color.Black
 		Me.CBIButts.Location = New System.Drawing.Point(15, 371)
 		Me.CBIButts.Name = "CBIButts"
 		Me.CBIButts.Size = New System.Drawing.Size(50, 17)
 		Me.CBIButts.TabIndex = 182
 		Me.CBIButts.Text = "Butts"
-		Me.CBIButts.UseVisualStyleBackColor = true
+		Me.CBIButts.UseVisualStyleBackColor = True
 		'
 		'CBIBoobs
 		'
-		Me.CBIBoobs.AutoSize = true
+		Me.CBIBoobs.AutoSize = True
 		Me.CBIBoobs.ForeColor = System.Drawing.Color.Black
 		Me.CBIBoobs.Location = New System.Drawing.Point(15, 342)
 		Me.CBIBoobs.Name = "CBIBoobs"
 		Me.CBIBoobs.Size = New System.Drawing.Size(56, 17)
 		Me.CBIBoobs.TabIndex = 181
 		Me.CBIBoobs.Text = "Boobs"
-		Me.CBIBoobs.UseVisualStyleBackColor = true
+		Me.CBIBoobs.UseVisualStyleBackColor = True
 		'
 		'CBButtSubDir
 		'
-		Me.CBButtSubDir.AutoSize = true
+		Me.CBButtSubDir.AutoSize = True
 		Me.CBButtSubDir.ForeColor = System.Drawing.Color.Black
 		Me.CBButtSubDir.Location = New System.Drawing.Point(347, 372)
 		Me.CBButtSubDir.Name = "CBButtSubDir"
 		Me.CBButtSubDir.Size = New System.Drawing.Size(15, 14)
 		Me.CBButtSubDir.TabIndex = 140
-		Me.CBButtSubDir.UseVisualStyleBackColor = true
+		Me.CBButtSubDir.UseVisualStyleBackColor = True
 		'
 		'LBLButtPath
 		'
 		Me.LBLButtPath.BackColor = System.Drawing.Color.Transparent
 		Me.LBLButtPath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLButtPath.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLButtPath.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLButtPath.ForeColor = System.Drawing.Color.Black
 		Me.LBLButtPath.Location = New System.Drawing.Point(122, 370)
 		Me.LBLButtPath.Name = "LBLButtPath"
@@ -5224,19 +5336,19 @@ Partial Class FrmSettings
 		'
 		'CBBoobSubDir
 		'
-		Me.CBBoobSubDir.AutoSize = true
+		Me.CBBoobSubDir.AutoSize = True
 		Me.CBBoobSubDir.ForeColor = System.Drawing.Color.Black
 		Me.CBBoobSubDir.Location = New System.Drawing.Point(347, 343)
 		Me.CBBoobSubDir.Name = "CBBoobSubDir"
 		Me.CBBoobSubDir.Size = New System.Drawing.Size(15, 14)
 		Me.CBBoobSubDir.TabIndex = 140
-		Me.CBBoobSubDir.UseVisualStyleBackColor = true
+		Me.CBBoobSubDir.UseVisualStyleBackColor = True
 		'
 		'LBLIFemdom
 		'
 		Me.LBLIFemdom.BackColor = System.Drawing.Color.Transparent
 		Me.LBLIFemdom.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLIFemdom.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLIFemdom.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLIFemdom.ForeColor = System.Drawing.Color.Black
 		Me.LBLIFemdom.Location = New System.Drawing.Point(122, 138)
 		Me.LBLIFemdom.Name = "LBLIFemdom"
@@ -5248,20 +5360,20 @@ Partial Class FrmSettings
 		'BTNButtPath
 		'
 		Me.BTNButtPath.BackColor = System.Drawing.Color.LightGray
-		Me.BTNButtPath.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNButtPath.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNButtPath.ForeColor = System.Drawing.Color.Black
 		Me.BTNButtPath.Location = New System.Drawing.Point(82, 364)
 		Me.BTNButtPath.Name = "BTNButtPath"
 		Me.BTNButtPath.Size = New System.Drawing.Size(34, 28)
 		Me.BTNButtPath.TabIndex = 131
 		Me.BTNButtPath.Text = "1"
-		Me.BTNButtPath.UseVisualStyleBackColor = false
+		Me.BTNButtPath.UseVisualStyleBackColor = False
 		'
 		'LBLBoobPath
 		'
 		Me.LBLBoobPath.BackColor = System.Drawing.Color.Transparent
 		Me.LBLBoobPath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLBoobPath.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLBoobPath.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLBoobPath.ForeColor = System.Drawing.Color.Black
 		Me.LBLBoobPath.Location = New System.Drawing.Point(122, 341)
 		Me.LBLBoobPath.Name = "LBLBoobPath"
@@ -5273,44 +5385,44 @@ Partial Class FrmSettings
 		'BTNIGeneral
 		'
 		Me.BTNIGeneral.BackColor = System.Drawing.Color.LightGray
-		Me.BTNIGeneral.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNIGeneral.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNIGeneral.ForeColor = System.Drawing.Color.Black
 		Me.BTNIGeneral.Location = New System.Drawing.Point(82, 306)
 		Me.BTNIGeneral.Name = "BTNIGeneral"
 		Me.BTNIGeneral.Size = New System.Drawing.Size(34, 28)
 		Me.BTNIGeneral.TabIndex = 166
 		Me.BTNIGeneral.Text = "1"
-		Me.BTNIGeneral.UseVisualStyleBackColor = false
+		Me.BTNIGeneral.UseVisualStyleBackColor = False
 		'
 		'CBILezdomSD
 		'
-		Me.CBILezdomSD.AutoSize = true
-		Me.CBILezdomSD.Checked = true
+		Me.CBILezdomSD.AutoSize = True
+		Me.CBILezdomSD.Checked = True
 		Me.CBILezdomSD.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBILezdomSD.ForeColor = System.Drawing.Color.Black
 		Me.CBILezdomSD.Location = New System.Drawing.Point(347, 169)
 		Me.CBILezdomSD.Name = "CBILezdomSD"
 		Me.CBILezdomSD.Size = New System.Drawing.Size(15, 14)
 		Me.CBILezdomSD.TabIndex = 172
-		Me.CBILezdomSD.UseVisualStyleBackColor = true
+		Me.CBILezdomSD.UseVisualStyleBackColor = True
 		'
 		'BTNBoobPath
 		'
 		Me.BTNBoobPath.BackColor = System.Drawing.Color.LightGray
-		Me.BTNBoobPath.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNBoobPath.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNBoobPath.ForeColor = System.Drawing.Color.Black
 		Me.BTNBoobPath.Location = New System.Drawing.Point(82, 335)
 		Me.BTNBoobPath.Name = "BTNBoobPath"
 		Me.BTNBoobPath.Size = New System.Drawing.Size(34, 28)
 		Me.BTNBoobPath.TabIndex = 131
 		Me.BTNBoobPath.Text = "1"
-		Me.BTNBoobPath.UseVisualStyleBackColor = false
+		Me.BTNBoobPath.UseVisualStyleBackColor = False
 		'
 		'LBLIHentai
 		'
 		Me.LBLIHentai.BackColor = System.Drawing.Color.Transparent
 		Me.LBLIHentai.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLIHentai.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLIHentai.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLIHentai.ForeColor = System.Drawing.Color.Black
 		Me.LBLIHentai.Location = New System.Drawing.Point(122, 196)
 		Me.LBLIHentai.Name = "LBLIHentai"
@@ -5321,159 +5433,159 @@ Partial Class FrmSettings
 		'
 		'CBILesbian
 		'
-		Me.CBILesbian.AutoSize = true
+		Me.CBILesbian.AutoSize = True
 		Me.CBILesbian.ForeColor = System.Drawing.Color.Black
 		Me.CBILesbian.Location = New System.Drawing.Point(15, 81)
 		Me.CBILesbian.Name = "CBILesbian"
 		Me.CBILesbian.Size = New System.Drawing.Size(63, 17)
 		Me.CBILesbian.TabIndex = 140
 		Me.CBILesbian.Text = "Lesbian"
-		Me.CBILesbian.UseVisualStyleBackColor = true
+		Me.CBILesbian.UseVisualStyleBackColor = True
 		'
 		'BTNICaptions
 		'
 		Me.BTNICaptions.BackColor = System.Drawing.Color.LightGray
-		Me.BTNICaptions.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNICaptions.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNICaptions.ForeColor = System.Drawing.Color.Black
 		Me.BTNICaptions.Location = New System.Drawing.Point(82, 277)
 		Me.BTNICaptions.Name = "BTNICaptions"
 		Me.BTNICaptions.Size = New System.Drawing.Size(34, 28)
 		Me.BTNICaptions.TabIndex = 178
 		Me.BTNICaptions.Text = "1"
-		Me.BTNICaptions.UseVisualStyleBackColor = false
+		Me.BTNICaptions.UseVisualStyleBackColor = False
 		'
 		'CBIBlowjob
 		'
-		Me.CBIBlowjob.AutoSize = true
+		Me.CBIBlowjob.AutoSize = True
 		Me.CBIBlowjob.ForeColor = System.Drawing.Color.Black
 		Me.CBIBlowjob.Location = New System.Drawing.Point(15, 110)
 		Me.CBIBlowjob.Name = "CBIBlowjob"
 		Me.CBIBlowjob.Size = New System.Drawing.Size(63, 17)
 		Me.CBIBlowjob.TabIndex = 141
 		Me.CBIBlowjob.Text = "Blowjob"
-		Me.CBIBlowjob.UseVisualStyleBackColor = true
+		Me.CBIBlowjob.UseVisualStyleBackColor = True
 		'
 		'BTNIMaledom
 		'
 		Me.BTNIMaledom.BackColor = System.Drawing.Color.LightGray
-		Me.BTNIMaledom.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNIMaledom.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNIMaledom.ForeColor = System.Drawing.Color.Black
 		Me.BTNIMaledom.Location = New System.Drawing.Point(82, 248)
 		Me.BTNIMaledom.Name = "BTNIMaledom"
 		Me.BTNIMaledom.Size = New System.Drawing.Size(34, 28)
 		Me.BTNIMaledom.TabIndex = 161
 		Me.BTNIMaledom.Text = "1"
-		Me.BTNIMaledom.UseVisualStyleBackColor = false
+		Me.BTNIMaledom.UseVisualStyleBackColor = False
 		'
 		'CBIFemdomSD
 		'
-		Me.CBIFemdomSD.AutoSize = true
-		Me.CBIFemdomSD.Checked = true
+		Me.CBIFemdomSD.AutoSize = True
+		Me.CBIFemdomSD.Checked = True
 		Me.CBIFemdomSD.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBIFemdomSD.ForeColor = System.Drawing.Color.Black
 		Me.CBIFemdomSD.Location = New System.Drawing.Point(347, 140)
 		Me.CBIFemdomSD.Name = "CBIFemdomSD"
 		Me.CBIFemdomSD.Size = New System.Drawing.Size(15, 14)
 		Me.CBIFemdomSD.TabIndex = 171
-		Me.CBIFemdomSD.UseVisualStyleBackColor = true
+		Me.CBIFemdomSD.UseVisualStyleBackColor = True
 		'
 		'CBIGay
 		'
-		Me.CBIGay.AutoSize = true
+		Me.CBIGay.AutoSize = True
 		Me.CBIGay.ForeColor = System.Drawing.Color.Black
 		Me.CBIGay.Location = New System.Drawing.Point(15, 226)
 		Me.CBIGay.Name = "CBIGay"
 		Me.CBIGay.Size = New System.Drawing.Size(45, 17)
 		Me.CBIGay.TabIndex = 157
 		Me.CBIGay.Text = "Gay"
-		Me.CBIGay.UseVisualStyleBackColor = true
+		Me.CBIGay.UseVisualStyleBackColor = True
 		'
 		'CBIHentaiSD
 		'
-		Me.CBIHentaiSD.AutoSize = true
-		Me.CBIHentaiSD.Checked = true
+		Me.CBIHentaiSD.AutoSize = True
+		Me.CBIHentaiSD.Checked = True
 		Me.CBIHentaiSD.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBIHentaiSD.ForeColor = System.Drawing.Color.Black
 		Me.CBIHentaiSD.Location = New System.Drawing.Point(347, 199)
 		Me.CBIHentaiSD.Name = "CBIHentaiSD"
 		Me.CBIHentaiSD.Size = New System.Drawing.Size(15, 14)
 		Me.CBIHentaiSD.TabIndex = 173
-		Me.CBIHentaiSD.UseVisualStyleBackColor = true
+		Me.CBIHentaiSD.UseVisualStyleBackColor = True
 		'
 		'BTNIGay
 		'
 		Me.BTNIGay.BackColor = System.Drawing.Color.LightGray
-		Me.BTNIGay.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNIGay.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNIGay.ForeColor = System.Drawing.Color.Black
 		Me.BTNIGay.Location = New System.Drawing.Point(82, 219)
 		Me.BTNIGay.Name = "BTNIGay"
 		Me.BTNIGay.Size = New System.Drawing.Size(34, 28)
 		Me.BTNIGay.TabIndex = 160
 		Me.BTNIGay.Text = "1"
-		Me.BTNIGay.UseVisualStyleBackColor = false
+		Me.BTNIGay.UseVisualStyleBackColor = False
 		'
 		'CBISoftcore
 		'
-		Me.CBISoftcore.AutoSize = true
+		Me.CBISoftcore.AutoSize = True
 		Me.CBISoftcore.ForeColor = System.Drawing.Color.Black
 		Me.CBISoftcore.Location = New System.Drawing.Point(15, 52)
 		Me.CBISoftcore.Name = "CBISoftcore"
 		Me.CBISoftcore.Size = New System.Drawing.Size(66, 17)
 		Me.CBISoftcore.TabIndex = 139
 		Me.CBISoftcore.Text = "Softcore"
-		Me.CBISoftcore.UseVisualStyleBackColor = true
+		Me.CBISoftcore.UseVisualStyleBackColor = True
 		'
 		'CBIHentai
 		'
-		Me.CBIHentai.AutoSize = true
+		Me.CBIHentai.AutoSize = True
 		Me.CBIHentai.ForeColor = System.Drawing.Color.Black
 		Me.CBIHentai.Location = New System.Drawing.Point(15, 197)
 		Me.CBIHentai.Name = "CBIHentai"
 		Me.CBIHentai.Size = New System.Drawing.Size(57, 17)
 		Me.CBIHentai.TabIndex = 156
 		Me.CBIHentai.Text = "Hentai"
-		Me.CBIHentai.UseVisualStyleBackColor = true
+		Me.CBIHentai.UseVisualStyleBackColor = True
 		'
 		'CBILezdom
 		'
-		Me.CBILezdom.AutoSize = true
+		Me.CBILezdom.AutoSize = True
 		Me.CBILezdom.ForeColor = System.Drawing.Color.Black
 		Me.CBILezdom.Location = New System.Drawing.Point(15, 168)
 		Me.CBILezdom.Name = "CBILezdom"
 		Me.CBILezdom.Size = New System.Drawing.Size(63, 17)
 		Me.CBILezdom.TabIndex = 143
 		Me.CBILezdom.Text = "Lezdom"
-		Me.CBILezdom.UseVisualStyleBackColor = true
+		Me.CBILezdom.UseVisualStyleBackColor = True
 		'
 		'BTNIHentai
 		'
 		Me.BTNIHentai.BackColor = System.Drawing.Color.LightGray
-		Me.BTNIHentai.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNIHentai.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNIHentai.ForeColor = System.Drawing.Color.Black
 		Me.BTNIHentai.Location = New System.Drawing.Point(82, 190)
 		Me.BTNIHentai.Name = "BTNIHentai"
 		Me.BTNIHentai.Size = New System.Drawing.Size(34, 28)
 		Me.BTNIHentai.TabIndex = 159
 		Me.BTNIHentai.Text = "1"
-		Me.BTNIHentai.UseVisualStyleBackColor = false
+		Me.BTNIHentai.UseVisualStyleBackColor = False
 		'
 		'CBIBlowjobSD
 		'
-		Me.CBIBlowjobSD.AutoSize = true
-		Me.CBIBlowjobSD.Checked = true
+		Me.CBIBlowjobSD.AutoSize = True
+		Me.CBIBlowjobSD.Checked = True
 		Me.CBIBlowjobSD.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBIBlowjobSD.ForeColor = System.Drawing.Color.Black
 		Me.CBIBlowjobSD.Location = New System.Drawing.Point(347, 111)
 		Me.CBIBlowjobSD.Name = "CBIBlowjobSD"
 		Me.CBIBlowjobSD.Size = New System.Drawing.Size(15, 14)
 		Me.CBIBlowjobSD.TabIndex = 170
-		Me.CBIBlowjobSD.UseVisualStyleBackColor = true
+		Me.CBIBlowjobSD.UseVisualStyleBackColor = True
 		'
 		'LBLILezdom
 		'
 		Me.LBLILezdom.BackColor = System.Drawing.Color.Transparent
 		Me.LBLILezdom.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLILezdom.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLILezdom.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLILezdom.ForeColor = System.Drawing.Color.Black
 		Me.LBLILezdom.Location = New System.Drawing.Point(122, 167)
 		Me.LBLILezdom.Name = "LBLILezdom"
@@ -5484,68 +5596,68 @@ Partial Class FrmSettings
 		'
 		'CBIGaySD
 		'
-		Me.CBIGaySD.AutoSize = true
-		Me.CBIGaySD.Checked = true
+		Me.CBIGaySD.AutoSize = True
+		Me.CBIGaySD.Checked = True
 		Me.CBIGaySD.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBIGaySD.ForeColor = System.Drawing.Color.Black
 		Me.CBIGaySD.Location = New System.Drawing.Point(347, 227)
 		Me.CBIGaySD.Name = "CBIGaySD"
 		Me.CBIGaySD.Size = New System.Drawing.Size(15, 14)
 		Me.CBIGaySD.TabIndex = 174
-		Me.CBIGaySD.UseVisualStyleBackColor = true
+		Me.CBIGaySD.UseVisualStyleBackColor = True
 		'
 		'BTNILezdom
 		'
 		Me.BTNILezdom.BackColor = System.Drawing.Color.LightGray
-		Me.BTNILezdom.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNILezdom.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNILezdom.ForeColor = System.Drawing.Color.Black
 		Me.BTNILezdom.Location = New System.Drawing.Point(82, 161)
 		Me.BTNILezdom.Name = "BTNILezdom"
 		Me.BTNILezdom.Size = New System.Drawing.Size(34, 28)
 		Me.BTNILezdom.TabIndex = 149
 		Me.BTNILezdom.Text = "1"
-		Me.BTNILezdom.UseVisualStyleBackColor = false
+		Me.BTNILezdom.UseVisualStyleBackColor = False
 		'
 		'CBIFemdom
 		'
-		Me.CBIFemdom.AutoSize = true
+		Me.CBIFemdom.AutoSize = True
 		Me.CBIFemdom.ForeColor = System.Drawing.Color.Black
 		Me.CBIFemdom.Location = New System.Drawing.Point(15, 139)
 		Me.CBIFemdom.Name = "CBIFemdom"
 		Me.CBIFemdom.Size = New System.Drawing.Size(66, 17)
 		Me.CBIFemdom.TabIndex = 142
 		Me.CBIFemdom.Text = "Femdom"
-		Me.CBIFemdom.UseVisualStyleBackColor = true
+		Me.CBIFemdom.UseVisualStyleBackColor = True
 		'
 		'BTNIFemdom
 		'
 		Me.BTNIFemdom.BackColor = System.Drawing.Color.LightGray
-		Me.BTNIFemdom.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNIFemdom.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNIFemdom.ForeColor = System.Drawing.Color.Black
 		Me.BTNIFemdom.Location = New System.Drawing.Point(82, 132)
 		Me.BTNIFemdom.Name = "BTNIFemdom"
 		Me.BTNIFemdom.Size = New System.Drawing.Size(34, 28)
 		Me.BTNIFemdom.TabIndex = 148
 		Me.BTNIFemdom.Text = "1"
-		Me.BTNIFemdom.UseVisualStyleBackColor = false
+		Me.BTNIFemdom.UseVisualStyleBackColor = False
 		'
 		'CBILesbianSD
 		'
-		Me.CBILesbianSD.AutoSize = true
-		Me.CBILesbianSD.Checked = true
+		Me.CBILesbianSD.AutoSize = True
+		Me.CBILesbianSD.Checked = True
 		Me.CBILesbianSD.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBILesbianSD.ForeColor = System.Drawing.Color.Black
 		Me.CBILesbianSD.Location = New System.Drawing.Point(347, 82)
 		Me.CBILesbianSD.Name = "CBILesbianSD"
 		Me.CBILesbianSD.Size = New System.Drawing.Size(15, 14)
 		Me.CBILesbianSD.TabIndex = 169
-		Me.CBILesbianSD.UseVisualStyleBackColor = true
+		Me.CBILesbianSD.UseVisualStyleBackColor = True
 		'
 		'LBLIBlowjob
 		'
 		Me.LBLIBlowjob.BackColor = System.Drawing.Color.Transparent
 		Me.LBLIBlowjob.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLIBlowjob.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLIBlowjob.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLIBlowjob.ForeColor = System.Drawing.Color.Black
 		Me.LBLIBlowjob.Location = New System.Drawing.Point(122, 109)
 		Me.LBLIBlowjob.Name = "LBLIBlowjob"
@@ -5556,45 +5668,45 @@ Partial Class FrmSettings
 		'
 		'CBIMaledomSD
 		'
-		Me.CBIMaledomSD.AutoSize = true
-		Me.CBIMaledomSD.Checked = true
+		Me.CBIMaledomSD.AutoSize = True
+		Me.CBIMaledomSD.Checked = True
 		Me.CBIMaledomSD.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBIMaledomSD.ForeColor = System.Drawing.Color.Black
 		Me.CBIMaledomSD.Location = New System.Drawing.Point(347, 256)
 		Me.CBIMaledomSD.Name = "CBIMaledomSD"
 		Me.CBIMaledomSD.Size = New System.Drawing.Size(15, 14)
 		Me.CBIMaledomSD.TabIndex = 175
-		Me.CBIMaledomSD.UseVisualStyleBackColor = true
+		Me.CBIMaledomSD.UseVisualStyleBackColor = True
 		'
 		'BTNIBlowjob
 		'
 		Me.BTNIBlowjob.BackColor = System.Drawing.Color.LightGray
-		Me.BTNIBlowjob.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNIBlowjob.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNIBlowjob.ForeColor = System.Drawing.Color.Black
 		Me.BTNIBlowjob.Location = New System.Drawing.Point(82, 103)
 		Me.BTNIBlowjob.Name = "BTNIBlowjob"
 		Me.BTNIBlowjob.Size = New System.Drawing.Size(34, 28)
 		Me.BTNIBlowjob.TabIndex = 147
 		Me.BTNIBlowjob.Text = "1"
-		Me.BTNIBlowjob.UseVisualStyleBackColor = false
+		Me.BTNIBlowjob.UseVisualStyleBackColor = False
 		'
 		'CBISoftcoreSD
 		'
-		Me.CBISoftcoreSD.AutoSize = true
-		Me.CBISoftcoreSD.Checked = true
+		Me.CBISoftcoreSD.AutoSize = True
+		Me.CBISoftcoreSD.Checked = True
 		Me.CBISoftcoreSD.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBISoftcoreSD.ForeColor = System.Drawing.Color.Black
 		Me.CBISoftcoreSD.Location = New System.Drawing.Point(347, 53)
 		Me.CBISoftcoreSD.Name = "CBISoftcoreSD"
 		Me.CBISoftcoreSD.Size = New System.Drawing.Size(15, 14)
 		Me.CBISoftcoreSD.TabIndex = 168
-		Me.CBISoftcoreSD.UseVisualStyleBackColor = true
+		Me.CBISoftcoreSD.UseVisualStyleBackColor = True
 		'
 		'LBLILesbian
 		'
 		Me.LBLILesbian.BackColor = System.Drawing.Color.Transparent
 		Me.LBLILesbian.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLILesbian.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLILesbian.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLILesbian.ForeColor = System.Drawing.Color.Black
 		Me.LBLILesbian.Location = New System.Drawing.Point(122, 80)
 		Me.LBLILesbian.Name = "LBLILesbian"
@@ -5605,44 +5717,44 @@ Partial Class FrmSettings
 		'
 		'CBICaptions
 		'
-		Me.CBICaptions.AutoSize = true
+		Me.CBICaptions.AutoSize = True
 		Me.CBICaptions.ForeColor = System.Drawing.Color.Black
 		Me.CBICaptions.Location = New System.Drawing.Point(15, 284)
 		Me.CBICaptions.Name = "CBICaptions"
 		Me.CBICaptions.Size = New System.Drawing.Size(67, 17)
 		Me.CBICaptions.TabIndex = 177
 		Me.CBICaptions.Text = "Captions"
-		Me.CBICaptions.UseVisualStyleBackColor = true
+		Me.CBICaptions.UseVisualStyleBackColor = True
 		'
 		'BTNILesbian
 		'
 		Me.BTNILesbian.BackColor = System.Drawing.Color.LightGray
-		Me.BTNILesbian.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNILesbian.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNILesbian.ForeColor = System.Drawing.Color.Black
 		Me.BTNILesbian.Location = New System.Drawing.Point(82, 74)
 		Me.BTNILesbian.Name = "BTNILesbian"
 		Me.BTNILesbian.Size = New System.Drawing.Size(34, 28)
 		Me.BTNILesbian.TabIndex = 146
 		Me.BTNILesbian.Text = "1"
-		Me.BTNILesbian.UseVisualStyleBackColor = false
+		Me.BTNILesbian.UseVisualStyleBackColor = False
 		'
 		'CBIHardcoreSD
 		'
-		Me.CBIHardcoreSD.AutoSize = true
-		Me.CBIHardcoreSD.Checked = true
+		Me.CBIHardcoreSD.AutoSize = True
+		Me.CBIHardcoreSD.Checked = True
 		Me.CBIHardcoreSD.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBIHardcoreSD.ForeColor = System.Drawing.Color.Black
 		Me.CBIHardcoreSD.Location = New System.Drawing.Point(347, 25)
 		Me.CBIHardcoreSD.Name = "CBIHardcoreSD"
 		Me.CBIHardcoreSD.Size = New System.Drawing.Size(15, 14)
 		Me.CBIHardcoreSD.TabIndex = 141
-		Me.CBIHardcoreSD.UseVisualStyleBackColor = true
+		Me.CBIHardcoreSD.UseVisualStyleBackColor = True
 		'
 		'LBLISoftcore
 		'
 		Me.LBLISoftcore.BackColor = System.Drawing.Color.Transparent
 		Me.LBLISoftcore.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLISoftcore.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLISoftcore.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLISoftcore.ForeColor = System.Drawing.Color.Black
 		Me.LBLISoftcore.Location = New System.Drawing.Point(122, 51)
 		Me.LBLISoftcore.Name = "LBLISoftcore"
@@ -5655,7 +5767,7 @@ Partial Class FrmSettings
 		'
 		Me.LBLIGeneral.BackColor = System.Drawing.Color.Transparent
 		Me.LBLIGeneral.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLIGeneral.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLIGeneral.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLIGeneral.ForeColor = System.Drawing.Color.Black
 		Me.LBLIGeneral.Location = New System.Drawing.Point(122, 312)
 		Me.LBLIGeneral.Name = "LBLIGeneral"
@@ -5667,20 +5779,20 @@ Partial Class FrmSettings
 		'BTNISoftcore
 		'
 		Me.BTNISoftcore.BackColor = System.Drawing.Color.LightGray
-		Me.BTNISoftcore.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNISoftcore.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNISoftcore.ForeColor = System.Drawing.Color.Black
 		Me.BTNISoftcore.Location = New System.Drawing.Point(82, 45)
 		Me.BTNISoftcore.Name = "BTNISoftcore"
 		Me.BTNISoftcore.Size = New System.Drawing.Size(34, 28)
 		Me.BTNISoftcore.TabIndex = 145
 		Me.BTNISoftcore.Text = "1"
-		Me.BTNISoftcore.UseVisualStyleBackColor = false
+		Me.BTNISoftcore.UseVisualStyleBackColor = False
 		'
 		'LBLICaptions
 		'
 		Me.LBLICaptions.BackColor = System.Drawing.Color.Transparent
 		Me.LBLICaptions.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLICaptions.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLICaptions.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLICaptions.ForeColor = System.Drawing.Color.Black
 		Me.LBLICaptions.Location = New System.Drawing.Point(122, 283)
 		Me.LBLICaptions.Name = "LBLICaptions"
@@ -5693,7 +5805,7 @@ Partial Class FrmSettings
 		'
 		Me.LBLIGay.BackColor = System.Drawing.Color.Transparent
 		Me.LBLIGay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLIGay.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLIGay.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLIGay.ForeColor = System.Drawing.Color.Black
 		Me.LBLIGay.Location = New System.Drawing.Point(122, 225)
 		Me.LBLIGay.Name = "LBLIGay"
@@ -5704,44 +5816,44 @@ Partial Class FrmSettings
 		'
 		'CBIGeneral
 		'
-		Me.CBIGeneral.AutoSize = true
+		Me.CBIGeneral.AutoSize = True
 		Me.CBIGeneral.ForeColor = System.Drawing.Color.Black
 		Me.CBIGeneral.Location = New System.Drawing.Point(15, 313)
 		Me.CBIGeneral.Name = "CBIGeneral"
 		Me.CBIGeneral.Size = New System.Drawing.Size(63, 17)
 		Me.CBIGeneral.TabIndex = 165
 		Me.CBIGeneral.Text = "General"
-		Me.CBIGeneral.UseVisualStyleBackColor = true
+		Me.CBIGeneral.UseVisualStyleBackColor = True
 		'
 		'BTNIHardcore
 		'
 		Me.BTNIHardcore.BackColor = System.Drawing.Color.LightGray
-		Me.BTNIHardcore.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNIHardcore.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNIHardcore.ForeColor = System.Drawing.Color.Black
 		Me.BTNIHardcore.Location = New System.Drawing.Point(82, 16)
 		Me.BTNIHardcore.Name = "BTNIHardcore"
 		Me.BTNIHardcore.Size = New System.Drawing.Size(34, 28)
 		Me.BTNIHardcore.TabIndex = 144
 		Me.BTNIHardcore.Text = "1"
-		Me.BTNIHardcore.UseVisualStyleBackColor = false
+		Me.BTNIHardcore.UseVisualStyleBackColor = False
 		'
 		'CBIGeneralSD
 		'
-		Me.CBIGeneralSD.AutoSize = true
-		Me.CBIGeneralSD.Checked = true
+		Me.CBIGeneralSD.AutoSize = True
+		Me.CBIGeneralSD.Checked = True
 		Me.CBIGeneralSD.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBIGeneralSD.ForeColor = System.Drawing.Color.Black
 		Me.CBIGeneralSD.Location = New System.Drawing.Point(347, 314)
 		Me.CBIGeneralSD.Name = "CBIGeneralSD"
 		Me.CBIGeneralSD.Size = New System.Drawing.Size(15, 14)
 		Me.CBIGeneralSD.TabIndex = 176
-		Me.CBIGeneralSD.UseVisualStyleBackColor = true
+		Me.CBIGeneralSD.UseVisualStyleBackColor = True
 		'
 		'LBLIHardcore
 		'
 		Me.LBLIHardcore.BackColor = System.Drawing.Color.Transparent
 		Me.LBLIHardcore.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLIHardcore.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLIHardcore.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLIHardcore.ForeColor = System.Drawing.Color.Black
 		Me.LBLIHardcore.Location = New System.Drawing.Point(122, 23)
 		Me.LBLIHardcore.Name = "LBLIHardcore"
@@ -5754,7 +5866,7 @@ Partial Class FrmSettings
 		'
 		Me.LBLIMaledom.BackColor = System.Drawing.Color.Transparent
 		Me.LBLIMaledom.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLIMaledom.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLIMaledom.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLIMaledom.ForeColor = System.Drawing.Color.Black
 		Me.LBLIMaledom.Location = New System.Drawing.Point(122, 254)
 		Me.LBLIMaledom.Name = "LBLIMaledom"
@@ -5765,37 +5877,37 @@ Partial Class FrmSettings
 		'
 		'CBICaptionsSD
 		'
-		Me.CBICaptionsSD.AutoSize = true
-		Me.CBICaptionsSD.Checked = true
+		Me.CBICaptionsSD.AutoSize = True
+		Me.CBICaptionsSD.Checked = True
 		Me.CBICaptionsSD.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBICaptionsSD.ForeColor = System.Drawing.Color.Black
 		Me.CBICaptionsSD.Location = New System.Drawing.Point(347, 285)
 		Me.CBICaptionsSD.Name = "CBICaptionsSD"
 		Me.CBICaptionsSD.Size = New System.Drawing.Size(15, 14)
 		Me.CBICaptionsSD.TabIndex = 180
-		Me.CBICaptionsSD.UseVisualStyleBackColor = true
+		Me.CBICaptionsSD.UseVisualStyleBackColor = True
 		'
 		'CBIHardcore
 		'
-		Me.CBIHardcore.AutoSize = true
+		Me.CBIHardcore.AutoSize = True
 		Me.CBIHardcore.ForeColor = System.Drawing.Color.Black
 		Me.CBIHardcore.Location = New System.Drawing.Point(15, 23)
 		Me.CBIHardcore.Name = "CBIHardcore"
 		Me.CBIHardcore.Size = New System.Drawing.Size(70, 17)
 		Me.CBIHardcore.TabIndex = 138
 		Me.CBIHardcore.Text = "Hardcore"
-		Me.CBIHardcore.UseVisualStyleBackColor = true
+		Me.CBIHardcore.UseVisualStyleBackColor = True
 		'
 		'CBIMaledom
 		'
-		Me.CBIMaledom.AutoSize = true
+		Me.CBIMaledom.AutoSize = True
 		Me.CBIMaledom.ForeColor = System.Drawing.Color.Black
 		Me.CBIMaledom.Location = New System.Drawing.Point(15, 255)
 		Me.CBIMaledom.Name = "CBIMaledom"
 		Me.CBIMaledom.Size = New System.Drawing.Size(69, 17)
 		Me.CBIMaledom.TabIndex = 158
 		Me.CBIMaledom.Text = "Maledom"
-		Me.CBIMaledom.UseVisualStyleBackColor = true
+		Me.CBIMaledom.UseVisualStyleBackColor = True
 		'
 		'TabPage12
 		'
@@ -5863,31 +5975,31 @@ Partial Class FrmSettings
 		'
 		'CBTagPiercing
 		'
-		Me.CBTagPiercing.AutoSize = true
-		Me.CBTagPiercing.Enabled = false
+		Me.CBTagPiercing.AutoSize = True
+		Me.CBTagPiercing.Enabled = False
 		Me.CBTagPiercing.ForeColor = System.Drawing.Color.Black
 		Me.CBTagPiercing.Location = New System.Drawing.Point(580, 211)
 		Me.CBTagPiercing.Name = "CBTagPiercing"
 		Me.CBTagPiercing.Size = New System.Drawing.Size(64, 17)
 		Me.CBTagPiercing.TabIndex = 183
 		Me.CBTagPiercing.Text = "Piercing"
-		Me.CBTagPiercing.UseVisualStyleBackColor = true
+		Me.CBTagPiercing.UseVisualStyleBackColor = True
 		'
 		'CBTagLegs
 		'
-		Me.CBTagLegs.AutoSize = true
-		Me.CBTagLegs.Enabled = false
+		Me.CBTagLegs.AutoSize = True
+		Me.CBTagLegs.Enabled = False
 		Me.CBTagLegs.ForeColor = System.Drawing.Color.Black
 		Me.CBTagLegs.Location = New System.Drawing.Point(487, 151)
 		Me.CBTagLegs.Name = "CBTagLegs"
 		Me.CBTagLegs.Size = New System.Drawing.Size(49, 17)
 		Me.CBTagLegs.TabIndex = 182
 		Me.CBTagLegs.Text = "Legs"
-		Me.CBTagLegs.UseVisualStyleBackColor = true
+		Me.CBTagLegs.UseVisualStyleBackColor = True
 		'
 		'TBTagFurniture
 		'
-		Me.TBTagFurniture.Enabled = false
+		Me.TBTagFurniture.Enabled = False
 		Me.TBTagFurniture.Location = New System.Drawing.Point(570, 334)
 		Me.TBTagFurniture.Name = "TBTagFurniture"
 		Me.TBTagFurniture.Size = New System.Drawing.Size(108, 20)
@@ -5895,19 +6007,19 @@ Partial Class FrmSettings
 		'
 		'CBTagFurniture
 		'
-		Me.CBTagFurniture.AutoSize = true
-		Me.CBTagFurniture.Enabled = false
+		Me.CBTagFurniture.AutoSize = True
+		Me.CBTagFurniture.Enabled = False
 		Me.CBTagFurniture.ForeColor = System.Drawing.Color.Black
 		Me.CBTagFurniture.Location = New System.Drawing.Point(487, 336)
 		Me.CBTagFurniture.Name = "CBTagFurniture"
 		Me.CBTagFurniture.Size = New System.Drawing.Size(67, 17)
 		Me.CBTagFurniture.TabIndex = 180
 		Me.CBTagFurniture.Text = "Furniture"
-		Me.CBTagFurniture.UseVisualStyleBackColor = true
+		Me.CBTagFurniture.UseVisualStyleBackColor = True
 		'
 		'TBTagSexToy
 		'
-		Me.TBTagSexToy.Enabled = false
+		Me.TBTagSexToy.Enabled = False
 		Me.TBTagSexToy.Location = New System.Drawing.Point(571, 310)
 		Me.TBTagSexToy.Name = "TBTagSexToy"
 		Me.TBTagSexToy.Size = New System.Drawing.Size(108, 20)
@@ -5915,19 +6027,19 @@ Partial Class FrmSettings
 		'
 		'CBTagSexToy
 		'
-		Me.CBTagSexToy.AutoSize = true
-		Me.CBTagSexToy.Enabled = false
+		Me.CBTagSexToy.AutoSize = True
+		Me.CBTagSexToy.Enabled = False
 		Me.CBTagSexToy.ForeColor = System.Drawing.Color.Black
 		Me.CBTagSexToy.Location = New System.Drawing.Point(487, 312)
 		Me.CBTagSexToy.Name = "CBTagSexToy"
 		Me.CBTagSexToy.Size = New System.Drawing.Size(65, 17)
 		Me.CBTagSexToy.TabIndex = 178
 		Me.CBTagSexToy.Text = "Sex Toy"
-		Me.CBTagSexToy.UseVisualStyleBackColor = true
+		Me.CBTagSexToy.UseVisualStyleBackColor = True
 		'
 		'TBTagTattoo
 		'
-		Me.TBTagTattoo.Enabled = false
+		Me.TBTagTattoo.Enabled = False
 		Me.TBTagTattoo.Location = New System.Drawing.Point(571, 286)
 		Me.TBTagTattoo.Name = "TBTagTattoo"
 		Me.TBTagTattoo.Size = New System.Drawing.Size(108, 20)
@@ -5935,19 +6047,19 @@ Partial Class FrmSettings
 		'
 		'CBTagTattoo
 		'
-		Me.CBTagTattoo.AutoSize = true
-		Me.CBTagTattoo.Enabled = false
+		Me.CBTagTattoo.AutoSize = True
+		Me.CBTagTattoo.Enabled = False
 		Me.CBTagTattoo.ForeColor = System.Drawing.Color.Black
 		Me.CBTagTattoo.Location = New System.Drawing.Point(487, 288)
 		Me.CBTagTattoo.Name = "CBTagTattoo"
 		Me.CBTagTattoo.Size = New System.Drawing.Size(57, 17)
 		Me.CBTagTattoo.TabIndex = 176
 		Me.CBTagTattoo.Text = "Tattoo"
-		Me.CBTagTattoo.UseVisualStyleBackColor = true
+		Me.CBTagTattoo.UseVisualStyleBackColor = True
 		'
 		'TBTagUnderwear
 		'
-		Me.TBTagUnderwear.Enabled = false
+		Me.TBTagUnderwear.Enabled = False
 		Me.TBTagUnderwear.Location = New System.Drawing.Point(571, 262)
 		Me.TBTagUnderwear.Name = "TBTagUnderwear"
 		Me.TBTagUnderwear.Size = New System.Drawing.Size(108, 20)
@@ -5955,19 +6067,19 @@ Partial Class FrmSettings
 		'
 		'CBTagUnderwear
 		'
-		Me.CBTagUnderwear.AutoSize = true
-		Me.CBTagUnderwear.Enabled = false
+		Me.CBTagUnderwear.AutoSize = True
+		Me.CBTagUnderwear.Enabled = False
 		Me.CBTagUnderwear.ForeColor = System.Drawing.Color.Black
 		Me.CBTagUnderwear.Location = New System.Drawing.Point(487, 264)
 		Me.CBTagUnderwear.Name = "CBTagUnderwear"
 		Me.CBTagUnderwear.Size = New System.Drawing.Size(78, 17)
 		Me.CBTagUnderwear.TabIndex = 174
 		Me.CBTagUnderwear.Text = "Underwear"
-		Me.CBTagUnderwear.UseVisualStyleBackColor = true
+		Me.CBTagUnderwear.UseVisualStyleBackColor = True
 		'
 		'TBTagGarment
 		'
-		Me.TBTagGarment.Enabled = false
+		Me.TBTagGarment.Enabled = False
 		Me.TBTagGarment.Location = New System.Drawing.Point(571, 238)
 		Me.TBTagGarment.Name = "TBTagGarment"
 		Me.TBTagGarment.Size = New System.Drawing.Size(108, 20)
@@ -5975,141 +6087,141 @@ Partial Class FrmSettings
 		'
 		'CBTagGarment
 		'
-		Me.CBTagGarment.AutoSize = true
-		Me.CBTagGarment.Enabled = false
+		Me.CBTagGarment.AutoSize = True
+		Me.CBTagGarment.Enabled = False
 		Me.CBTagGarment.ForeColor = System.Drawing.Color.Black
 		Me.CBTagGarment.Location = New System.Drawing.Point(487, 240)
 		Me.CBTagGarment.Name = "CBTagGarment"
 		Me.CBTagGarment.Size = New System.Drawing.Size(66, 17)
 		Me.CBTagGarment.TabIndex = 172
 		Me.CBTagGarment.Text = "Garment"
-		Me.CBTagGarment.UseVisualStyleBackColor = true
+		Me.CBTagGarment.UseVisualStyleBackColor = True
 		'
 		'Label72
 		'
 		Me.Label72.BackColor = System.Drawing.Color.Transparent
-		Me.Label72.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label72.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label72.ForeColor = System.Drawing.Color.Black
 		Me.Label72.Location = New System.Drawing.Point(8, 400)
 		Me.Label72.Name = "Label72"
 		Me.Label72.Size = New System.Drawing.Size(451, 35)
 		Me.Label72.TabIndex = 62
-		Me.Label72.Text = "Open a directory containing images. Check all tags that apply to each image displ"& _ 
-    "ayed, and enter one-word tag descriptions in the text fields when appropriate. ("& _ 
-    "e.g. Garment: dress)"
+		Me.Label72.Text = "Open a directory containing images. Check all tags that apply to each image displ" &
+	"ayed, and enter one-word tag descriptions in the text fields when appropriate. (" &
+	"e.g. Garment: dress)"
 		Me.Label72.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
 		'
 		'CBTagHandsCovering
 		'
-		Me.CBTagHandsCovering.AutoSize = true
-		Me.CBTagHandsCovering.Enabled = false
+		Me.CBTagHandsCovering.AutoSize = True
+		Me.CBTagHandsCovering.Enabled = False
 		Me.CBTagHandsCovering.Location = New System.Drawing.Point(580, 131)
 		Me.CBTagHandsCovering.Name = "CBTagHandsCovering"
 		Me.CBTagHandsCovering.Size = New System.Drawing.Size(101, 17)
 		Me.CBTagHandsCovering.TabIndex = 171
 		Me.CBTagHandsCovering.Text = "Hands Covering"
-		Me.CBTagHandsCovering.UseVisualStyleBackColor = true
+		Me.CBTagHandsCovering.UseVisualStyleBackColor = True
 		'
 		'CBTagGarmentCovering
 		'
-		Me.CBTagGarmentCovering.AutoSize = true
-		Me.CBTagGarmentCovering.Enabled = false
+		Me.CBTagGarmentCovering.AutoSize = True
+		Me.CBTagGarmentCovering.Enabled = False
 		Me.CBTagGarmentCovering.Location = New System.Drawing.Point(580, 111)
 		Me.CBTagGarmentCovering.Name = "CBTagGarmentCovering"
 		Me.CBTagGarmentCovering.Size = New System.Drawing.Size(110, 17)
 		Me.CBTagGarmentCovering.TabIndex = 170
 		Me.CBTagGarmentCovering.Text = "Garment Covering"
-		Me.CBTagGarmentCovering.UseVisualStyleBackColor = true
+		Me.CBTagGarmentCovering.UseVisualStyleBackColor = True
 		'
 		'CBTagCloseUp
 		'
-		Me.CBTagCloseUp.AutoSize = true
-		Me.CBTagCloseUp.Enabled = false
+		Me.CBTagCloseUp.AutoSize = True
+		Me.CBTagCloseUp.Enabled = False
 		Me.CBTagCloseUp.ForeColor = System.Drawing.Color.Black
 		Me.CBTagCloseUp.Location = New System.Drawing.Point(580, 191)
 		Me.CBTagCloseUp.Name = "CBTagCloseUp"
 		Me.CBTagCloseUp.Size = New System.Drawing.Size(69, 17)
 		Me.CBTagCloseUp.TabIndex = 168
 		Me.CBTagCloseUp.Text = "Close Up"
-		Me.CBTagCloseUp.UseVisualStyleBackColor = true
+		Me.CBTagCloseUp.UseVisualStyleBackColor = True
 		'
 		'CBTagNaked
 		'
-		Me.CBTagNaked.AutoSize = true
-		Me.CBTagNaked.Enabled = false
+		Me.CBTagNaked.AutoSize = True
+		Me.CBTagNaked.Enabled = False
 		Me.CBTagNaked.Location = New System.Drawing.Point(580, 151)
 		Me.CBTagNaked.Name = "CBTagNaked"
 		Me.CBTagNaked.Size = New System.Drawing.Size(57, 17)
 		Me.CBTagNaked.TabIndex = 162
 		Me.CBTagNaked.Text = "Naked"
-		Me.CBTagNaked.UseVisualStyleBackColor = true
+		Me.CBTagNaked.UseVisualStyleBackColor = True
 		'
 		'CBTagSideView
 		'
-		Me.CBTagSideView.AutoSize = true
-		Me.CBTagSideView.Enabled = false
+		Me.CBTagSideView.AutoSize = True
+		Me.CBTagSideView.Enabled = False
 		Me.CBTagSideView.ForeColor = System.Drawing.Color.Black
 		Me.CBTagSideView.Location = New System.Drawing.Point(580, 171)
 		Me.CBTagSideView.Name = "CBTagSideView"
 		Me.CBTagSideView.Size = New System.Drawing.Size(73, 17)
 		Me.CBTagSideView.TabIndex = 167
 		Me.CBTagSideView.Text = "Side View"
-		Me.CBTagSideView.UseVisualStyleBackColor = true
+		Me.CBTagSideView.UseVisualStyleBackColor = True
 		'
 		'BTNTagPrevious
 		'
 		Me.BTNTagPrevious.BackColor = System.Drawing.Color.LightGray
-		Me.BTNTagPrevious.Enabled = false
-		Me.BTNTagPrevious.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNTagPrevious.Enabled = False
+		Me.BTNTagPrevious.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNTagPrevious.ForeColor = System.Drawing.Color.Black
 		Me.BTNTagPrevious.Location = New System.Drawing.Point(487, 369)
 		Me.BTNTagPrevious.Name = "BTNTagPrevious"
 		Me.BTNTagPrevious.Size = New System.Drawing.Size(47, 24)
 		Me.BTNTagPrevious.TabIndex = 169
 		Me.BTNTagPrevious.Text = "<<"
-		Me.BTNTagPrevious.UseVisualStyleBackColor = false
+		Me.BTNTagPrevious.UseVisualStyleBackColor = False
 		'
 		'CBTagHalfDressed
 		'
-		Me.CBTagHalfDressed.AutoSize = true
-		Me.CBTagHalfDressed.Enabled = false
+		Me.CBTagHalfDressed.AutoSize = True
+		Me.CBTagHalfDressed.Enabled = False
 		Me.CBTagHalfDressed.Location = New System.Drawing.Point(580, 91)
 		Me.CBTagHalfDressed.Name = "CBTagHalfDressed"
 		Me.CBTagHalfDressed.Size = New System.Drawing.Size(86, 17)
 		Me.CBTagHalfDressed.TabIndex = 161
 		Me.CBTagHalfDressed.Text = "Half Dressed"
-		Me.CBTagHalfDressed.UseVisualStyleBackColor = true
+		Me.CBTagHalfDressed.UseVisualStyleBackColor = True
 		'
 		'BTNTagNext
 		'
 		Me.BTNTagNext.BackColor = System.Drawing.Color.LightGray
-		Me.BTNTagNext.Enabled = false
-		Me.BTNTagNext.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNTagNext.Enabled = False
+		Me.BTNTagNext.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNTagNext.ForeColor = System.Drawing.Color.Black
 		Me.BTNTagNext.Location = New System.Drawing.Point(631, 369)
 		Me.BTNTagNext.Name = "BTNTagNext"
 		Me.BTNTagNext.Size = New System.Drawing.Size(47, 24)
 		Me.BTNTagNext.TabIndex = 168
 		Me.BTNTagNext.Text = ">>"
-		Me.BTNTagNext.UseVisualStyleBackColor = false
+		Me.BTNTagNext.UseVisualStyleBackColor = False
 		'
 		'CBTagFullyDressed
 		'
-		Me.CBTagFullyDressed.AutoSize = true
-		Me.CBTagFullyDressed.Enabled = false
+		Me.CBTagFullyDressed.AutoSize = True
+		Me.CBTagFullyDressed.Enabled = False
 		Me.CBTagFullyDressed.Location = New System.Drawing.Point(580, 71)
 		Me.CBTagFullyDressed.Name = "CBTagFullyDressed"
 		Me.CBTagFullyDressed.Size = New System.Drawing.Size(88, 17)
 		Me.CBTagFullyDressed.TabIndex = 160
 		Me.CBTagFullyDressed.Text = "Fully Dressed"
-		Me.CBTagFullyDressed.UseVisualStyleBackColor = true
+		Me.CBTagFullyDressed.UseVisualStyleBackColor = True
 		'
 		'LBLTagCount
 		'
 		Me.LBLTagCount.BackColor = System.Drawing.Color.Transparent
 		Me.LBLTagCount.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLTagCount.Enabled = false
-		Me.LBLTagCount.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLTagCount.Enabled = False
+		Me.LBLTagCount.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLTagCount.ForeColor = System.Drawing.Color.Black
 		Me.LBLTagCount.Location = New System.Drawing.Point(540, 371)
 		Me.LBLTagCount.Name = "LBLTagCount"
@@ -6120,95 +6232,95 @@ Partial Class FrmSettings
 		'
 		'CBTagSucking
 		'
-		Me.CBTagSucking.AutoSize = true
-		Me.CBTagSucking.Enabled = false
+		Me.CBTagSucking.AutoSize = True
+		Me.CBTagSucking.Enabled = False
 		Me.CBTagSucking.ForeColor = System.Drawing.Color.Black
 		Me.CBTagSucking.Location = New System.Drawing.Point(487, 211)
 		Me.CBTagSucking.Name = "CBTagSucking"
 		Me.CBTagSucking.Size = New System.Drawing.Size(65, 17)
 		Me.CBTagSucking.TabIndex = 166
 		Me.CBTagSucking.Text = "Sucking"
-		Me.CBTagSucking.UseVisualStyleBackColor = true
+		Me.CBTagSucking.UseVisualStyleBackColor = True
 		'
 		'CBTagMasturbating
 		'
-		Me.CBTagMasturbating.AutoSize = true
-		Me.CBTagMasturbating.Enabled = false
+		Me.CBTagMasturbating.AutoSize = True
+		Me.CBTagMasturbating.Enabled = False
 		Me.CBTagMasturbating.ForeColor = System.Drawing.Color.Black
 		Me.CBTagMasturbating.Location = New System.Drawing.Point(487, 191)
 		Me.CBTagMasturbating.Name = "CBTagMasturbating"
 		Me.CBTagMasturbating.Size = New System.Drawing.Size(87, 17)
 		Me.CBTagMasturbating.TabIndex = 165
 		Me.CBTagMasturbating.Text = "Masturbating"
-		Me.CBTagMasturbating.UseVisualStyleBackColor = true
+		Me.CBTagMasturbating.UseVisualStyleBackColor = True
 		'
 		'CBTagFeet
 		'
-		Me.CBTagFeet.AutoSize = true
-		Me.CBTagFeet.Enabled = false
+		Me.CBTagFeet.AutoSize = True
+		Me.CBTagFeet.Enabled = False
 		Me.CBTagFeet.ForeColor = System.Drawing.Color.Black
 		Me.CBTagFeet.Location = New System.Drawing.Point(487, 171)
 		Me.CBTagFeet.Name = "CBTagFeet"
 		Me.CBTagFeet.Size = New System.Drawing.Size(47, 17)
 		Me.CBTagFeet.TabIndex = 164
 		Me.CBTagFeet.Text = "Feet"
-		Me.CBTagFeet.UseVisualStyleBackColor = true
+		Me.CBTagFeet.UseVisualStyleBackColor = True
 		'
 		'CBTagBoobs
 		'
-		Me.CBTagBoobs.AutoSize = true
-		Me.CBTagBoobs.Enabled = false
+		Me.CBTagBoobs.AutoSize = True
+		Me.CBTagBoobs.Enabled = False
 		Me.CBTagBoobs.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBoobs.Location = New System.Drawing.Point(487, 91)
 		Me.CBTagBoobs.Name = "CBTagBoobs"
 		Me.CBTagBoobs.Size = New System.Drawing.Size(56, 17)
 		Me.CBTagBoobs.TabIndex = 159
 		Me.CBTagBoobs.Text = "Boobs"
-		Me.CBTagBoobs.UseVisualStyleBackColor = true
+		Me.CBTagBoobs.UseVisualStyleBackColor = True
 		'
 		'CBTagAss
 		'
-		Me.CBTagAss.AutoSize = true
-		Me.CBTagAss.Enabled = false
+		Me.CBTagAss.AutoSize = True
+		Me.CBTagAss.Enabled = False
 		Me.CBTagAss.ForeColor = System.Drawing.Color.Black
 		Me.CBTagAss.Location = New System.Drawing.Point(487, 131)
 		Me.CBTagAss.Name = "CBTagAss"
 		Me.CBTagAss.Size = New System.Drawing.Size(43, 17)
 		Me.CBTagAss.TabIndex = 158
 		Me.CBTagAss.Text = "Ass"
-		Me.CBTagAss.UseVisualStyleBackColor = true
+		Me.CBTagAss.UseVisualStyleBackColor = True
 		'
 		'CBTagPussy
 		'
-		Me.CBTagPussy.AutoSize = true
-		Me.CBTagPussy.Enabled = false
+		Me.CBTagPussy.AutoSize = True
+		Me.CBTagPussy.Enabled = False
 		Me.CBTagPussy.ForeColor = System.Drawing.Color.Black
 		Me.CBTagPussy.Location = New System.Drawing.Point(487, 111)
 		Me.CBTagPussy.Name = "CBTagPussy"
 		Me.CBTagPussy.Size = New System.Drawing.Size(54, 17)
 		Me.CBTagPussy.TabIndex = 157
 		Me.CBTagPussy.Text = "Pussy"
-		Me.CBTagPussy.UseVisualStyleBackColor = true
+		Me.CBTagPussy.UseVisualStyleBackColor = True
 		'
 		'BTNTagSave
 		'
-		Me.BTNTagSave.Enabled = false
+		Me.BTNTagSave.Enabled = False
 		Me.BTNTagSave.Location = New System.Drawing.Point(487, 400)
 		Me.BTNTagSave.Name = "BTNTagSave"
 		Me.BTNTagSave.Size = New System.Drawing.Size(192, 23)
 		Me.BTNTagSave.TabIndex = 156
 		Me.BTNTagSave.Text = "Finished"
-		Me.BTNTagSave.UseVisualStyleBackColor = true
+		Me.BTNTagSave.UseVisualStyleBackColor = True
 		'
 		'BTNTagDir
 		'
-		Me.BTNTagDir.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNTagDir.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNTagDir.Location = New System.Drawing.Point(487, 39)
 		Me.BTNTagDir.Name = "BTNTagDir"
 		Me.BTNTagDir.Size = New System.Drawing.Size(43, 23)
 		Me.BTNTagDir.TabIndex = 155
 		Me.BTNTagDir.Text = "1"
-		Me.BTNTagDir.UseVisualStyleBackColor = true
+		Me.BTNTagDir.UseVisualStyleBackColor = True
 		'
 		'ImageTagPictureBox
 		'
@@ -6218,35 +6330,35 @@ Partial Class FrmSettings
 		Me.ImageTagPictureBox.Size = New System.Drawing.Size(451, 358)
 		Me.ImageTagPictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
 		Me.ImageTagPictureBox.TabIndex = 154
-		Me.ImageTagPictureBox.TabStop = false
+		Me.ImageTagPictureBox.TabStop = False
 		'
 		'CBTagFace
 		'
-		Me.CBTagFace.AutoSize = true
-		Me.CBTagFace.Enabled = false
+		Me.CBTagFace.AutoSize = True
+		Me.CBTagFace.Enabled = False
 		Me.CBTagFace.ForeColor = System.Drawing.Color.Black
 		Me.CBTagFace.Location = New System.Drawing.Point(487, 71)
 		Me.CBTagFace.Name = "CBTagFace"
 		Me.CBTagFace.Size = New System.Drawing.Size(50, 17)
 		Me.CBTagFace.TabIndex = 153
 		Me.CBTagFace.Text = "Face"
-		Me.CBTagFace.UseVisualStyleBackColor = true
+		Me.CBTagFace.UseVisualStyleBackColor = True
 		'
 		'PictureBox14
 		'
 		Me.PictureBox14.BackColor = System.Drawing.Color.LightGray
-		Me.PictureBox14.Image = CType(resources.GetObject("PictureBox14.Image"),System.Drawing.Image)
+		Me.PictureBox14.Image = CType(resources.GetObject("PictureBox14.Image"), System.Drawing.Image)
 		Me.PictureBox14.Location = New System.Drawing.Point(9, 6)
 		Me.PictureBox14.Name = "PictureBox14"
 		Me.PictureBox14.Size = New System.Drawing.Size(160, 19)
 		Me.PictureBox14.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage
 		Me.PictureBox14.TabIndex = 151
-		Me.PictureBox14.TabStop = false
+		Me.PictureBox14.TabStop = False
 		'
 		'Label87
 		'
 		Me.Label87.BackColor = System.Drawing.Color.Transparent
-		Me.Label87.Font = New System.Drawing.Font("Microsoft Sans Serif", 12!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label87.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label87.ForeColor = System.Drawing.Color.Black
 		Me.Label87.Location = New System.Drawing.Point(7, 6)
 		Me.Label87.Name = "Label87"
@@ -6301,68 +6413,68 @@ Partial Class FrmSettings
 		Me.GroupBox55.Name = "GroupBox55"
 		Me.GroupBox55.Size = New System.Drawing.Size(103, 118)
 		Me.GroupBox55.TabIndex = 227
-		Me.GroupBox55.TabStop = false
+		Me.GroupBox55.TabStop = False
 		Me.GroupBox55.Text = "Outfit"
 		'
 		'CBTagNurse
 		'
-		Me.CBTagNurse.AutoSize = true
-		Me.CBTagNurse.Enabled = false
+		Me.CBTagNurse.AutoSize = True
+		Me.CBTagNurse.Enabled = False
 		Me.CBTagNurse.ForeColor = System.Drawing.Color.Black
 		Me.CBTagNurse.Location = New System.Drawing.Point(15, 17)
 		Me.CBTagNurse.Name = "CBTagNurse"
 		Me.CBTagNurse.Size = New System.Drawing.Size(54, 17)
 		Me.CBTagNurse.TabIndex = 203
 		Me.CBTagNurse.Text = "Nurse"
-		Me.CBTagNurse.UseVisualStyleBackColor = true
+		Me.CBTagNurse.UseVisualStyleBackColor = True
 		'
 		'CBTagSchoolgirl
 		'
-		Me.CBTagSchoolgirl.AutoSize = true
-		Me.CBTagSchoolgirl.Enabled = false
+		Me.CBTagSchoolgirl.AutoSize = True
+		Me.CBTagSchoolgirl.Enabled = False
 		Me.CBTagSchoolgirl.ForeColor = System.Drawing.Color.Black
 		Me.CBTagSchoolgirl.Location = New System.Drawing.Point(15, 57)
 		Me.CBTagSchoolgirl.Name = "CBTagSchoolgirl"
 		Me.CBTagSchoolgirl.Size = New System.Drawing.Size(72, 17)
 		Me.CBTagSchoolgirl.TabIndex = 204
 		Me.CBTagSchoolgirl.Text = "Schoolgirl"
-		Me.CBTagSchoolgirl.UseVisualStyleBackColor = true
+		Me.CBTagSchoolgirl.UseVisualStyleBackColor = True
 		'
 		'CBTagMaid
 		'
-		Me.CBTagMaid.AutoSize = true
-		Me.CBTagMaid.Enabled = false
+		Me.CBTagMaid.AutoSize = True
+		Me.CBTagMaid.Enabled = False
 		Me.CBTagMaid.ForeColor = System.Drawing.Color.Black
 		Me.CBTagMaid.Location = New System.Drawing.Point(15, 77)
 		Me.CBTagMaid.Name = "CBTagMaid"
 		Me.CBTagMaid.Size = New System.Drawing.Size(49, 17)
 		Me.CBTagMaid.TabIndex = 205
 		Me.CBTagMaid.Text = "Maid"
-		Me.CBTagMaid.UseVisualStyleBackColor = true
+		Me.CBTagMaid.UseVisualStyleBackColor = True
 		'
 		'CBTagTeacher
 		'
-		Me.CBTagTeacher.AutoSize = true
-		Me.CBTagTeacher.Enabled = false
+		Me.CBTagTeacher.AutoSize = True
+		Me.CBTagTeacher.Enabled = False
 		Me.CBTagTeacher.ForeColor = System.Drawing.Color.Black
 		Me.CBTagTeacher.Location = New System.Drawing.Point(15, 37)
 		Me.CBTagTeacher.Name = "CBTagTeacher"
 		Me.CBTagTeacher.Size = New System.Drawing.Size(66, 17)
 		Me.CBTagTeacher.TabIndex = 206
 		Me.CBTagTeacher.Text = "Teacher"
-		Me.CBTagTeacher.UseVisualStyleBackColor = true
+		Me.CBTagTeacher.UseVisualStyleBackColor = True
 		'
 		'CBTagSuperhero
 		'
-		Me.CBTagSuperhero.AutoSize = true
-		Me.CBTagSuperhero.Enabled = false
+		Me.CBTagSuperhero.AutoSize = True
+		Me.CBTagSuperhero.Enabled = False
 		Me.CBTagSuperhero.ForeColor = System.Drawing.Color.Black
 		Me.CBTagSuperhero.Location = New System.Drawing.Point(15, 97)
 		Me.CBTagSuperhero.Name = "CBTagSuperhero"
 		Me.CBTagSuperhero.Size = New System.Drawing.Size(75, 17)
 		Me.CBTagSuperhero.TabIndex = 213
 		Me.CBTagSuperhero.Text = "Superhero"
-		Me.CBTagSuperhero.UseVisualStyleBackColor = true
+		Me.CBTagSuperhero.UseVisualStyleBackColor = True
 		'
 		'GroupBox53
 		'
@@ -6380,128 +6492,128 @@ Partial Class FrmSettings
 		Me.GroupBox53.Name = "GroupBox53"
 		Me.GroupBox53.Size = New System.Drawing.Size(246, 118)
 		Me.GroupBox53.TabIndex = 226
-		Me.GroupBox53.TabStop = false
+		Me.GroupBox53.TabStop = False
 		Me.GroupBox53.Text = "Hentai/JAV Themes"
 		'
 		'CBTagTrap
 		'
-		Me.CBTagTrap.AutoSize = true
-		Me.CBTagTrap.Enabled = false
+		Me.CBTagTrap.AutoSize = True
+		Me.CBTagTrap.Enabled = False
 		Me.CBTagTrap.ForeColor = System.Drawing.Color.Black
 		Me.CBTagTrap.Location = New System.Drawing.Point(126, 37)
 		Me.CBTagTrap.Name = "CBTagTrap"
 		Me.CBTagTrap.Size = New System.Drawing.Size(48, 17)
 		Me.CBTagTrap.TabIndex = 226
 		Me.CBTagTrap.Text = "Trap"
-		Me.CBTagTrap.UseVisualStyleBackColor = true
+		Me.CBTagTrap.UseVisualStyleBackColor = True
 		'
 		'CBTagTentacles
 		'
-		Me.CBTagTentacles.AutoSize = true
-		Me.CBTagTentacles.Enabled = false
+		Me.CBTagTentacles.AutoSize = True
+		Me.CBTagTentacles.Enabled = False
 		Me.CBTagTentacles.ForeColor = System.Drawing.Color.Black
 		Me.CBTagTentacles.Location = New System.Drawing.Point(15, 37)
 		Me.CBTagTentacles.Name = "CBTagTentacles"
 		Me.CBTagTentacles.Size = New System.Drawing.Size(73, 17)
 		Me.CBTagTentacles.TabIndex = 204
 		Me.CBTagTentacles.Text = "Tentacles"
-		Me.CBTagTentacles.UseVisualStyleBackColor = true
+		Me.CBTagTentacles.UseVisualStyleBackColor = True
 		'
 		'CBTagMonsterGirl
 		'
-		Me.CBTagMonsterGirl.AutoSize = true
-		Me.CBTagMonsterGirl.Enabled = false
+		Me.CBTagMonsterGirl.AutoSize = True
+		Me.CBTagMonsterGirl.Enabled = False
 		Me.CBTagMonsterGirl.ForeColor = System.Drawing.Color.Black
 		Me.CBTagMonsterGirl.Location = New System.Drawing.Point(126, 97)
 		Me.CBTagMonsterGirl.Name = "CBTagMonsterGirl"
 		Me.CBTagMonsterGirl.Size = New System.Drawing.Size(82, 17)
 		Me.CBTagMonsterGirl.TabIndex = 214
 		Me.CBTagMonsterGirl.Text = "Monster Girl"
-		Me.CBTagMonsterGirl.UseVisualStyleBackColor = true
+		Me.CBTagMonsterGirl.UseVisualStyleBackColor = True
 		'
 		'CBTagBukkake
 		'
-		Me.CBTagBukkake.AutoSize = true
-		Me.CBTagBukkake.Enabled = false
+		Me.CBTagBukkake.AutoSize = True
+		Me.CBTagBukkake.Enabled = False
 		Me.CBTagBukkake.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBukkake.Location = New System.Drawing.Point(15, 57)
 		Me.CBTagBukkake.Name = "CBTagBukkake"
 		Me.CBTagBukkake.Size = New System.Drawing.Size(69, 17)
 		Me.CBTagBukkake.TabIndex = 210
 		Me.CBTagBukkake.Text = "Bukkake"
-		Me.CBTagBukkake.UseVisualStyleBackColor = true
+		Me.CBTagBukkake.UseVisualStyleBackColor = True
 		'
 		'CBTagGanguro
 		'
-		Me.CBTagGanguro.AutoSize = true
-		Me.CBTagGanguro.Enabled = false
+		Me.CBTagGanguro.AutoSize = True
+		Me.CBTagGanguro.Enabled = False
 		Me.CBTagGanguro.ForeColor = System.Drawing.Color.Black
 		Me.CBTagGanguro.Location = New System.Drawing.Point(126, 57)
 		Me.CBTagGanguro.Name = "CBTagGanguro"
 		Me.CBTagGanguro.Size = New System.Drawing.Size(67, 17)
 		Me.CBTagGanguro.TabIndex = 205
 		Me.CBTagGanguro.Text = "Ganguro"
-		Me.CBTagGanguro.UseVisualStyleBackColor = true
+		Me.CBTagGanguro.UseVisualStyleBackColor = True
 		'
 		'CBTagBodyWriting
 		'
-		Me.CBTagBodyWriting.AutoSize = true
-		Me.CBTagBodyWriting.Enabled = false
+		Me.CBTagBodyWriting.AutoSize = True
+		Me.CBTagBodyWriting.Enabled = False
 		Me.CBTagBodyWriting.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBodyWriting.Location = New System.Drawing.Point(126, 17)
 		Me.CBTagBodyWriting.Name = "CBTagBodyWriting"
 		Me.CBTagBodyWriting.Size = New System.Drawing.Size(86, 17)
 		Me.CBTagBodyWriting.TabIndex = 208
 		Me.CBTagBodyWriting.Text = "Body Writing"
-		Me.CBTagBodyWriting.UseVisualStyleBackColor = true
+		Me.CBTagBodyWriting.UseVisualStyleBackColor = True
 		'
 		'CBTagMahouShoujo
 		'
-		Me.CBTagMahouShoujo.AutoSize = true
-		Me.CBTagMahouShoujo.Enabled = false
+		Me.CBTagMahouShoujo.AutoSize = True
+		Me.CBTagMahouShoujo.Enabled = False
 		Me.CBTagMahouShoujo.ForeColor = System.Drawing.Color.Black
 		Me.CBTagMahouShoujo.Location = New System.Drawing.Point(126, 77)
 		Me.CBTagMahouShoujo.Name = "CBTagMahouShoujo"
 		Me.CBTagMahouShoujo.Size = New System.Drawing.Size(95, 17)
 		Me.CBTagMahouShoujo.TabIndex = 209
 		Me.CBTagMahouShoujo.Text = "Mahou Shoujo"
-		Me.CBTagMahouShoujo.UseVisualStyleBackColor = true
+		Me.CBTagMahouShoujo.UseVisualStyleBackColor = True
 		'
 		'CBTagBakunyuu
 		'
-		Me.CBTagBakunyuu.AutoSize = true
-		Me.CBTagBakunyuu.Enabled = false
+		Me.CBTagBakunyuu.AutoSize = True
+		Me.CBTagBakunyuu.Enabled = False
 		Me.CBTagBakunyuu.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBakunyuu.Location = New System.Drawing.Point(15, 77)
 		Me.CBTagBakunyuu.Name = "CBTagBakunyuu"
 		Me.CBTagBakunyuu.Size = New System.Drawing.Size(74, 17)
 		Me.CBTagBakunyuu.TabIndex = 213
 		Me.CBTagBakunyuu.Text = "Bakunyuu"
-		Me.CBTagBakunyuu.UseVisualStyleBackColor = true
+		Me.CBTagBakunyuu.UseVisualStyleBackColor = True
 		'
 		'CBTagAhegao
 		'
-		Me.CBTagAhegao.AutoSize = true
-		Me.CBTagAhegao.Enabled = false
+		Me.CBTagAhegao.AutoSize = True
+		Me.CBTagAhegao.Enabled = False
 		Me.CBTagAhegao.ForeColor = System.Drawing.Color.Black
 		Me.CBTagAhegao.Location = New System.Drawing.Point(15, 97)
 		Me.CBTagAhegao.Name = "CBTagAhegao"
 		Me.CBTagAhegao.Size = New System.Drawing.Size(63, 17)
 		Me.CBTagAhegao.TabIndex = 207
 		Me.CBTagAhegao.Text = "Ahegao"
-		Me.CBTagAhegao.UseVisualStyleBackColor = true
+		Me.CBTagAhegao.UseVisualStyleBackColor = True
 		'
 		'CBTagShibari
 		'
-		Me.CBTagShibari.AutoSize = true
-		Me.CBTagShibari.Enabled = false
+		Me.CBTagShibari.AutoSize = True
+		Me.CBTagShibari.Enabled = False
 		Me.CBTagShibari.ForeColor = System.Drawing.Color.Black
 		Me.CBTagShibari.Location = New System.Drawing.Point(15, 17)
 		Me.CBTagShibari.Name = "CBTagShibari"
 		Me.CBTagShibari.Size = New System.Drawing.Size(58, 17)
 		Me.CBTagShibari.TabIndex = 203
 		Me.CBTagShibari.Text = "Shibari"
-		Me.CBTagShibari.UseVisualStyleBackColor = true
+		Me.CBTagShibari.UseVisualStyleBackColor = True
 		'
 		'GroupBox49
 		'
@@ -6520,140 +6632,140 @@ Partial Class FrmSettings
 		Me.GroupBox49.Name = "GroupBox49"
 		Me.GroupBox49.Size = New System.Drawing.Size(103, 238)
 		Me.GroupBox49.TabIndex = 221
-		Me.GroupBox49.TabStop = false
+		Me.GroupBox49.TabStop = False
 		Me.GroupBox49.Text = "Body Part"
 		'
 		'CBTagBodyMouth
 		'
-		Me.CBTagBodyMouth.AutoSize = true
-		Me.CBTagBodyMouth.Enabled = false
+		Me.CBTagBodyMouth.AutoSize = True
+		Me.CBTagBodyMouth.Enabled = False
 		Me.CBTagBodyMouth.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBodyMouth.Location = New System.Drawing.Point(14, 57)
 		Me.CBTagBodyMouth.Name = "CBTagBodyMouth"
 		Me.CBTagBodyMouth.Size = New System.Drawing.Size(56, 17)
 		Me.CBTagBodyMouth.TabIndex = 220
 		Me.CBTagBodyMouth.Text = "Mouth"
-		Me.CBTagBodyMouth.UseVisualStyleBackColor = true
+		Me.CBTagBodyMouth.UseVisualStyleBackColor = True
 		'
 		'CBTagBodyAss
 		'
-		Me.CBTagBodyAss.AutoSize = true
-		Me.CBTagBodyAss.Enabled = false
+		Me.CBTagBodyAss.AutoSize = True
+		Me.CBTagBodyAss.Enabled = False
 		Me.CBTagBodyAss.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBodyAss.Location = New System.Drawing.Point(15, 137)
 		Me.CBTagBodyAss.Name = "CBTagBodyAss"
 		Me.CBTagBodyAss.Size = New System.Drawing.Size(43, 17)
 		Me.CBTagBodyAss.TabIndex = 219
 		Me.CBTagBodyAss.Text = "Ass"
-		Me.CBTagBodyAss.UseVisualStyleBackColor = true
+		Me.CBTagBodyAss.UseVisualStyleBackColor = True
 		'
 		'CBTagBodyFace
 		'
-		Me.CBTagBodyFace.AutoSize = true
-		Me.CBTagBodyFace.Enabled = false
+		Me.CBTagBodyFace.AutoSize = True
+		Me.CBTagBodyFace.Enabled = False
 		Me.CBTagBodyFace.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBodyFace.Location = New System.Drawing.Point(15, 17)
 		Me.CBTagBodyFace.Name = "CBTagBodyFace"
 		Me.CBTagBodyFace.Size = New System.Drawing.Size(50, 17)
 		Me.CBTagBodyFace.TabIndex = 203
 		Me.CBTagBodyFace.Text = "Face"
-		Me.CBTagBodyFace.UseVisualStyleBackColor = true
+		Me.CBTagBodyFace.UseVisualStyleBackColor = True
 		'
 		'CBTagBodyLegs
 		'
-		Me.CBTagBodyLegs.AutoSize = true
-		Me.CBTagBodyLegs.Enabled = false
+		Me.CBTagBodyLegs.AutoSize = True
+		Me.CBTagBodyLegs.Enabled = False
 		Me.CBTagBodyLegs.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBodyLegs.Location = New System.Drawing.Point(15, 157)
 		Me.CBTagBodyLegs.Name = "CBTagBodyLegs"
 		Me.CBTagBodyLegs.Size = New System.Drawing.Size(49, 17)
 		Me.CBTagBodyLegs.TabIndex = 218
 		Me.CBTagBodyLegs.Text = "Legs"
-		Me.CBTagBodyLegs.UseVisualStyleBackColor = true
+		Me.CBTagBodyLegs.UseVisualStyleBackColor = True
 		'
 		'CBTagBodyBalls
 		'
-		Me.CBTagBodyBalls.AutoSize = true
-		Me.CBTagBodyBalls.Enabled = false
+		Me.CBTagBodyBalls.AutoSize = True
+		Me.CBTagBodyBalls.Enabled = False
 		Me.CBTagBodyBalls.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBodyBalls.Location = New System.Drawing.Point(15, 217)
 		Me.CBTagBodyBalls.Name = "CBTagBodyBalls"
 		Me.CBTagBodyBalls.Size = New System.Drawing.Size(48, 17)
 		Me.CBTagBodyBalls.TabIndex = 217
 		Me.CBTagBodyBalls.Text = "Balls"
-		Me.CBTagBodyBalls.UseVisualStyleBackColor = true
+		Me.CBTagBodyBalls.UseVisualStyleBackColor = True
 		'
 		'CBTagBodyCock
 		'
-		Me.CBTagBodyCock.AutoSize = true
-		Me.CBTagBodyCock.Enabled = false
+		Me.CBTagBodyCock.AutoSize = True
+		Me.CBTagBodyCock.Enabled = False
 		Me.CBTagBodyCock.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBodyCock.Location = New System.Drawing.Point(15, 197)
 		Me.CBTagBodyCock.Name = "CBTagBodyCock"
 		Me.CBTagBodyCock.Size = New System.Drawing.Size(51, 17)
 		Me.CBTagBodyCock.TabIndex = 216
 		Me.CBTagBodyCock.Text = "Cock"
-		Me.CBTagBodyCock.UseVisualStyleBackColor = true
+		Me.CBTagBodyCock.UseVisualStyleBackColor = True
 		'
 		'CBTagBodyFeet
 		'
-		Me.CBTagBodyFeet.AutoSize = true
-		Me.CBTagBodyFeet.Enabled = false
+		Me.CBTagBodyFeet.AutoSize = True
+		Me.CBTagBodyFeet.Enabled = False
 		Me.CBTagBodyFeet.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBodyFeet.Location = New System.Drawing.Point(15, 177)
 		Me.CBTagBodyFeet.Name = "CBTagBodyFeet"
 		Me.CBTagBodyFeet.Size = New System.Drawing.Size(47, 17)
 		Me.CBTagBodyFeet.TabIndex = 215
 		Me.CBTagBodyFeet.Text = "Feet"
-		Me.CBTagBodyFeet.UseVisualStyleBackColor = true
+		Me.CBTagBodyFeet.UseVisualStyleBackColor = True
 		'
 		'CBTagBodyNipples
 		'
-		Me.CBTagBodyNipples.AutoSize = true
-		Me.CBTagBodyNipples.Enabled = false
+		Me.CBTagBodyNipples.AutoSize = True
+		Me.CBTagBodyNipples.Enabled = False
 		Me.CBTagBodyNipples.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBodyNipples.Location = New System.Drawing.Point(15, 97)
 		Me.CBTagBodyNipples.Name = "CBTagBodyNipples"
 		Me.CBTagBodyNipples.Size = New System.Drawing.Size(61, 17)
 		Me.CBTagBodyNipples.TabIndex = 207
 		Me.CBTagBodyNipples.Text = "Nipples"
-		Me.CBTagBodyNipples.UseVisualStyleBackColor = true
+		Me.CBTagBodyNipples.UseVisualStyleBackColor = True
 		'
 		'CBTagBodyPussy
 		'
-		Me.CBTagBodyPussy.AutoSize = true
-		Me.CBTagBodyPussy.Enabled = false
+		Me.CBTagBodyPussy.AutoSize = True
+		Me.CBTagBodyPussy.Enabled = False
 		Me.CBTagBodyPussy.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBodyPussy.Location = New System.Drawing.Point(15, 117)
 		Me.CBTagBodyPussy.Name = "CBTagBodyPussy"
 		Me.CBTagBodyPussy.Size = New System.Drawing.Size(54, 17)
 		Me.CBTagBodyPussy.TabIndex = 209
 		Me.CBTagBodyPussy.Text = "Pussy"
-		Me.CBTagBodyPussy.UseVisualStyleBackColor = true
+		Me.CBTagBodyPussy.UseVisualStyleBackColor = True
 		'
 		'CBTagBodyTits
 		'
-		Me.CBTagBodyTits.AutoSize = true
-		Me.CBTagBodyTits.Enabled = false
+		Me.CBTagBodyTits.AutoSize = True
+		Me.CBTagBodyTits.Enabled = False
 		Me.CBTagBodyTits.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBodyTits.Location = New System.Drawing.Point(15, 77)
 		Me.CBTagBodyTits.Name = "CBTagBodyTits"
 		Me.CBTagBodyTits.Size = New System.Drawing.Size(43, 17)
 		Me.CBTagBodyTits.TabIndex = 213
 		Me.CBTagBodyTits.Text = "Tits"
-		Me.CBTagBodyTits.UseVisualStyleBackColor = true
+		Me.CBTagBodyTits.UseVisualStyleBackColor = True
 		'
 		'CBTagBodyFingers
 		'
-		Me.CBTagBodyFingers.AutoSize = true
-		Me.CBTagBodyFingers.Enabled = false
+		Me.CBTagBodyFingers.AutoSize = True
+		Me.CBTagBodyFingers.Enabled = False
 		Me.CBTagBodyFingers.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBodyFingers.Location = New System.Drawing.Point(15, 37)
 		Me.CBTagBodyFingers.Name = "CBTagBodyFingers"
 		Me.CBTagBodyFingers.Size = New System.Drawing.Size(60, 17)
 		Me.CBTagBodyFingers.TabIndex = 210
 		Me.CBTagBodyFingers.Text = "Fingers"
-		Me.CBTagBodyFingers.UseVisualStyleBackColor = true
+		Me.CBTagBodyFingers.UseVisualStyleBackColor = True
 		'
 		'GroupBox46
 		'
@@ -6678,212 +6790,212 @@ Partial Class FrmSettings
 		Me.GroupBox46.Name = "GroupBox46"
 		Me.GroupBox46.Size = New System.Drawing.Size(105, 358)
 		Me.GroupBox46.TabIndex = 219
-		Me.GroupBox46.TabStop = false
+		Me.GroupBox46.TabStop = False
 		Me.GroupBox46.Text = "Genders && Roles"
 		'
 		'CBTagMultiSub
 		'
-		Me.CBTagMultiSub.AutoSize = true
-		Me.CBTagMultiSub.Enabled = false
+		Me.CBTagMultiSub.AutoSize = True
+		Me.CBTagMultiSub.Enabled = False
 		Me.CBTagMultiSub.ForeColor = System.Drawing.Color.Black
 		Me.CBTagMultiSub.Location = New System.Drawing.Point(15, 337)
 		Me.CBTagMultiSub.Name = "CBTagMultiSub"
 		Me.CBTagMultiSub.Size = New System.Drawing.Size(70, 17)
 		Me.CBTagMultiSub.TabIndex = 207
 		Me.CBTagMultiSub.Text = "Multi-Sub"
-		Me.CBTagMultiSub.UseVisualStyleBackColor = true
+		Me.CBTagMultiSub.UseVisualStyleBackColor = True
 		'
 		'CBTagMultiDom
 		'
-		Me.CBTagMultiDom.AutoSize = true
-		Me.CBTagMultiDom.Enabled = false
+		Me.CBTagMultiDom.AutoSize = True
+		Me.CBTagMultiDom.Enabled = False
 		Me.CBTagMultiDom.ForeColor = System.Drawing.Color.Black
 		Me.CBTagMultiDom.Location = New System.Drawing.Point(15, 317)
 		Me.CBTagMultiDom.Name = "CBTagMultiDom"
 		Me.CBTagMultiDom.Size = New System.Drawing.Size(73, 17)
 		Me.CBTagMultiDom.TabIndex = 230
 		Me.CBTagMultiDom.Text = "Multi-Dom"
-		Me.CBTagMultiDom.UseVisualStyleBackColor = true
+		Me.CBTagMultiDom.UseVisualStyleBackColor = True
 		'
 		'CBTagFemdom
 		'
-		Me.CBTagFemdom.AutoSize = true
-		Me.CBTagFemdom.Enabled = false
+		Me.CBTagFemdom.AutoSize = True
+		Me.CBTagFemdom.Enabled = False
 		Me.CBTagFemdom.ForeColor = System.Drawing.Color.Black
 		Me.CBTagFemdom.Location = New System.Drawing.Point(15, 197)
 		Me.CBTagFemdom.Name = "CBTagFemdom"
 		Me.CBTagFemdom.Size = New System.Drawing.Size(66, 17)
 		Me.CBTagFemdom.TabIndex = 229
 		Me.CBTagFemdom.Text = "Femdom"
-		Me.CBTagFemdom.UseVisualStyleBackColor = true
+		Me.CBTagFemdom.UseVisualStyleBackColor = True
 		'
 		'CBTag2M
 		'
-		Me.CBTag2M.AutoSize = true
-		Me.CBTag2M.Enabled = false
+		Me.CBTag2M.AutoSize = True
+		Me.CBTag2M.Enabled = False
 		Me.CBTag2M.ForeColor = System.Drawing.Color.Black
 		Me.CBTag2M.Location = New System.Drawing.Point(15, 97)
 		Me.CBTag2M.Name = "CBTag2M"
 		Me.CBTag2M.Size = New System.Drawing.Size(56, 17)
 		Me.CBTag2M.TabIndex = 206
 		Me.CBTag2M.Text = "2 Men"
-		Me.CBTag2M.UseVisualStyleBackColor = true
+		Me.CBTag2M.UseVisualStyleBackColor = True
 		'
 		'CBTagFutadom
 		'
-		Me.CBTagFutadom.AutoSize = true
-		Me.CBTagFutadom.Enabled = false
+		Me.CBTagFutadom.AutoSize = True
+		Me.CBTagFutadom.Enabled = False
 		Me.CBTagFutadom.ForeColor = System.Drawing.Color.Black
 		Me.CBTagFutadom.Location = New System.Drawing.Point(15, 237)
 		Me.CBTagFutadom.Name = "CBTagFutadom"
 		Me.CBTagFutadom.Size = New System.Drawing.Size(67, 17)
 		Me.CBTagFutadom.TabIndex = 204
 		Me.CBTagFutadom.Text = "Futadom"
-		Me.CBTagFutadom.UseVisualStyleBackColor = true
+		Me.CBTagFutadom.UseVisualStyleBackColor = True
 		'
 		'CBTagFemsub
 		'
-		Me.CBTagFemsub.AutoSize = true
-		Me.CBTagFemsub.Enabled = false
+		Me.CBTagFemsub.AutoSize = True
+		Me.CBTagFemsub.Enabled = False
 		Me.CBTagFemsub.ForeColor = System.Drawing.Color.Black
 		Me.CBTagFemsub.Location = New System.Drawing.Point(15, 257)
 		Me.CBTagFemsub.Name = "CBTagFemsub"
 		Me.CBTagFemsub.Size = New System.Drawing.Size(63, 17)
 		Me.CBTagFemsub.TabIndex = 205
 		Me.CBTagFemsub.Text = "Femsub"
-		Me.CBTagFemsub.UseVisualStyleBackColor = true
+		Me.CBTagFemsub.UseVisualStyleBackColor = True
 		'
 		'CBTag2Futa
 		'
-		Me.CBTag2Futa.AutoSize = true
-		Me.CBTag2Futa.Enabled = false
+		Me.CBTag2Futa.AutoSize = True
+		Me.CBTag2Futa.Enabled = False
 		Me.CBTag2Futa.ForeColor = System.Drawing.Color.Black
 		Me.CBTag2Futa.Location = New System.Drawing.Point(15, 157)
 		Me.CBTag2Futa.Name = "CBTag2Futa"
 		Me.CBTag2Futa.Size = New System.Drawing.Size(56, 17)
 		Me.CBTag2Futa.TabIndex = 186
 		Me.CBTag2Futa.Text = "2 Futa"
-		Me.CBTag2Futa.UseVisualStyleBackColor = true
+		Me.CBTag2Futa.UseVisualStyleBackColor = True
 		'
 		'CBTagMaledom
 		'
-		Me.CBTagMaledom.AutoSize = true
-		Me.CBTagMaledom.Enabled = false
+		Me.CBTagMaledom.AutoSize = True
+		Me.CBTagMaledom.Enabled = False
 		Me.CBTagMaledom.ForeColor = System.Drawing.Color.Black
 		Me.CBTagMaledom.Location = New System.Drawing.Point(15, 217)
 		Me.CBTagMaledom.Name = "CBTagMaledom"
 		Me.CBTagMaledom.Size = New System.Drawing.Size(69, 17)
 		Me.CBTagMaledom.TabIndex = 206
 		Me.CBTagMaledom.Text = "Maledom"
-		Me.CBTagMaledom.UseVisualStyleBackColor = true
+		Me.CBTagMaledom.UseVisualStyleBackColor = True
 		'
 		'CBTag3M
 		'
-		Me.CBTag3M.AutoSize = true
-		Me.CBTag3M.Enabled = false
+		Me.CBTag3M.AutoSize = True
+		Me.CBTag3M.Enabled = False
 		Me.CBTag3M.ForeColor = System.Drawing.Color.Black
 		Me.CBTag3M.Location = New System.Drawing.Point(15, 117)
 		Me.CBTag3M.Name = "CBTag3M"
 		Me.CBTag3M.Size = New System.Drawing.Size(56, 17)
 		Me.CBTag3M.TabIndex = 190
 		Me.CBTag3M.Text = "3 Men"
-		Me.CBTag3M.UseVisualStyleBackColor = true
+		Me.CBTag3M.UseVisualStyleBackColor = True
 		'
 		'CBTagFutasub
 		'
-		Me.CBTagFutasub.AutoSize = true
-		Me.CBTagFutasub.Enabled = false
+		Me.CBTagFutasub.AutoSize = True
+		Me.CBTagFutasub.Enabled = False
 		Me.CBTagFutasub.ForeColor = System.Drawing.Color.Black
 		Me.CBTagFutasub.Location = New System.Drawing.Point(15, 297)
 		Me.CBTagFutasub.Name = "CBTagFutasub"
 		Me.CBTagFutasub.Size = New System.Drawing.Size(64, 17)
 		Me.CBTagFutasub.TabIndex = 213
 		Me.CBTagFutasub.Text = "Futasub"
-		Me.CBTagFutasub.UseVisualStyleBackColor = true
+		Me.CBTagFutasub.UseVisualStyleBackColor = True
 		'
 		'CBTag3Futa
 		'
-		Me.CBTag3Futa.AutoSize = true
-		Me.CBTag3Futa.Enabled = false
+		Me.CBTag3Futa.AutoSize = True
+		Me.CBTag3Futa.Enabled = False
 		Me.CBTag3Futa.ForeColor = System.Drawing.Color.Black
 		Me.CBTag3Futa.Location = New System.Drawing.Point(15, 177)
 		Me.CBTag3Futa.Name = "CBTag3Futa"
 		Me.CBTag3Futa.Size = New System.Drawing.Size(56, 17)
 		Me.CBTag3Futa.TabIndex = 197
 		Me.CBTag3Futa.Text = "3 Futa"
-		Me.CBTag3Futa.UseVisualStyleBackColor = true
+		Me.CBTag3Futa.UseVisualStyleBackColor = True
 		'
 		'CBTagMalesub
 		'
-		Me.CBTagMalesub.AutoSize = true
-		Me.CBTagMalesub.Enabled = false
+		Me.CBTagMalesub.AutoSize = True
+		Me.CBTagMalesub.Enabled = False
 		Me.CBTagMalesub.ForeColor = System.Drawing.Color.Black
 		Me.CBTagMalesub.Location = New System.Drawing.Point(15, 277)
 		Me.CBTagMalesub.Name = "CBTagMalesub"
 		Me.CBTagMalesub.Size = New System.Drawing.Size(66, 17)
 		Me.CBTagMalesub.TabIndex = 210
 		Me.CBTagMalesub.Text = "Malesub"
-		Me.CBTagMalesub.UseVisualStyleBackColor = true
+		Me.CBTagMalesub.UseVisualStyleBackColor = True
 		'
 		'CBTag2F
 		'
-		Me.CBTag2F.AutoSize = true
-		Me.CBTag2F.Enabled = false
+		Me.CBTag2F.AutoSize = True
+		Me.CBTag2F.Enabled = False
 		Me.CBTag2F.ForeColor = System.Drawing.Color.Black
 		Me.CBTag2F.Location = New System.Drawing.Point(15, 37)
 		Me.CBTag2F.Name = "CBTag2F"
 		Me.CBTag2F.Size = New System.Drawing.Size(72, 17)
 		Me.CBTag2F.TabIndex = 188
 		Me.CBTag2F.Text = "2 Women"
-		Me.CBTag2F.UseVisualStyleBackColor = true
+		Me.CBTag2F.UseVisualStyleBackColor = True
 		'
 		'CBTag1Futa
 		'
-		Me.CBTag1Futa.AutoSize = true
-		Me.CBTag1Futa.Enabled = false
+		Me.CBTag1Futa.AutoSize = True
+		Me.CBTag1Futa.Enabled = False
 		Me.CBTag1Futa.ForeColor = System.Drawing.Color.Black
 		Me.CBTag1Futa.Location = New System.Drawing.Point(15, 137)
 		Me.CBTag1Futa.Name = "CBTag1Futa"
 		Me.CBTag1Futa.Size = New System.Drawing.Size(56, 17)
 		Me.CBTag1Futa.TabIndex = 191
 		Me.CBTag1Futa.Text = "1 Futa"
-		Me.CBTag1Futa.UseVisualStyleBackColor = true
+		Me.CBTag1Futa.UseVisualStyleBackColor = True
 		'
 		'CBTag1M
 		'
-		Me.CBTag1M.AutoSize = true
-		Me.CBTag1M.Enabled = false
+		Me.CBTag1M.AutoSize = True
+		Me.CBTag1M.Enabled = False
 		Me.CBTag1M.ForeColor = System.Drawing.Color.Black
 		Me.CBTag1M.Location = New System.Drawing.Point(15, 77)
 		Me.CBTag1M.Name = "CBTag1M"
 		Me.CBTag1M.Size = New System.Drawing.Size(56, 17)
 		Me.CBTag1M.TabIndex = 189
 		Me.CBTag1M.Text = "1 Man"
-		Me.CBTag1M.UseVisualStyleBackColor = true
+		Me.CBTag1M.UseVisualStyleBackColor = True
 		'
 		'CBTag1F
 		'
-		Me.CBTag1F.AutoSize = true
-		Me.CBTag1F.Enabled = false
+		Me.CBTag1F.AutoSize = True
+		Me.CBTag1F.Enabled = False
 		Me.CBTag1F.ForeColor = System.Drawing.Color.Black
 		Me.CBTag1F.Location = New System.Drawing.Point(15, 17)
 		Me.CBTag1F.Name = "CBTag1F"
 		Me.CBTag1F.Size = New System.Drawing.Size(72, 17)
 		Me.CBTag1F.TabIndex = 185
 		Me.CBTag1F.Text = "1 Woman"
-		Me.CBTag1F.UseVisualStyleBackColor = true
+		Me.CBTag1F.UseVisualStyleBackColor = True
 		'
 		'CBTag3F
 		'
-		Me.CBTag3F.AutoSize = true
-		Me.CBTag3F.Enabled = false
+		Me.CBTag3F.AutoSize = True
+		Me.CBTag3F.Enabled = False
 		Me.CBTag3F.ForeColor = System.Drawing.Color.Black
 		Me.CBTag3F.Location = New System.Drawing.Point(15, 57)
 		Me.CBTag3F.Name = "CBTag3F"
 		Me.CBTag3F.Size = New System.Drawing.Size(72, 17)
 		Me.CBTag3F.TabIndex = 192
 		Me.CBTag3F.Text = "3 Women"
-		Me.CBTag3F.UseVisualStyleBackColor = true
+		Me.CBTag3F.UseVisualStyleBackColor = True
 		'
 		'GroupBox54
 		'
@@ -6902,140 +7014,140 @@ Partial Class FrmSettings
 		Me.GroupBox54.Name = "GroupBox54"
 		Me.GroupBox54.Size = New System.Drawing.Size(135, 238)
 		Me.GroupBox54.TabIndex = 225
-		Me.GroupBox54.TabStop = false
+		Me.GroupBox54.TabStop = False
 		Me.GroupBox54.Text = "Misc"
 		'
 		'CBTagTattoos
 		'
-		Me.CBTagTattoos.AutoSize = true
-		Me.CBTagTattoos.Enabled = false
+		Me.CBTagTattoos.AutoSize = True
+		Me.CBTagTattoos.Enabled = False
 		Me.CBTagTattoos.ForeColor = System.Drawing.Color.Black
 		Me.CBTagTattoos.Location = New System.Drawing.Point(15, 97)
 		Me.CBTagTattoos.Name = "CBTagTattoos"
 		Me.CBTagTattoos.Size = New System.Drawing.Size(62, 17)
 		Me.CBTagTattoos.TabIndex = 214
 		Me.CBTagTattoos.Text = "Tattoos"
-		Me.CBTagTattoos.UseVisualStyleBackColor = true
+		Me.CBTagTattoos.UseVisualStyleBackColor = True
 		'
 		'CBTagAnalToy
 		'
-		Me.CBTagAnalToy.AutoSize = true
-		Me.CBTagAnalToy.Enabled = false
+		Me.CBTagAnalToy.AutoSize = True
+		Me.CBTagAnalToy.Enabled = False
 		Me.CBTagAnalToy.ForeColor = System.Drawing.Color.Black
 		Me.CBTagAnalToy.Location = New System.Drawing.Point(15, 197)
 		Me.CBTagAnalToy.Name = "CBTagAnalToy"
 		Me.CBTagAnalToy.Size = New System.Drawing.Size(68, 17)
 		Me.CBTagAnalToy.TabIndex = 215
 		Me.CBTagAnalToy.Text = "Anal Toy"
-		Me.CBTagAnalToy.UseVisualStyleBackColor = true
+		Me.CBTagAnalToy.UseVisualStyleBackColor = True
 		'
 		'CBTagDomme
 		'
-		Me.CBTagDomme.AutoSize = true
-		Me.CBTagDomme.Enabled = false
+		Me.CBTagDomme.AutoSize = True
+		Me.CBTagDomme.Enabled = False
 		Me.CBTagDomme.ForeColor = System.Drawing.Color.Black
 		Me.CBTagDomme.Location = New System.Drawing.Point(15, 17)
 		Me.CBTagDomme.Name = "CBTagDomme"
 		Me.CBTagDomme.Size = New System.Drawing.Size(114, 17)
 		Me.CBTagDomme.TabIndex = 219
 		Me.CBTagDomme.Text = "Tease A.I. Domme"
-		Me.CBTagDomme.UseVisualStyleBackColor = true
+		Me.CBTagDomme.UseVisualStyleBackColor = True
 		'
 		'CBTagPocketPussy
 		'
-		Me.CBTagPocketPussy.AutoSize = true
-		Me.CBTagPocketPussy.Enabled = false
+		Me.CBTagPocketPussy.AutoSize = True
+		Me.CBTagPocketPussy.Enabled = False
 		Me.CBTagPocketPussy.ForeColor = System.Drawing.Color.Black
 		Me.CBTagPocketPussy.Location = New System.Drawing.Point(15, 177)
 		Me.CBTagPocketPussy.Name = "CBTagPocketPussy"
 		Me.CBTagPocketPussy.Size = New System.Drawing.Size(91, 17)
 		Me.CBTagPocketPussy.TabIndex = 205
 		Me.CBTagPocketPussy.Text = "Pocket Pussy"
-		Me.CBTagPocketPussy.UseVisualStyleBackColor = true
+		Me.CBTagPocketPussy.UseVisualStyleBackColor = True
 		'
 		'CBTagWatersports
 		'
-		Me.CBTagWatersports.AutoSize = true
-		Me.CBTagWatersports.Enabled = false
+		Me.CBTagWatersports.AutoSize = True
+		Me.CBTagWatersports.Enabled = False
 		Me.CBTagWatersports.ForeColor = System.Drawing.Color.Black
 		Me.CBTagWatersports.Location = New System.Drawing.Point(15, 217)
 		Me.CBTagWatersports.Name = "CBTagWatersports"
 		Me.CBTagWatersports.Size = New System.Drawing.Size(83, 17)
 		Me.CBTagWatersports.TabIndex = 218
 		Me.CBTagWatersports.Text = "Watersports"
-		Me.CBTagWatersports.UseVisualStyleBackColor = true
+		Me.CBTagWatersports.UseVisualStyleBackColor = True
 		'
 		'CBTagStockings
 		'
-		Me.CBTagStockings.AutoSize = true
-		Me.CBTagStockings.Enabled = false
+		Me.CBTagStockings.AutoSize = True
+		Me.CBTagStockings.Enabled = False
 		Me.CBTagStockings.ForeColor = System.Drawing.Color.Black
 		Me.CBTagStockings.Location = New System.Drawing.Point(15, 117)
 		Me.CBTagStockings.Name = "CBTagStockings"
 		Me.CBTagStockings.Size = New System.Drawing.Size(73, 17)
 		Me.CBTagStockings.TabIndex = 217
 		Me.CBTagStockings.Text = "Stockings"
-		Me.CBTagStockings.UseVisualStyleBackColor = true
+		Me.CBTagStockings.UseVisualStyleBackColor = True
 		'
 		'CBTagCumshot
 		'
-		Me.CBTagCumshot.AutoSize = true
-		Me.CBTagCumshot.Enabled = false
+		Me.CBTagCumshot.AutoSize = True
+		Me.CBTagCumshot.Enabled = False
 		Me.CBTagCumshot.ForeColor = System.Drawing.Color.Black
 		Me.CBTagCumshot.Location = New System.Drawing.Point(15, 37)
 		Me.CBTagCumshot.Name = "CBTagCumshot"
 		Me.CBTagCumshot.Size = New System.Drawing.Size(67, 17)
 		Me.CBTagCumshot.TabIndex = 206
 		Me.CBTagCumshot.Text = "Cumshot"
-		Me.CBTagCumshot.UseVisualStyleBackColor = true
+		Me.CBTagCumshot.UseVisualStyleBackColor = True
 		'
 		'CBTagCumEating
 		'
-		Me.CBTagCumEating.AutoSize = true
-		Me.CBTagCumEating.Enabled = false
+		Me.CBTagCumEating.AutoSize = True
+		Me.CBTagCumEating.Enabled = False
 		Me.CBTagCumEating.ForeColor = System.Drawing.Color.Black
 		Me.CBTagCumEating.Location = New System.Drawing.Point(15, 57)
 		Me.CBTagCumEating.Name = "CBTagCumEating"
 		Me.CBTagCumEating.Size = New System.Drawing.Size(80, 17)
 		Me.CBTagCumEating.TabIndex = 204
 		Me.CBTagCumEating.Text = "Cum Eating"
-		Me.CBTagCumEating.UseVisualStyleBackColor = true
+		Me.CBTagCumEating.UseVisualStyleBackColor = True
 		'
 		'CBTagVibrator
 		'
-		Me.CBTagVibrator.AutoSize = true
-		Me.CBTagVibrator.Enabled = false
+		Me.CBTagVibrator.AutoSize = True
+		Me.CBTagVibrator.Enabled = False
 		Me.CBTagVibrator.ForeColor = System.Drawing.Color.Black
 		Me.CBTagVibrator.Location = New System.Drawing.Point(15, 137)
 		Me.CBTagVibrator.Name = "CBTagVibrator"
 		Me.CBTagVibrator.Size = New System.Drawing.Size(62, 17)
 		Me.CBTagVibrator.TabIndex = 210
 		Me.CBTagVibrator.Text = "Vibrator"
-		Me.CBTagVibrator.UseVisualStyleBackColor = true
+		Me.CBTagVibrator.UseVisualStyleBackColor = True
 		'
 		'CBTagDildo
 		'
-		Me.CBTagDildo.AutoSize = true
-		Me.CBTagDildo.Enabled = false
+		Me.CBTagDildo.AutoSize = True
+		Me.CBTagDildo.Enabled = False
 		Me.CBTagDildo.ForeColor = System.Drawing.Color.Black
 		Me.CBTagDildo.Location = New System.Drawing.Point(15, 157)
 		Me.CBTagDildo.Name = "CBTagDildo"
 		Me.CBTagDildo.Size = New System.Drawing.Size(50, 17)
 		Me.CBTagDildo.TabIndex = 213
 		Me.CBTagDildo.Text = "Dildo"
-		Me.CBTagDildo.UseVisualStyleBackColor = true
+		Me.CBTagDildo.UseVisualStyleBackColor = True
 		'
 		'CBTagKissing
 		'
-		Me.CBTagKissing.AutoSize = true
-		Me.CBTagKissing.Enabled = false
+		Me.CBTagKissing.AutoSize = True
+		Me.CBTagKissing.Enabled = False
 		Me.CBTagKissing.ForeColor = System.Drawing.Color.Black
 		Me.CBTagKissing.Location = New System.Drawing.Point(15, 77)
 		Me.CBTagKissing.Name = "CBTagKissing"
 		Me.CBTagKissing.Size = New System.Drawing.Size(59, 17)
 		Me.CBTagKissing.TabIndex = 203
 		Me.CBTagKissing.Text = "Kissing"
-		Me.CBTagKissing.UseVisualStyleBackColor = true
+		Me.CBTagKissing.UseVisualStyleBackColor = True
 		'
 		'GroupBox51
 		'
@@ -7054,140 +7166,140 @@ Partial Class FrmSettings
 		Me.GroupBox51.Name = "GroupBox51"
 		Me.GroupBox51.Size = New System.Drawing.Size(105, 238)
 		Me.GroupBox51.TabIndex = 223
-		Me.GroupBox51.TabStop = false
+		Me.GroupBox51.TabStop = False
 		Me.GroupBox51.Text = "BDSM"
 		'
 		'CBTagBallTorture
 		'
-		Me.CBTagBallTorture.AutoSize = true
-		Me.CBTagBallTorture.Enabled = false
+		Me.CBTagBallTorture.AutoSize = True
+		Me.CBTagBallTorture.Enabled = False
 		Me.CBTagBallTorture.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBallTorture.Location = New System.Drawing.Point(15, 77)
 		Me.CBTagBallTorture.Name = "CBTagBallTorture"
 		Me.CBTagBallTorture.Size = New System.Drawing.Size(80, 17)
 		Me.CBTagBallTorture.TabIndex = 220
 		Me.CBTagBallTorture.Text = "Ball Torture"
-		Me.CBTagBallTorture.UseVisualStyleBackColor = true
+		Me.CBTagBallTorture.UseVisualStyleBackColor = True
 		'
 		'CBTagGag
 		'
-		Me.CBTagGag.AutoSize = true
-		Me.CBTagGag.Enabled = false
+		Me.CBTagGag.AutoSize = True
+		Me.CBTagGag.Enabled = False
 		Me.CBTagGag.ForeColor = System.Drawing.Color.Black
 		Me.CBTagGag.Location = New System.Drawing.Point(15, 137)
 		Me.CBTagGag.Name = "CBTagGag"
 		Me.CBTagGag.Size = New System.Drawing.Size(46, 17)
 		Me.CBTagGag.TabIndex = 214
 		Me.CBTagGag.Text = "Gag"
-		Me.CBTagGag.UseVisualStyleBackColor = true
+		Me.CBTagGag.UseVisualStyleBackColor = True
 		'
 		'CBTagBlindfold
 		'
-		Me.CBTagBlindfold.AutoSize = true
-		Me.CBTagBlindfold.Enabled = false
+		Me.CBTagBlindfold.AutoSize = True
+		Me.CBTagBlindfold.Enabled = False
 		Me.CBTagBlindfold.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBlindfold.Location = New System.Drawing.Point(15, 117)
 		Me.CBTagBlindfold.Name = "CBTagBlindfold"
 		Me.CBTagBlindfold.Size = New System.Drawing.Size(66, 17)
 		Me.CBTagBlindfold.TabIndex = 208
 		Me.CBTagBlindfold.Text = "Blindfold"
-		Me.CBTagBlindfold.UseVisualStyleBackColor = true
+		Me.CBTagBlindfold.UseVisualStyleBackColor = True
 		'
 		'CBTagWhipping
 		'
-		Me.CBTagWhipping.AutoSize = true
-		Me.CBTagWhipping.Enabled = false
+		Me.CBTagWhipping.AutoSize = True
+		Me.CBTagWhipping.Enabled = False
 		Me.CBTagWhipping.ForeColor = System.Drawing.Color.Black
 		Me.CBTagWhipping.Location = New System.Drawing.Point(15, 17)
 		Me.CBTagWhipping.Name = "CBTagWhipping"
 		Me.CBTagWhipping.Size = New System.Drawing.Size(71, 17)
 		Me.CBTagWhipping.TabIndex = 203
 		Me.CBTagWhipping.Text = "Whipping"
-		Me.CBTagWhipping.UseVisualStyleBackColor = true
+		Me.CBTagWhipping.UseVisualStyleBackColor = True
 		'
 		'CBTagCockTorture
 		'
-		Me.CBTagCockTorture.AutoSize = true
-		Me.CBTagCockTorture.Enabled = false
+		Me.CBTagCockTorture.AutoSize = True
+		Me.CBTagCockTorture.Enabled = False
 		Me.CBTagCockTorture.ForeColor = System.Drawing.Color.Black
 		Me.CBTagCockTorture.Location = New System.Drawing.Point(15, 57)
 		Me.CBTagCockTorture.Name = "CBTagCockTorture"
 		Me.CBTagCockTorture.Size = New System.Drawing.Size(88, 17)
 		Me.CBTagCockTorture.TabIndex = 204
 		Me.CBTagCockTorture.Text = "Cock Torture"
-		Me.CBTagCockTorture.UseVisualStyleBackColor = true
+		Me.CBTagCockTorture.UseVisualStyleBackColor = True
 		'
 		'CBTagElectro
 		'
-		Me.CBTagElectro.AutoSize = true
-		Me.CBTagElectro.Enabled = false
+		Me.CBTagElectro.AutoSize = True
+		Me.CBTagElectro.Enabled = False
 		Me.CBTagElectro.ForeColor = System.Drawing.Color.Black
 		Me.CBTagElectro.Location = New System.Drawing.Point(15, 217)
 		Me.CBTagElectro.Name = "CBTagElectro"
 		Me.CBTagElectro.Size = New System.Drawing.Size(59, 17)
 		Me.CBTagElectro.TabIndex = 207
 		Me.CBTagElectro.Text = "Electro"
-		Me.CBTagElectro.UseVisualStyleBackColor = true
+		Me.CBTagElectro.UseVisualStyleBackColor = True
 		'
 		'CBTagHotWax
 		'
-		Me.CBTagHotWax.AutoSize = true
-		Me.CBTagHotWax.Enabled = false
+		Me.CBTagHotWax.AutoSize = True
+		Me.CBTagHotWax.Enabled = False
 		Me.CBTagHotWax.ForeColor = System.Drawing.Color.Black
 		Me.CBTagHotWax.Location = New System.Drawing.Point(15, 177)
 		Me.CBTagHotWax.Name = "CBTagHotWax"
 		Me.CBTagHotWax.Size = New System.Drawing.Size(68, 17)
 		Me.CBTagHotWax.TabIndex = 213
 		Me.CBTagHotWax.Text = "Hot Wax"
-		Me.CBTagHotWax.UseVisualStyleBackColor = true
+		Me.CBTagHotWax.UseVisualStyleBackColor = True
 		'
 		'CBTagClamps
 		'
-		Me.CBTagClamps.AutoSize = true
-		Me.CBTagClamps.Enabled = false
+		Me.CBTagClamps.AutoSize = True
+		Me.CBTagClamps.Enabled = False
 		Me.CBTagClamps.ForeColor = System.Drawing.Color.Black
 		Me.CBTagClamps.Location = New System.Drawing.Point(15, 157)
 		Me.CBTagClamps.Name = "CBTagClamps"
 		Me.CBTagClamps.Size = New System.Drawing.Size(60, 17)
 		Me.CBTagClamps.TabIndex = 210
 		Me.CBTagClamps.Text = "Clamps"
-		Me.CBTagClamps.UseVisualStyleBackColor = true
+		Me.CBTagClamps.UseVisualStyleBackColor = True
 		'
 		'CBTagStrapon
 		'
-		Me.CBTagStrapon.AutoSize = true
-		Me.CBTagStrapon.Enabled = false
+		Me.CBTagStrapon.AutoSize = True
+		Me.CBTagStrapon.Enabled = False
 		Me.CBTagStrapon.ForeColor = System.Drawing.Color.Black
 		Me.CBTagStrapon.Location = New System.Drawing.Point(15, 97)
 		Me.CBTagStrapon.Name = "CBTagStrapon"
 		Me.CBTagStrapon.Size = New System.Drawing.Size(66, 17)
 		Me.CBTagStrapon.TabIndex = 205
 		Me.CBTagStrapon.Text = "Strap-on"
-		Me.CBTagStrapon.UseVisualStyleBackColor = true
+		Me.CBTagStrapon.UseVisualStyleBackColor = True
 		'
 		'CBTagSpanking
 		'
-		Me.CBTagSpanking.AutoSize = true
-		Me.CBTagSpanking.Enabled = false
+		Me.CBTagSpanking.AutoSize = True
+		Me.CBTagSpanking.Enabled = False
 		Me.CBTagSpanking.ForeColor = System.Drawing.Color.Black
 		Me.CBTagSpanking.Location = New System.Drawing.Point(15, 37)
 		Me.CBTagSpanking.Name = "CBTagSpanking"
 		Me.CBTagSpanking.Size = New System.Drawing.Size(71, 17)
 		Me.CBTagSpanking.TabIndex = 206
 		Me.CBTagSpanking.Text = "Spanking"
-		Me.CBTagSpanking.UseVisualStyleBackColor = true
+		Me.CBTagSpanking.UseVisualStyleBackColor = True
 		'
 		'CBTagNeedles
 		'
-		Me.CBTagNeedles.AutoSize = true
-		Me.CBTagNeedles.Enabled = false
+		Me.CBTagNeedles.AutoSize = True
+		Me.CBTagNeedles.Enabled = False
 		Me.CBTagNeedles.ForeColor = System.Drawing.Color.Black
 		Me.CBTagNeedles.Location = New System.Drawing.Point(15, 197)
 		Me.CBTagNeedles.Name = "CBTagNeedles"
 		Me.CBTagNeedles.Size = New System.Drawing.Size(65, 17)
 		Me.CBTagNeedles.TabIndex = 209
 		Me.CBTagNeedles.Text = "Needles"
-		Me.CBTagNeedles.UseVisualStyleBackColor = true
+		Me.CBTagNeedles.UseVisualStyleBackColor = True
 		'
 		'GroupBox50
 		'
@@ -7212,212 +7324,212 @@ Partial Class FrmSettings
 		Me.GroupBox50.Name = "GroupBox50"
 		Me.GroupBox50.Size = New System.Drawing.Size(105, 358)
 		Me.GroupBox50.TabIndex = 222
-		Me.GroupBox50.TabStop = false
+		Me.GroupBox50.TabStop = False
 		Me.GroupBox50.Text = "Sex"
 		'
 		'CBTagRimming
 		'
-		Me.CBTagRimming.AutoSize = true
-		Me.CBTagRimming.Enabled = false
+		Me.CBTagRimming.AutoSize = True
+		Me.CBTagRimming.Enabled = False
 		Me.CBTagRimming.ForeColor = System.Drawing.Color.Black
 		Me.CBTagRimming.Location = New System.Drawing.Point(15, 177)
 		Me.CBTagRimming.Name = "CBTagRimming"
 		Me.CBTagRimming.Size = New System.Drawing.Size(66, 17)
 		Me.CBTagRimming.TabIndex = 219
 		Me.CBTagRimming.Text = "Rimming"
-		Me.CBTagRimming.UseVisualStyleBackColor = true
+		Me.CBTagRimming.UseVisualStyleBackColor = True
 		'
 		'CBTagFacesitting
 		'
-		Me.CBTagFacesitting.AutoSize = true
-		Me.CBTagFacesitting.Enabled = false
+		Me.CBTagFacesitting.AutoSize = True
+		Me.CBTagFacesitting.Enabled = False
 		Me.CBTagFacesitting.ForeColor = System.Drawing.Color.Black
 		Me.CBTagFacesitting.Location = New System.Drawing.Point(15, 157)
 		Me.CBTagFacesitting.Name = "CBTagFacesitting"
 		Me.CBTagFacesitting.Size = New System.Drawing.Size(77, 17)
 		Me.CBTagFacesitting.TabIndex = 226
 		Me.CBTagFacesitting.Text = "Facesitting"
-		Me.CBTagFacesitting.UseVisualStyleBackColor = true
+		Me.CBTagFacesitting.UseVisualStyleBackColor = True
 		'
 		'CBTagMissionary
 		'
-		Me.CBTagMissionary.AutoSize = true
-		Me.CBTagMissionary.Enabled = false
+		Me.CBTagMissionary.AutoSize = True
+		Me.CBTagMissionary.Enabled = False
 		Me.CBTagMissionary.ForeColor = System.Drawing.Color.Black
 		Me.CBTagMissionary.Location = New System.Drawing.Point(15, 197)
 		Me.CBTagMissionary.Name = "CBTagMissionary"
 		Me.CBTagMissionary.Size = New System.Drawing.Size(75, 17)
 		Me.CBTagMissionary.TabIndex = 208
 		Me.CBTagMissionary.Text = "Missionary"
-		Me.CBTagMissionary.UseVisualStyleBackColor = true
+		Me.CBTagMissionary.UseVisualStyleBackColor = True
 		'
 		'CBTagMasturbation
 		'
-		Me.CBTagMasturbation.AutoSize = true
-		Me.CBTagMasturbation.Enabled = false
+		Me.CBTagMasturbation.AutoSize = True
+		Me.CBTagMasturbation.Enabled = False
 		Me.CBTagMasturbation.ForeColor = System.Drawing.Color.Black
 		Me.CBTagMasturbation.Location = New System.Drawing.Point(15, 17)
 		Me.CBTagMasturbation.Name = "CBTagMasturbation"
 		Me.CBTagMasturbation.Size = New System.Drawing.Size(87, 17)
 		Me.CBTagMasturbation.TabIndex = 203
 		Me.CBTagMasturbation.Text = "Masturbation"
-		Me.CBTagMasturbation.UseVisualStyleBackColor = true
+		Me.CBTagMasturbation.UseVisualStyleBackColor = True
 		'
 		'CBTagRCowgirl
 		'
-		Me.CBTagRCowgirl.AutoSize = true
-		Me.CBTagRCowgirl.Enabled = false
+		Me.CBTagRCowgirl.AutoSize = True
+		Me.CBTagRCowgirl.Enabled = False
 		Me.CBTagRCowgirl.ForeColor = System.Drawing.Color.Black
 		Me.CBTagRCowgirl.Location = New System.Drawing.Point(15, 257)
 		Me.CBTagRCowgirl.Name = "CBTagRCowgirl"
 		Me.CBTagRCowgirl.Size = New System.Drawing.Size(74, 17)
 		Me.CBTagRCowgirl.TabIndex = 218
 		Me.CBTagRCowgirl.Text = "R. Cowgirl"
-		Me.CBTagRCowgirl.UseVisualStyleBackColor = true
+		Me.CBTagRCowgirl.UseVisualStyleBackColor = True
 		'
 		'CBTagFingering
 		'
-		Me.CBTagFingering.AutoSize = true
-		Me.CBTagFingering.Enabled = false
+		Me.CBTagFingering.AutoSize = True
+		Me.CBTagFingering.Enabled = False
 		Me.CBTagFingering.ForeColor = System.Drawing.Color.Black
 		Me.CBTagFingering.Location = New System.Drawing.Point(15, 57)
 		Me.CBTagFingering.Name = "CBTagFingering"
 		Me.CBTagFingering.Size = New System.Drawing.Size(69, 17)
 		Me.CBTagFingering.TabIndex = 204
 		Me.CBTagFingering.Text = "Fingering"
-		Me.CBTagFingering.UseVisualStyleBackColor = true
+		Me.CBTagFingering.UseVisualStyleBackColor = True
 		'
 		'CBTagGangbang
 		'
-		Me.CBTagGangbang.AutoSize = true
-		Me.CBTagGangbang.Enabled = false
+		Me.CBTagGangbang.AutoSize = True
+		Me.CBTagGangbang.Enabled = False
 		Me.CBTagGangbang.ForeColor = System.Drawing.Color.Black
 		Me.CBTagGangbang.Location = New System.Drawing.Point(15, 337)
 		Me.CBTagGangbang.Name = "CBTagGangbang"
 		Me.CBTagGangbang.Size = New System.Drawing.Size(76, 17)
 		Me.CBTagGangbang.TabIndex = 217
 		Me.CBTagGangbang.Text = "Gangbang"
-		Me.CBTagGangbang.UseVisualStyleBackColor = true
+		Me.CBTagGangbang.UseVisualStyleBackColor = True
 		'
 		'CBTagBlowjob
 		'
-		Me.CBTagBlowjob.AutoSize = true
-		Me.CBTagBlowjob.Enabled = false
+		Me.CBTagBlowjob.AutoSize = True
+		Me.CBTagBlowjob.Enabled = False
 		Me.CBTagBlowjob.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBlowjob.Location = New System.Drawing.Point(15, 77)
 		Me.CBTagBlowjob.Name = "CBTagBlowjob"
 		Me.CBTagBlowjob.Size = New System.Drawing.Size(63, 17)
 		Me.CBTagBlowjob.TabIndex = 205
 		Me.CBTagBlowjob.Text = "Blowjob"
-		Me.CBTagBlowjob.UseVisualStyleBackColor = true
+		Me.CBTagBlowjob.UseVisualStyleBackColor = True
 		'
 		'CBTagDP
 		'
-		Me.CBTagDP.AutoSize = true
-		Me.CBTagDP.Enabled = false
+		Me.CBTagDP.AutoSize = True
+		Me.CBTagDP.Enabled = False
 		Me.CBTagDP.ForeColor = System.Drawing.Color.Black
 		Me.CBTagDP.Location = New System.Drawing.Point(15, 317)
 		Me.CBTagDP.Name = "CBTagDP"
 		Me.CBTagDP.Size = New System.Drawing.Size(41, 17)
 		Me.CBTagDP.TabIndex = 216
 		Me.CBTagDP.Text = "DP"
-		Me.CBTagDP.UseVisualStyleBackColor = true
+		Me.CBTagDP.UseVisualStyleBackColor = True
 		'
 		'CBTagHandjob
 		'
-		Me.CBTagHandjob.AutoSize = true
-		Me.CBTagHandjob.Enabled = false
+		Me.CBTagHandjob.AutoSize = True
+		Me.CBTagHandjob.Enabled = False
 		Me.CBTagHandjob.ForeColor = System.Drawing.Color.Black
 		Me.CBTagHandjob.Location = New System.Drawing.Point(15, 37)
 		Me.CBTagHandjob.Name = "CBTagHandjob"
 		Me.CBTagHandjob.Size = New System.Drawing.Size(66, 17)
 		Me.CBTagHandjob.TabIndex = 206
 		Me.CBTagHandjob.Text = "Handjob"
-		Me.CBTagHandjob.UseVisualStyleBackColor = true
+		Me.CBTagHandjob.UseVisualStyleBackColor = True
 		'
 		'CBTagStanding
 		'
-		Me.CBTagStanding.AutoSize = true
-		Me.CBTagStanding.Enabled = false
+		Me.CBTagStanding.AutoSize = True
+		Me.CBTagStanding.Enabled = False
 		Me.CBTagStanding.ForeColor = System.Drawing.Color.Black
 		Me.CBTagStanding.Location = New System.Drawing.Point(15, 277)
 		Me.CBTagStanding.Name = "CBTagStanding"
 		Me.CBTagStanding.Size = New System.Drawing.Size(68, 17)
 		Me.CBTagStanding.TabIndex = 215
 		Me.CBTagStanding.Text = "Standing"
-		Me.CBTagStanding.UseVisualStyleBackColor = true
+		Me.CBTagStanding.UseVisualStyleBackColor = True
 		'
 		'CBTagFootjob
 		'
-		Me.CBTagFootjob.AutoSize = true
-		Me.CBTagFootjob.Enabled = false
+		Me.CBTagFootjob.AutoSize = True
+		Me.CBTagFootjob.Enabled = False
 		Me.CBTagFootjob.ForeColor = System.Drawing.Color.Black
 		Me.CBTagFootjob.Location = New System.Drawing.Point(15, 137)
 		Me.CBTagFootjob.Name = "CBTagFootjob"
 		Me.CBTagFootjob.Size = New System.Drawing.Size(61, 17)
 		Me.CBTagFootjob.TabIndex = 207
 		Me.CBTagFootjob.Text = "Footjob"
-		Me.CBTagFootjob.UseVisualStyleBackColor = true
+		Me.CBTagFootjob.UseVisualStyleBackColor = True
 		'
 		'CBTagCowgirl
 		'
-		Me.CBTagCowgirl.AutoSize = true
-		Me.CBTagCowgirl.Enabled = false
+		Me.CBTagCowgirl.AutoSize = True
+		Me.CBTagCowgirl.Enabled = False
 		Me.CBTagCowgirl.ForeColor = System.Drawing.Color.Black
 		Me.CBTagCowgirl.Location = New System.Drawing.Point(15, 237)
 		Me.CBTagCowgirl.Name = "CBTagCowgirl"
 		Me.CBTagCowgirl.Size = New System.Drawing.Size(60, 17)
 		Me.CBTagCowgirl.TabIndex = 214
 		Me.CBTagCowgirl.Text = "Cowgirl"
-		Me.CBTagCowgirl.UseVisualStyleBackColor = true
+		Me.CBTagCowgirl.UseVisualStyleBackColor = True
 		'
 		'CBTagDoggyStyle
 		'
-		Me.CBTagDoggyStyle.AutoSize = true
-		Me.CBTagDoggyStyle.Enabled = false
+		Me.CBTagDoggyStyle.AutoSize = True
+		Me.CBTagDoggyStyle.Enabled = False
 		Me.CBTagDoggyStyle.ForeColor = System.Drawing.Color.Black
 		Me.CBTagDoggyStyle.Location = New System.Drawing.Point(15, 217)
 		Me.CBTagDoggyStyle.Name = "CBTagDoggyStyle"
 		Me.CBTagDoggyStyle.Size = New System.Drawing.Size(83, 17)
 		Me.CBTagDoggyStyle.TabIndex = 209
 		Me.CBTagDoggyStyle.Text = "Doggy Style"
-		Me.CBTagDoggyStyle.UseVisualStyleBackColor = true
+		Me.CBTagDoggyStyle.UseVisualStyleBackColor = True
 		'
 		'CBTagTitjob
 		'
-		Me.CBTagTitjob.AutoSize = true
-		Me.CBTagTitjob.Enabled = false
+		Me.CBTagTitjob.AutoSize = True
+		Me.CBTagTitjob.Enabled = False
 		Me.CBTagTitjob.ForeColor = System.Drawing.Color.Black
 		Me.CBTagTitjob.Location = New System.Drawing.Point(15, 117)
 		Me.CBTagTitjob.Name = "CBTagTitjob"
 		Me.CBTagTitjob.Size = New System.Drawing.Size(52, 17)
 		Me.CBTagTitjob.TabIndex = 213
 		Me.CBTagTitjob.Text = "Titjob"
-		Me.CBTagTitjob.UseVisualStyleBackColor = true
+		Me.CBTagTitjob.UseVisualStyleBackColor = True
 		'
 		'CBTagCunnilingus
 		'
-		Me.CBTagCunnilingus.AutoSize = true
-		Me.CBTagCunnilingus.Enabled = false
+		Me.CBTagCunnilingus.AutoSize = True
+		Me.CBTagCunnilingus.Enabled = False
 		Me.CBTagCunnilingus.ForeColor = System.Drawing.Color.Black
 		Me.CBTagCunnilingus.Location = New System.Drawing.Point(15, 97)
 		Me.CBTagCunnilingus.Name = "CBTagCunnilingus"
 		Me.CBTagCunnilingus.Size = New System.Drawing.Size(80, 17)
 		Me.CBTagCunnilingus.TabIndex = 210
 		Me.CBTagCunnilingus.Text = "Cunnilingus"
-		Me.CBTagCunnilingus.UseVisualStyleBackColor = true
+		Me.CBTagCunnilingus.UseVisualStyleBackColor = True
 		'
 		'CBTagAnalSex
 		'
-		Me.CBTagAnalSex.AutoSize = true
-		Me.CBTagAnalSex.Enabled = false
+		Me.CBTagAnalSex.AutoSize = True
+		Me.CBTagAnalSex.Enabled = False
 		Me.CBTagAnalSex.ForeColor = System.Drawing.Color.Black
 		Me.CBTagAnalSex.Location = New System.Drawing.Point(15, 297)
 		Me.CBTagAnalSex.Name = "CBTagAnalSex"
 		Me.CBTagAnalSex.Size = New System.Drawing.Size(68, 17)
 		Me.CBTagAnalSex.TabIndex = 212
 		Me.CBTagAnalSex.Text = "Anal Sex"
-		Me.CBTagAnalSex.UseVisualStyleBackColor = true
+		Me.CBTagAnalSex.UseVisualStyleBackColor = True
 		'
 		'GroupBox48
 		'
@@ -7442,212 +7554,212 @@ Partial Class FrmSettings
 		Me.GroupBox48.Name = "GroupBox48"
 		Me.GroupBox48.Size = New System.Drawing.Size(105, 358)
 		Me.GroupBox48.TabIndex = 220
-		Me.GroupBox48.TabStop = false
+		Me.GroupBox48.TabStop = False
 		Me.GroupBox48.Text = "Category"
 		'
 		'CBTagArtwork
 		'
-		Me.CBTagArtwork.AutoSize = true
-		Me.CBTagArtwork.Enabled = false
+		Me.CBTagArtwork.AutoSize = True
+		Me.CBTagArtwork.Enabled = False
 		Me.CBTagArtwork.ForeColor = System.Drawing.Color.Black
 		Me.CBTagArtwork.Location = New System.Drawing.Point(15, 337)
 		Me.CBTagArtwork.Name = "CBTagArtwork"
 		Me.CBTagArtwork.Size = New System.Drawing.Size(62, 17)
 		Me.CBTagArtwork.TabIndex = 225
 		Me.CBTagArtwork.Text = "Artwork"
-		Me.CBTagArtwork.UseVisualStyleBackColor = true
+		Me.CBTagArtwork.UseVisualStyleBackColor = True
 		'
 		'CBTagOutdoors
 		'
-		Me.CBTagOutdoors.AutoSize = true
-		Me.CBTagOutdoors.Enabled = false
+		Me.CBTagOutdoors.AutoSize = True
+		Me.CBTagOutdoors.Enabled = False
 		Me.CBTagOutdoors.ForeColor = System.Drawing.Color.Black
 		Me.CBTagOutdoors.Location = New System.Drawing.Point(15, 317)
 		Me.CBTagOutdoors.Name = "CBTagOutdoors"
 		Me.CBTagOutdoors.Size = New System.Drawing.Size(69, 17)
 		Me.CBTagOutdoors.TabIndex = 219
 		Me.CBTagOutdoors.Text = "Outdoors"
-		Me.CBTagOutdoors.UseVisualStyleBackColor = true
+		Me.CBTagOutdoors.UseVisualStyleBackColor = True
 		'
 		'CBTagPOV
 		'
-		Me.CBTagPOV.AutoSize = true
-		Me.CBTagPOV.Enabled = false
+		Me.CBTagPOV.AutoSize = True
+		Me.CBTagPOV.Enabled = False
 		Me.CBTagPOV.ForeColor = System.Drawing.Color.Black
 		Me.CBTagPOV.Location = New System.Drawing.Point(15, 157)
 		Me.CBTagPOV.Name = "CBTagPOV"
 		Me.CBTagPOV.Size = New System.Drawing.Size(48, 17)
 		Me.CBTagPOV.TabIndex = 208
 		Me.CBTagPOV.Text = "POV"
-		Me.CBTagPOV.UseVisualStyleBackColor = true
+		Me.CBTagPOV.UseVisualStyleBackColor = True
 		'
 		'CBTagHardcore
 		'
-		Me.CBTagHardcore.AutoSize = true
-		Me.CBTagHardcore.Enabled = false
+		Me.CBTagHardcore.AutoSize = True
+		Me.CBTagHardcore.Enabled = False
 		Me.CBTagHardcore.ForeColor = System.Drawing.Color.Black
 		Me.CBTagHardcore.Location = New System.Drawing.Point(15, 17)
 		Me.CBTagHardcore.Name = "CBTagHardcore"
 		Me.CBTagHardcore.Size = New System.Drawing.Size(70, 17)
 		Me.CBTagHardcore.TabIndex = 203
 		Me.CBTagHardcore.Text = "Hardcore"
-		Me.CBTagHardcore.UseVisualStyleBackColor = true
+		Me.CBTagHardcore.UseVisualStyleBackColor = True
 		'
 		'CBTagTD
 		'
-		Me.CBTagTD.AutoSize = true
-		Me.CBTagTD.Enabled = false
+		Me.CBTagTD.AutoSize = True
+		Me.CBTagTD.Enabled = False
 		Me.CBTagTD.ForeColor = System.Drawing.Color.Black
 		Me.CBTagTD.Location = New System.Drawing.Point(15, 217)
 		Me.CBTagTD.Name = "CBTagTD"
 		Me.CBTagTD.Size = New System.Drawing.Size(47, 17)
 		Me.CBTagTD.TabIndex = 218
 		Me.CBTagTD.Text = "T&&D"
-		Me.CBTagTD.UseVisualStyleBackColor = true
+		Me.CBTagTD.UseVisualStyleBackColor = True
 		'
 		'CBTagGay
 		'
-		Me.CBTagGay.AutoSize = true
-		Me.CBTagGay.Enabled = false
+		Me.CBTagGay.AutoSize = True
+		Me.CBTagGay.Enabled = False
 		Me.CBTagGay.ForeColor = System.Drawing.Color.Black
 		Me.CBTagGay.Location = New System.Drawing.Point(15, 57)
 		Me.CBTagGay.Name = "CBTagGay"
 		Me.CBTagGay.Size = New System.Drawing.Size(45, 17)
 		Me.CBTagGay.TabIndex = 204
 		Me.CBTagGay.Text = "Gay"
-		Me.CBTagGay.UseVisualStyleBackColor = true
+		Me.CBTagGay.UseVisualStyleBackColor = True
 		'
 		'CBTagBath
 		'
-		Me.CBTagBath.AutoSize = true
-		Me.CBTagBath.Enabled = false
+		Me.CBTagBath.AutoSize = True
+		Me.CBTagBath.Enabled = False
 		Me.CBTagBath.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBath.Location = New System.Drawing.Point(15, 277)
 		Me.CBTagBath.Name = "CBTagBath"
 		Me.CBTagBath.Size = New System.Drawing.Size(48, 17)
 		Me.CBTagBath.TabIndex = 217
 		Me.CBTagBath.Text = "Bath"
-		Me.CBTagBath.UseVisualStyleBackColor = true
+		Me.CBTagBath.UseVisualStyleBackColor = True
 		'
 		'CBTagBisexual
 		'
-		Me.CBTagBisexual.AutoSize = true
-		Me.CBTagBisexual.Enabled = false
+		Me.CBTagBisexual.AutoSize = True
+		Me.CBTagBisexual.Enabled = False
 		Me.CBTagBisexual.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBisexual.Location = New System.Drawing.Point(15, 77)
 		Me.CBTagBisexual.Name = "CBTagBisexual"
 		Me.CBTagBisexual.Size = New System.Drawing.Size(65, 17)
 		Me.CBTagBisexual.TabIndex = 205
 		Me.CBTagBisexual.Text = "Bisexual"
-		Me.CBTagBisexual.UseVisualStyleBackColor = true
+		Me.CBTagBisexual.UseVisualStyleBackColor = True
 		'
 		'CBTagCFNM
 		'
-		Me.CBTagCFNM.AutoSize = true
-		Me.CBTagCFNM.Enabled = false
+		Me.CBTagCFNM.AutoSize = True
+		Me.CBTagCFNM.Enabled = False
 		Me.CBTagCFNM.ForeColor = System.Drawing.Color.Black
 		Me.CBTagCFNM.Location = New System.Drawing.Point(15, 257)
 		Me.CBTagCFNM.Name = "CBTagCFNM"
 		Me.CBTagCFNM.Size = New System.Drawing.Size(56, 17)
 		Me.CBTagCFNM.TabIndex = 216
 		Me.CBTagCFNM.Text = "CFNM"
-		Me.CBTagCFNM.UseVisualStyleBackColor = true
+		Me.CBTagCFNM.UseVisualStyleBackColor = True
 		'
 		'CBTagLesbian
 		'
-		Me.CBTagLesbian.AutoSize = true
-		Me.CBTagLesbian.Enabled = false
+		Me.CBTagLesbian.AutoSize = True
+		Me.CBTagLesbian.Enabled = False
 		Me.CBTagLesbian.ForeColor = System.Drawing.Color.Black
 		Me.CBTagLesbian.Location = New System.Drawing.Point(15, 37)
 		Me.CBTagLesbian.Name = "CBTagLesbian"
 		Me.CBTagLesbian.Size = New System.Drawing.Size(63, 17)
 		Me.CBTagLesbian.TabIndex = 206
 		Me.CBTagLesbian.Text = "Lesbian"
-		Me.CBTagLesbian.UseVisualStyleBackColor = true
+		Me.CBTagLesbian.UseVisualStyleBackColor = True
 		'
 		'CBTagSoloFuta
 		'
-		Me.CBTagSoloFuta.AutoSize = true
-		Me.CBTagSoloFuta.Enabled = false
+		Me.CBTagSoloFuta.AutoSize = True
+		Me.CBTagSoloFuta.Enabled = False
 		Me.CBTagSoloFuta.ForeColor = System.Drawing.Color.Black
 		Me.CBTagSoloFuta.Location = New System.Drawing.Point(15, 137)
 		Me.CBTagSoloFuta.Name = "CBTagSoloFuta"
 		Me.CBTagSoloFuta.Size = New System.Drawing.Size(71, 17)
 		Me.CBTagSoloFuta.TabIndex = 207
 		Me.CBTagSoloFuta.Text = "Solo Futa"
-		Me.CBTagSoloFuta.UseVisualStyleBackColor = true
+		Me.CBTagSoloFuta.UseVisualStyleBackColor = True
 		'
 		'CBTagSM
 		'
-		Me.CBTagSM.AutoSize = true
-		Me.CBTagSM.Enabled = false
+		Me.CBTagSM.AutoSize = True
+		Me.CBTagSM.Enabled = False
 		Me.CBTagSM.ForeColor = System.Drawing.Color.Black
 		Me.CBTagSM.Location = New System.Drawing.Point(15, 197)
 		Me.CBTagSM.Name = "CBTagSM"
 		Me.CBTagSM.Size = New System.Drawing.Size(48, 17)
 		Me.CBTagSM.TabIndex = 214
 		Me.CBTagSM.Text = "S&&M"
-		Me.CBTagSM.UseVisualStyleBackColor = true
+		Me.CBTagSM.UseVisualStyleBackColor = True
 		'
 		'CBTagBondage
 		'
-		Me.CBTagBondage.AutoSize = true
-		Me.CBTagBondage.Enabled = false
+		Me.CBTagBondage.AutoSize = True
+		Me.CBTagBondage.Enabled = False
 		Me.CBTagBondage.ForeColor = System.Drawing.Color.Black
 		Me.CBTagBondage.Location = New System.Drawing.Point(15, 177)
 		Me.CBTagBondage.Name = "CBTagBondage"
 		Me.CBTagBondage.Size = New System.Drawing.Size(69, 17)
 		Me.CBTagBondage.TabIndex = 209
 		Me.CBTagBondage.Text = "Bondage"
-		Me.CBTagBondage.UseVisualStyleBackColor = true
+		Me.CBTagBondage.UseVisualStyleBackColor = True
 		'
 		'CBTagSoloM
 		'
-		Me.CBTagSoloM.AutoSize = true
-		Me.CBTagSoloM.Enabled = false
+		Me.CBTagSoloM.AutoSize = True
+		Me.CBTagSoloM.Enabled = False
 		Me.CBTagSoloM.ForeColor = System.Drawing.Color.Black
 		Me.CBTagSoloM.Location = New System.Drawing.Point(15, 117)
 		Me.CBTagSoloM.Name = "CBTagSoloM"
 		Me.CBTagSoloM.Size = New System.Drawing.Size(59, 17)
 		Me.CBTagSoloM.TabIndex = 213
 		Me.CBTagSoloM.Text = "Solo M"
-		Me.CBTagSoloM.UseVisualStyleBackColor = true
+		Me.CBTagSoloM.UseVisualStyleBackColor = True
 		'
 		'CBTagSoloF
 		'
-		Me.CBTagSoloF.AutoSize = true
-		Me.CBTagSoloF.Enabled = false
+		Me.CBTagSoloF.AutoSize = True
+		Me.CBTagSoloF.Enabled = False
 		Me.CBTagSoloF.ForeColor = System.Drawing.Color.Black
 		Me.CBTagSoloF.Location = New System.Drawing.Point(15, 97)
 		Me.CBTagSoloF.Name = "CBTagSoloF"
 		Me.CBTagSoloF.Size = New System.Drawing.Size(56, 17)
 		Me.CBTagSoloF.TabIndex = 210
 		Me.CBTagSoloF.Text = "Solo F"
-		Me.CBTagSoloF.UseVisualStyleBackColor = true
+		Me.CBTagSoloF.UseVisualStyleBackColor = True
 		'
 		'CBTagChastity
 		'
-		Me.CBTagChastity.AutoSize = true
-		Me.CBTagChastity.Enabled = false
+		Me.CBTagChastity.AutoSize = True
+		Me.CBTagChastity.Enabled = False
 		Me.CBTagChastity.ForeColor = System.Drawing.Color.Black
 		Me.CBTagChastity.Location = New System.Drawing.Point(15, 237)
 		Me.CBTagChastity.Name = "CBTagChastity"
 		Me.CBTagChastity.Size = New System.Drawing.Size(63, 17)
 		Me.CBTagChastity.TabIndex = 212
 		Me.CBTagChastity.Text = "Chastity"
-		Me.CBTagChastity.UseVisualStyleBackColor = true
+		Me.CBTagChastity.UseVisualStyleBackColor = True
 		'
 		'CBTagShower
 		'
-		Me.CBTagShower.AutoSize = true
-		Me.CBTagShower.Enabled = false
+		Me.CBTagShower.AutoSize = True
+		Me.CBTagShower.Enabled = False
 		Me.CBTagShower.ForeColor = System.Drawing.Color.Black
 		Me.CBTagShower.Location = New System.Drawing.Point(15, 297)
 		Me.CBTagShower.Name = "CBTagShower"
 		Me.CBTagShower.Size = New System.Drawing.Size(62, 17)
 		Me.CBTagShower.TabIndex = 211
 		Me.CBTagShower.Text = "Shower"
-		Me.CBTagShower.UseVisualStyleBackColor = true
+		Me.CBTagShower.UseVisualStyleBackColor = True
 		'
 		'TBLocalTagDir
 		'
@@ -7660,35 +7772,35 @@ Partial Class FrmSettings
 		'BTNLocalTagPrevious
 		'
 		Me.BTNLocalTagPrevious.BackColor = System.Drawing.Color.LightGray
-		Me.BTNLocalTagPrevious.Enabled = false
-		Me.BTNLocalTagPrevious.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNLocalTagPrevious.Enabled = False
+		Me.BTNLocalTagPrevious.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNLocalTagPrevious.ForeColor = System.Drawing.Color.Black
 		Me.BTNLocalTagPrevious.Location = New System.Drawing.Point(394, 40)
 		Me.BTNLocalTagPrevious.Name = "BTNLocalTagPrevious"
 		Me.BTNLocalTagPrevious.Size = New System.Drawing.Size(47, 24)
 		Me.BTNLocalTagPrevious.TabIndex = 169
 		Me.BTNLocalTagPrevious.Text = "<<"
-		Me.BTNLocalTagPrevious.UseVisualStyleBackColor = false
+		Me.BTNLocalTagPrevious.UseVisualStyleBackColor = False
 		'
 		'BTNLocalTagNext
 		'
 		Me.BTNLocalTagNext.BackColor = System.Drawing.Color.LightGray
-		Me.BTNLocalTagNext.Enabled = false
-		Me.BTNLocalTagNext.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNLocalTagNext.Enabled = False
+		Me.BTNLocalTagNext.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNLocalTagNext.ForeColor = System.Drawing.Color.Black
 		Me.BTNLocalTagNext.Location = New System.Drawing.Point(563, 40)
 		Me.BTNLocalTagNext.Name = "BTNLocalTagNext"
 		Me.BTNLocalTagNext.Size = New System.Drawing.Size(47, 24)
 		Me.BTNLocalTagNext.TabIndex = 168
 		Me.BTNLocalTagNext.Text = ">>"
-		Me.BTNLocalTagNext.UseVisualStyleBackColor = false
+		Me.BTNLocalTagNext.UseVisualStyleBackColor = False
 		'
 		'LBLLocalTagCount
 		'
 		Me.LBLLocalTagCount.BackColor = System.Drawing.Color.Transparent
 		Me.LBLLocalTagCount.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLLocalTagCount.Enabled = false
-		Me.LBLLocalTagCount.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLLocalTagCount.Enabled = False
+		Me.LBLLocalTagCount.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLLocalTagCount.ForeColor = System.Drawing.Color.Black
 		Me.LBLLocalTagCount.Location = New System.Drawing.Point(447, 42)
 		Me.LBLLocalTagCount.Name = "LBLLocalTagCount"
@@ -7699,39 +7811,39 @@ Partial Class FrmSettings
 		'
 		'BTNLocalTagSave
 		'
-		Me.BTNLocalTagSave.Enabled = false
+		Me.BTNLocalTagSave.Enabled = False
 		Me.BTNLocalTagSave.Location = New System.Drawing.Point(616, 41)
 		Me.BTNLocalTagSave.Name = "BTNLocalTagSave"
 		Me.BTNLocalTagSave.Size = New System.Drawing.Size(83, 23)
 		Me.BTNLocalTagSave.TabIndex = 156
 		Me.BTNLocalTagSave.Text = "Finished"
-		Me.BTNLocalTagSave.UseVisualStyleBackColor = true
+		Me.BTNLocalTagSave.UseVisualStyleBackColor = True
 		'
 		'BTNLocalTagDir
 		'
-		Me.BTNLocalTagDir.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNLocalTagDir.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNLocalTagDir.Location = New System.Drawing.Point(9, 40)
 		Me.BTNLocalTagDir.Name = "BTNLocalTagDir"
 		Me.BTNLocalTagDir.Size = New System.Drawing.Size(43, 23)
 		Me.BTNLocalTagDir.TabIndex = 155
 		Me.BTNLocalTagDir.Text = "1"
-		Me.BTNLocalTagDir.UseVisualStyleBackColor = true
+		Me.BTNLocalTagDir.UseVisualStyleBackColor = True
 		'
 		'PictureBox7
 		'
 		Me.PictureBox7.BackColor = System.Drawing.Color.LightGray
-		Me.PictureBox7.Image = CType(resources.GetObject("PictureBox7.Image"),System.Drawing.Image)
+		Me.PictureBox7.Image = CType(resources.GetObject("PictureBox7.Image"), System.Drawing.Image)
 		Me.PictureBox7.Location = New System.Drawing.Point(9, 6)
 		Me.PictureBox7.Name = "PictureBox7"
 		Me.PictureBox7.Size = New System.Drawing.Size(160, 19)
 		Me.PictureBox7.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage
 		Me.PictureBox7.TabIndex = 151
-		Me.PictureBox7.TabStop = false
+		Me.PictureBox7.TabStop = False
 		'
 		'Label85
 		'
 		Me.Label85.BackColor = System.Drawing.Color.Transparent
-		Me.Label85.Font = New System.Drawing.Font("Microsoft Sans Serif", 12!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label85.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label85.ForeColor = System.Drawing.Color.Black
 		Me.Label85.Location = New System.Drawing.Point(7, 6)
 		Me.Label85.Name = "Label85"
@@ -7783,41 +7895,41 @@ Partial Class FrmSettings
 		'BTNWIContinue
 		'
 		Me.BTNWIContinue.BackColor = System.Drawing.Color.LightGray
-		Me.BTNWIContinue.Enabled = false
-		Me.BTNWIContinue.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNWIContinue.Enabled = False
+		Me.BTNWIContinue.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNWIContinue.ForeColor = System.Drawing.Color.Black
 		Me.BTNWIContinue.Location = New System.Drawing.Point(566, 158)
 		Me.BTNWIContinue.Name = "BTNWIContinue"
 		Me.BTNWIContinue.Size = New System.Drawing.Size(131, 24)
 		Me.BTNWIContinue.TabIndex = 168
 		Me.BTNWIContinue.Text = "Continue"
-		Me.BTNWIContinue.UseVisualStyleBackColor = false
+		Me.BTNWIContinue.UseVisualStyleBackColor = False
 		'
 		'BTNWIAddandContinue
 		'
 		Me.BTNWIAddandContinue.BackColor = System.Drawing.Color.LightGray
-		Me.BTNWIAddandContinue.Enabled = false
-		Me.BTNWIAddandContinue.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNWIAddandContinue.Enabled = False
+		Me.BTNWIAddandContinue.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNWIAddandContinue.ForeColor = System.Drawing.Color.Black
 		Me.BTNWIAddandContinue.Location = New System.Drawing.Point(566, 128)
 		Me.BTNWIAddandContinue.Name = "BTNWIAddandContinue"
 		Me.BTNWIAddandContinue.Size = New System.Drawing.Size(131, 24)
 		Me.BTNWIAddandContinue.TabIndex = 167
 		Me.BTNWIAddandContinue.Text = "Add and Continue"
-		Me.BTNWIAddandContinue.UseVisualStyleBackColor = false
+		Me.BTNWIAddandContinue.UseVisualStyleBackColor = False
 		'
 		'BTNWICancel
 		'
 		Me.BTNWICancel.BackColor = System.Drawing.Color.LightGray
-		Me.BTNWICancel.Enabled = false
-		Me.BTNWICancel.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNWICancel.Enabled = False
+		Me.BTNWICancel.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNWICancel.ForeColor = System.Drawing.Color.Black
 		Me.BTNWICancel.Location = New System.Drawing.Point(566, 188)
 		Me.BTNWICancel.Name = "BTNWICancel"
 		Me.BTNWICancel.Size = New System.Drawing.Size(131, 24)
 		Me.BTNWICancel.TabIndex = 166
 		Me.BTNWICancel.Text = "Cancel"
-		Me.BTNWICancel.UseVisualStyleBackColor = false
+		Me.BTNWICancel.UseVisualStyleBackColor = False
 		'
 		'CBWIReview
 		'
@@ -7826,24 +7938,24 @@ Partial Class FrmSettings
 		Me.CBWIReview.Size = New System.Drawing.Size(124, 30)
 		Me.CBWIReview.TabIndex = 165
 		Me.CBWIReview.Text = "Review Each Image"
-		Me.CBWIReview.UseVisualStyleBackColor = true
+		Me.CBWIReview.UseVisualStyleBackColor = True
 		'
 		'BTNWIBrowse
 		'
 		Me.BTNWIBrowse.BackColor = System.Drawing.Color.LightGray
-		Me.BTNWIBrowse.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNWIBrowse.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNWIBrowse.ForeColor = System.Drawing.Color.Black
 		Me.BTNWIBrowse.Location = New System.Drawing.Point(105, 402)
 		Me.BTNWIBrowse.Name = "BTNWIBrowse"
 		Me.BTNWIBrowse.Size = New System.Drawing.Size(50, 24)
 		Me.BTNWIBrowse.TabIndex = 163
 		Me.BTNWIBrowse.Text = "Browse"
-		Me.BTNWIBrowse.UseVisualStyleBackColor = false
+		Me.BTNWIBrowse.UseVisualStyleBackColor = False
 		'
 		'TBWIDirectory
 		'
 		Me.TBWIDirectory.BackColor = System.Drawing.Color.White
-		Me.TBWIDirectory.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.TBWIDirectory.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.TBWIDirectory.ForeColor = System.Drawing.Color.Black
 		Me.TBWIDirectory.Location = New System.Drawing.Point(161, 404)
 		Me.TBWIDirectory.Name = "TBWIDirectory"
@@ -7854,41 +7966,41 @@ Partial Class FrmSettings
 		'BTNWIDisliked
 		'
 		Me.BTNWIDisliked.BackColor = System.Drawing.Color.LightGray
-		Me.BTNWIDisliked.Enabled = false
-		Me.BTNWIDisliked.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNWIDisliked.Enabled = False
+		Me.BTNWIDisliked.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNWIDisliked.ForeColor = System.Drawing.Color.Black
 		Me.BTNWIDisliked.Location = New System.Drawing.Point(567, 372)
 		Me.BTNWIDisliked.Name = "BTNWIDisliked"
 		Me.BTNWIDisliked.Size = New System.Drawing.Size(131, 24)
 		Me.BTNWIDisliked.TabIndex = 162
 		Me.BTNWIDisliked.Text = "Add to Disliked Images"
-		Me.BTNWIDisliked.UseVisualStyleBackColor = false
+		Me.BTNWIDisliked.UseVisualStyleBackColor = False
 		'
 		'BTNWILiked
 		'
 		Me.BTNWILiked.BackColor = System.Drawing.Color.LightGray
-		Me.BTNWILiked.Enabled = false
-		Me.BTNWILiked.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNWILiked.Enabled = False
+		Me.BTNWILiked.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNWILiked.ForeColor = System.Drawing.Color.Black
 		Me.BTNWILiked.Location = New System.Drawing.Point(567, 342)
 		Me.BTNWILiked.Name = "BTNWILiked"
 		Me.BTNWILiked.Size = New System.Drawing.Size(131, 24)
 		Me.BTNWILiked.TabIndex = 161
 		Me.BTNWILiked.Text = "Add to Liked Images"
-		Me.BTNWILiked.UseVisualStyleBackColor = false
+		Me.BTNWILiked.UseVisualStyleBackColor = False
 		'
 		'BTNWIRemove
 		'
 		Me.BTNWIRemove.BackColor = System.Drawing.Color.LightGray
-		Me.BTNWIRemove.Enabled = false
-		Me.BTNWIRemove.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNWIRemove.Enabled = False
+		Me.BTNWIRemove.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNWIRemove.ForeColor = System.Drawing.Color.Black
 		Me.BTNWIRemove.Location = New System.Drawing.Point(567, 312)
 		Me.BTNWIRemove.Name = "BTNWIRemove"
 		Me.BTNWIRemove.Size = New System.Drawing.Size(131, 24)
 		Me.BTNWIRemove.TabIndex = 160
 		Me.BTNWIRemove.Text = "Remove From URL File"
-		Me.BTNWIRemove.UseVisualStyleBackColor = false
+		Me.BTNWIRemove.UseVisualStyleBackColor = False
 		'
 		'CBWISaveToDisk
 		'
@@ -7897,18 +8009,18 @@ Partial Class FrmSettings
 		Me.CBWISaveToDisk.Size = New System.Drawing.Size(124, 30)
 		Me.CBWISaveToDisk.TabIndex = 157
 		Me.CBWISaveToDisk.Text = "Save Images to Disk"
-		Me.CBWISaveToDisk.UseVisualStyleBackColor = true
+		Me.CBWISaveToDisk.UseVisualStyleBackColor = True
 		'
 		'PictureBox5
 		'
 		Me.PictureBox5.BackColor = System.Drawing.Color.LightGray
-		Me.PictureBox5.Image = CType(resources.GetObject("PictureBox5.Image"),System.Drawing.Image)
+		Me.PictureBox5.Image = CType(resources.GetObject("PictureBox5.Image"), System.Drawing.Image)
 		Me.PictureBox5.Location = New System.Drawing.Point(9, 6)
 		Me.PictureBox5.Name = "PictureBox5"
 		Me.PictureBox5.Size = New System.Drawing.Size(160, 19)
 		Me.PictureBox5.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage
 		Me.PictureBox5.TabIndex = 156
-		Me.PictureBox5.TabStop = false
+		Me.PictureBox5.TabStop = False
 		'
 		'WebImageProgressBar
 		'
@@ -7921,20 +8033,20 @@ Partial Class FrmSettings
 		'BTNWICreateURL
 		'
 		Me.BTNWICreateURL.BackColor = System.Drawing.Color.LightGray
-		Me.BTNWICreateURL.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNWICreateURL.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNWICreateURL.ForeColor = System.Drawing.Color.Black
 		Me.BTNWICreateURL.Location = New System.Drawing.Point(567, 39)
 		Me.BTNWICreateURL.Name = "BTNWICreateURL"
 		Me.BTNWICreateURL.Size = New System.Drawing.Size(132, 24)
 		Me.BTNWICreateURL.TabIndex = 154
 		Me.BTNWICreateURL.Text = "Create URL File"
-		Me.BTNWICreateURL.UseVisualStyleBackColor = false
+		Me.BTNWICreateURL.UseVisualStyleBackColor = False
 		'
 		'LBLWebImageCount
 		'
 		Me.LBLWebImageCount.BackColor = System.Drawing.Color.Transparent
 		Me.LBLWebImageCount.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLWebImageCount.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLWebImageCount.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLWebImageCount.ForeColor = System.Drawing.Color.Black
 		Me.LBLWebImageCount.Location = New System.Drawing.Point(6, 404)
 		Me.LBLWebImageCount.Name = "LBLWebImageCount"
@@ -7946,53 +8058,53 @@ Partial Class FrmSettings
 		'BTNWISave
 		'
 		Me.BTNWISave.BackColor = System.Drawing.Color.LightGray
-		Me.BTNWISave.Enabled = false
-		Me.BTNWISave.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNWISave.Enabled = False
+		Me.BTNWISave.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNWISave.ForeColor = System.Drawing.Color.Black
 		Me.BTNWISave.Location = New System.Drawing.Point(567, 401)
 		Me.BTNWISave.Name = "BTNWISave"
 		Me.BTNWISave.Size = New System.Drawing.Size(131, 24)
 		Me.BTNWISave.TabIndex = 152
 		Me.BTNWISave.Text = "Save Image to Disk"
-		Me.BTNWISave.UseVisualStyleBackColor = false
+		Me.BTNWISave.UseVisualStyleBackColor = False
 		'
 		'BTNWIOpenURL
 		'
 		Me.BTNWIOpenURL.BackColor = System.Drawing.Color.LightGray
-		Me.BTNWIOpenURL.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNWIOpenURL.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNWIOpenURL.ForeColor = System.Drawing.Color.Black
 		Me.BTNWIOpenURL.Location = New System.Drawing.Point(566, 252)
 		Me.BTNWIOpenURL.Name = "BTNWIOpenURL"
 		Me.BTNWIOpenURL.Size = New System.Drawing.Size(132, 24)
 		Me.BTNWIOpenURL.TabIndex = 151
 		Me.BTNWIOpenURL.Text = "Open URL File"
-		Me.BTNWIOpenURL.UseVisualStyleBackColor = false
+		Me.BTNWIOpenURL.UseVisualStyleBackColor = False
 		'
 		'BTNWIPrevious
 		'
 		Me.BTNWIPrevious.BackColor = System.Drawing.Color.LightGray
-		Me.BTNWIPrevious.Enabled = false
-		Me.BTNWIPrevious.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNWIPrevious.Enabled = False
+		Me.BTNWIPrevious.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNWIPrevious.ForeColor = System.Drawing.Color.Black
 		Me.BTNWIPrevious.Location = New System.Drawing.Point(567, 282)
 		Me.BTNWIPrevious.Name = "BTNWIPrevious"
 		Me.BTNWIPrevious.Size = New System.Drawing.Size(47, 24)
 		Me.BTNWIPrevious.TabIndex = 149
 		Me.BTNWIPrevious.Text = "<<"
-		Me.BTNWIPrevious.UseVisualStyleBackColor = false
+		Me.BTNWIPrevious.UseVisualStyleBackColor = False
 		'
 		'BTNWINext
 		'
 		Me.BTNWINext.BackColor = System.Drawing.Color.LightGray
-		Me.BTNWINext.Enabled = false
-		Me.BTNWINext.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNWINext.Enabled = False
+		Me.BTNWINext.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNWINext.ForeColor = System.Drawing.Color.Black
 		Me.BTNWINext.Location = New System.Drawing.Point(651, 282)
 		Me.BTNWINext.Name = "BTNWINext"
 		Me.BTNWINext.Size = New System.Drawing.Size(47, 24)
 		Me.BTNWINext.TabIndex = 150
 		Me.BTNWINext.Text = ">>"
-		Me.BTNWINext.UseVisualStyleBackColor = false
+		Me.BTNWINext.UseVisualStyleBackColor = False
 		'
 		'WebPictureBox
 		'
@@ -8002,12 +8114,12 @@ Partial Class FrmSettings
 		Me.WebPictureBox.Size = New System.Drawing.Size(555, 358)
 		Me.WebPictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
 		Me.WebPictureBox.TabIndex = 148
-		Me.WebPictureBox.TabStop = false
+		Me.WebPictureBox.TabStop = False
 		'
 		'Label71
 		'
 		Me.Label71.BackColor = System.Drawing.Color.Transparent
-		Me.Label71.Font = New System.Drawing.Font("Microsoft Sans Serif", 12!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label71.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label71.ForeColor = System.Drawing.Color.Black
 		Me.Label71.Location = New System.Drawing.Point(7, 6)
 		Me.Label71.Name = "Label71"
@@ -8049,30 +8161,30 @@ Partial Class FrmSettings
 		'PictureBox6
 		'
 		Me.PictureBox6.BackColor = System.Drawing.Color.LightGray
-		Me.PictureBox6.Image = CType(resources.GetObject("PictureBox6.Image"),System.Drawing.Image)
+		Me.PictureBox6.Image = CType(resources.GetObject("PictureBox6.Image"), System.Drawing.Image)
 		Me.PictureBox6.Location = New System.Drawing.Point(9, 6)
 		Me.PictureBox6.Name = "PictureBox6"
 		Me.PictureBox6.Size = New System.Drawing.Size(160, 19)
 		Me.PictureBox6.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage
 		Me.PictureBox6.TabIndex = 151
-		Me.PictureBox6.TabStop = false
+		Me.PictureBox6.TabStop = False
 		'
 		'BTNRefreshVideos
 		'
 		Me.BTNRefreshVideos.BackColor = System.Drawing.Color.LightGray
-		Me.BTNRefreshVideos.BackgroundImage = CType(resources.GetObject("BTNRefreshVideos.BackgroundImage"),System.Drawing.Image)
+		Me.BTNRefreshVideos.BackgroundImage = CType(resources.GetObject("BTNRefreshVideos.BackgroundImage"), System.Drawing.Image)
 		Me.BTNRefreshVideos.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom
 		Me.BTNRefreshVideos.FlatAppearance.BorderSize = 0
 		Me.BTNRefreshVideos.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Gray
 		Me.BTNRefreshVideos.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Silver
 		Me.BTNRefreshVideos.FlatStyle = System.Windows.Forms.FlatStyle.Flat
-		Me.BTNRefreshVideos.Font = New System.Drawing.Font("Arial", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNRefreshVideos.Font = New System.Drawing.Font("Arial", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNRefreshVideos.ForeColor = System.Drawing.Color.Black
 		Me.BTNRefreshVideos.Location = New System.Drawing.Point(671, 6)
 		Me.BTNRefreshVideos.Name = "BTNRefreshVideos"
 		Me.BTNRefreshVideos.Size = New System.Drawing.Size(30, 26)
 		Me.BTNRefreshVideos.TabIndex = 149
-		Me.BTNRefreshVideos.UseVisualStyleBackColor = false
+		Me.BTNRefreshVideos.UseVisualStyleBackColor = False
 		'
 		'GroupBox25
 		'
@@ -8086,13 +8198,13 @@ Partial Class FrmSettings
 		Me.GroupBox25.Name = "GroupBox25"
 		Me.GroupBox25.Size = New System.Drawing.Size(340, 48)
 		Me.GroupBox25.TabIndex = 147
-		Me.GroupBox25.TabStop = false
+		Me.GroupBox25.TabStop = False
 		Me.GroupBox25.Text = "Domme General"
 		'
 		'LblVideoGeneralTotalD
 		'
 		Me.LblVideoGeneralTotalD.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoGeneralTotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoGeneralTotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoGeneralTotalD.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoGeneralTotalD.Location = New System.Drawing.Point(299, 19)
 		Me.LblVideoGeneralTotalD.Name = "LblVideoGeneralTotalD"
@@ -8105,7 +8217,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoGeneralD.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoGeneralD.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoGeneralD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoGeneralD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoGeneralD.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoGeneralD.Location = New System.Drawing.Point(113, 18)
 		Me.LblVideoGeneralD.Name = "LblVideoGeneralD"
@@ -8117,25 +8229,25 @@ Partial Class FrmSettings
 		'BTNVideoGeneralD
 		'
 		Me.BTNVideoGeneralD.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoGeneralD.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoGeneralD.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoGeneralD.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoGeneralD.Location = New System.Drawing.Point(73, 13)
 		Me.BTNVideoGeneralD.Name = "BTNVideoGeneralD"
 		Me.BTNVideoGeneralD.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoGeneralD.TabIndex = 131
 		Me.BTNVideoGeneralD.Text = "1"
-		Me.BTNVideoGeneralD.UseVisualStyleBackColor = false
+		Me.BTNVideoGeneralD.UseVisualStyleBackColor = False
 		'
 		'CBVideoGeneralD
 		'
-		Me.CBVideoGeneralD.AutoSize = true
+		Me.CBVideoGeneralD.AutoSize = True
 		Me.CBVideoGeneralD.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoGeneralD.Location = New System.Drawing.Point(6, 19)
 		Me.CBVideoGeneralD.Name = "CBVideoGeneralD"
 		Me.CBVideoGeneralD.Size = New System.Drawing.Size(63, 17)
 		Me.CBVideoGeneralD.TabIndex = 56
 		Me.CBVideoGeneralD.Text = "General"
-		Me.CBVideoGeneralD.UseVisualStyleBackColor = true
+		Me.CBVideoGeneralD.UseVisualStyleBackColor = True
 		'
 		'GroupBox24
 		'
@@ -8153,13 +8265,13 @@ Partial Class FrmSettings
 		Me.GroupBox24.Name = "GroupBox24"
 		Me.GroupBox24.Size = New System.Drawing.Size(340, 70)
 		Me.GroupBox24.TabIndex = 150
-		Me.GroupBox24.TabStop = false
+		Me.GroupBox24.TabStop = False
 		Me.GroupBox24.Text = "Domme Special"
 		'
 		'LblVideoCHTotalD
 		'
 		Me.LblVideoCHTotalD.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoCHTotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoCHTotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoCHTotalD.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoCHTotalD.Location = New System.Drawing.Point(299, 42)
 		Me.LblVideoCHTotalD.Name = "LblVideoCHTotalD"
@@ -8171,7 +8283,7 @@ Partial Class FrmSettings
 		'LblVideoJOITotalD
 		'
 		Me.LblVideoJOITotalD.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoJOITotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoJOITotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoJOITotalD.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoJOITotalD.Location = New System.Drawing.Point(299, 19)
 		Me.LblVideoJOITotalD.Name = "LblVideoJOITotalD"
@@ -8184,7 +8296,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoCHD.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoCHD.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoCHD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoCHD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoCHD.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoCHD.Location = New System.Drawing.Point(113, 41)
 		Me.LblVideoCHD.Name = "LblVideoCHD"
@@ -8197,7 +8309,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoJOID.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoJOID.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoJOID.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoJOID.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoJOID.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoJOID.Location = New System.Drawing.Point(113, 18)
 		Me.LblVideoJOID.Name = "LblVideoJOID"
@@ -8209,48 +8321,48 @@ Partial Class FrmSettings
 		'BTNVideoCHD
 		'
 		Me.BTNVideoCHD.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoCHD.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoCHD.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoCHD.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoCHD.Location = New System.Drawing.Point(73, 36)
 		Me.BTNVideoCHD.Name = "BTNVideoCHD"
 		Me.BTNVideoCHD.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoCHD.TabIndex = 132
 		Me.BTNVideoCHD.Text = "1"
-		Me.BTNVideoCHD.UseVisualStyleBackColor = false
+		Me.BTNVideoCHD.UseVisualStyleBackColor = False
 		'
 		'BTNVideoJOID
 		'
 		Me.BTNVideoJOID.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoJOID.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoJOID.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoJOID.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoJOID.Location = New System.Drawing.Point(73, 13)
 		Me.BTNVideoJOID.Name = "BTNVideoJOID"
 		Me.BTNVideoJOID.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoJOID.TabIndex = 131
 		Me.BTNVideoJOID.Text = "1"
-		Me.BTNVideoJOID.UseVisualStyleBackColor = false
+		Me.BTNVideoJOID.UseVisualStyleBackColor = False
 		'
 		'CBVideoJOID
 		'
-		Me.CBVideoJOID.AutoSize = true
+		Me.CBVideoJOID.AutoSize = True
 		Me.CBVideoJOID.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoJOID.Location = New System.Drawing.Point(6, 19)
 		Me.CBVideoJOID.Name = "CBVideoJOID"
 		Me.CBVideoJOID.Size = New System.Drawing.Size(42, 17)
 		Me.CBVideoJOID.TabIndex = 56
 		Me.CBVideoJOID.Text = "JOI"
-		Me.CBVideoJOID.UseVisualStyleBackColor = true
+		Me.CBVideoJOID.UseVisualStyleBackColor = True
 		'
 		'CBVideoCHD
 		'
-		Me.CBVideoCHD.AutoSize = true
+		Me.CBVideoCHD.AutoSize = True
 		Me.CBVideoCHD.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoCHD.Location = New System.Drawing.Point(6, 43)
 		Me.CBVideoCHD.Name = "CBVideoCHD"
 		Me.CBVideoCHD.Size = New System.Drawing.Size(41, 17)
 		Me.CBVideoCHD.TabIndex = 57
 		Me.CBVideoCHD.Text = "CH"
-		Me.CBVideoCHD.UseVisualStyleBackColor = true
+		Me.CBVideoCHD.UseVisualStyleBackColor = True
 		'
 		'GroupBox23
 		'
@@ -8284,13 +8396,13 @@ Partial Class FrmSettings
 		Me.GroupBox23.Name = "GroupBox23"
 		Me.GroupBox23.Size = New System.Drawing.Size(340, 165)
 		Me.GroupBox23.TabIndex = 144
-		Me.GroupBox23.TabStop = false
+		Me.GroupBox23.TabStop = False
 		Me.GroupBox23.Text = "Domme Genre"
 		'
 		'LblVideoFemsubTotalD
 		'
 		Me.LblVideoFemsubTotalD.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoFemsubTotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoFemsubTotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoFemsubTotalD.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoFemsubTotalD.Location = New System.Drawing.Point(299, 136)
 		Me.LblVideoFemsubTotalD.Name = "LblVideoFemsubTotalD"
@@ -8303,7 +8415,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoFemsubD.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoFemsubD.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoFemsubD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoFemsubD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoFemsubD.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoFemsubD.Location = New System.Drawing.Point(113, 136)
 		Me.LblVideoFemsubD.Name = "LblVideoFemsubD"
@@ -8315,7 +8427,7 @@ Partial Class FrmSettings
 		'LblVideoFemdomTotalD
 		'
 		Me.LblVideoFemdomTotalD.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoFemdomTotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoFemdomTotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoFemdomTotalD.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoFemdomTotalD.Location = New System.Drawing.Point(299, 112)
 		Me.LblVideoFemdomTotalD.Name = "LblVideoFemdomTotalD"
@@ -8328,7 +8440,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoFemdomD.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoFemdomD.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoFemdomD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoFemdomD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoFemdomD.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoFemdomD.Location = New System.Drawing.Point(113, 112)
 		Me.LblVideoFemdomD.Name = "LblVideoFemdomD"
@@ -8341,7 +8453,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoBlowjobD.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoBlowjobD.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoBlowjobD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoBlowjobD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoBlowjobD.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoBlowjobD.Location = New System.Drawing.Point(113, 88)
 		Me.LblVideoBlowjobD.Name = "LblVideoBlowjobD"
@@ -8353,7 +8465,7 @@ Partial Class FrmSettings
 		'LblVideoBlowjobTotalD
 		'
 		Me.LblVideoBlowjobTotalD.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoBlowjobTotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoBlowjobTotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoBlowjobTotalD.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoBlowjobTotalD.Location = New System.Drawing.Point(299, 88)
 		Me.LblVideoBlowjobTotalD.Name = "LblVideoBlowjobTotalD"
@@ -8366,7 +8478,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoLesbianD.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoLesbianD.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoLesbianD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoLesbianD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoLesbianD.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoLesbianD.Location = New System.Drawing.Point(113, 65)
 		Me.LblVideoLesbianD.Name = "LblVideoLesbianD"
@@ -8379,7 +8491,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoSoftCoreD.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoSoftCoreD.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoSoftCoreD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoSoftCoreD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoSoftCoreD.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoSoftCoreD.Location = New System.Drawing.Point(113, 42)
 		Me.LblVideoSoftCoreD.Name = "LblVideoSoftCoreD"
@@ -8391,7 +8503,7 @@ Partial Class FrmSettings
 		'LblVideoLesbianTotalD
 		'
 		Me.LblVideoLesbianTotalD.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoLesbianTotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoLesbianTotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoLesbianTotalD.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoLesbianTotalD.Location = New System.Drawing.Point(299, 66)
 		Me.LblVideoLesbianTotalD.Name = "LblVideoLesbianTotalD"
@@ -8404,7 +8516,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoHardCoreD.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoHardCoreD.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoHardCoreD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoHardCoreD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoHardCoreD.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoHardCoreD.Location = New System.Drawing.Point(113, 19)
 		Me.LblVideoHardCoreD.Name = "LblVideoHardCoreD"
@@ -8416,19 +8528,19 @@ Partial Class FrmSettings
 		'BTNVideoFemSubD
 		'
 		Me.BTNVideoFemSubD.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoFemSubD.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoFemSubD.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoFemSubD.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoFemSubD.Location = New System.Drawing.Point(73, 130)
 		Me.BTNVideoFemSubD.Name = "BTNVideoFemSubD"
 		Me.BTNVideoFemSubD.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoFemSubD.TabIndex = 131
 		Me.BTNVideoFemSubD.Text = "1"
-		Me.BTNVideoFemSubD.UseVisualStyleBackColor = false
+		Me.BTNVideoFemSubD.UseVisualStyleBackColor = False
 		'
 		'LblVideoSoftCoreTotalD
 		'
 		Me.LblVideoSoftCoreTotalD.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoSoftCoreTotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoSoftCoreTotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoSoftCoreTotalD.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoSoftCoreTotalD.Location = New System.Drawing.Point(299, 43)
 		Me.LblVideoSoftCoreTotalD.Name = "LblVideoSoftCoreTotalD"
@@ -8440,31 +8552,31 @@ Partial Class FrmSettings
 		'BTNVideoFemDomD
 		'
 		Me.BTNVideoFemDomD.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoFemDomD.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoFemDomD.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoFemDomD.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoFemDomD.Location = New System.Drawing.Point(73, 106)
 		Me.BTNVideoFemDomD.Name = "BTNVideoFemDomD"
 		Me.BTNVideoFemDomD.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoFemDomD.TabIndex = 130
 		Me.BTNVideoFemDomD.Text = "1"
-		Me.BTNVideoFemDomD.UseVisualStyleBackColor = false
+		Me.BTNVideoFemDomD.UseVisualStyleBackColor = False
 		'
 		'BTNVideoBlowjobD
 		'
 		Me.BTNVideoBlowjobD.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoBlowjobD.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoBlowjobD.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoBlowjobD.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoBlowjobD.Location = New System.Drawing.Point(73, 82)
 		Me.BTNVideoBlowjobD.Name = "BTNVideoBlowjobD"
 		Me.BTNVideoBlowjobD.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoBlowjobD.TabIndex = 129
 		Me.BTNVideoBlowjobD.Text = "1"
-		Me.BTNVideoBlowjobD.UseVisualStyleBackColor = false
+		Me.BTNVideoBlowjobD.UseVisualStyleBackColor = False
 		'
 		'LblVideoHardCoreTotalD
 		'
 		Me.LblVideoHardCoreTotalD.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoHardCoreTotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoHardCoreTotalD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoHardCoreTotalD.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoHardCoreTotalD.Location = New System.Drawing.Point(299, 19)
 		Me.LblVideoHardCoreTotalD.Name = "LblVideoHardCoreTotalD"
@@ -8476,104 +8588,104 @@ Partial Class FrmSettings
 		'BTNVideoLesbianD
 		'
 		Me.BTNVideoLesbianD.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoLesbianD.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoLesbianD.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoLesbianD.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoLesbianD.Location = New System.Drawing.Point(73, 59)
 		Me.BTNVideoLesbianD.Name = "BTNVideoLesbianD"
 		Me.BTNVideoLesbianD.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoLesbianD.TabIndex = 128
 		Me.BTNVideoLesbianD.Text = "1"
-		Me.BTNVideoLesbianD.UseVisualStyleBackColor = false
+		Me.BTNVideoLesbianD.UseVisualStyleBackColor = False
 		'
 		'BTNVideoSoftCoreD
 		'
 		Me.BTNVideoSoftCoreD.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoSoftCoreD.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoSoftCoreD.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoSoftCoreD.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoSoftCoreD.Location = New System.Drawing.Point(73, 36)
 		Me.BTNVideoSoftCoreD.Name = "BTNVideoSoftCoreD"
 		Me.BTNVideoSoftCoreD.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoSoftCoreD.TabIndex = 127
 		Me.BTNVideoSoftCoreD.Text = "1"
-		Me.BTNVideoSoftCoreD.UseVisualStyleBackColor = false
+		Me.BTNVideoSoftCoreD.UseVisualStyleBackColor = False
 		'
 		'BTNVideoHardCoreD
 		'
 		Me.BTNVideoHardCoreD.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoHardCoreD.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoHardCoreD.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoHardCoreD.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoHardCoreD.Location = New System.Drawing.Point(73, 12)
 		Me.BTNVideoHardCoreD.Name = "BTNVideoHardCoreD"
 		Me.BTNVideoHardCoreD.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoHardCoreD.TabIndex = 126
 		Me.BTNVideoHardCoreD.Text = "1"
-		Me.BTNVideoHardCoreD.UseVisualStyleBackColor = false
+		Me.BTNVideoHardCoreD.UseVisualStyleBackColor = False
 		'
 		'CBVideoHardcoreD
 		'
-		Me.CBVideoHardcoreD.AutoSize = true
+		Me.CBVideoHardcoreD.AutoSize = True
 		Me.CBVideoHardcoreD.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoHardcoreD.Location = New System.Drawing.Point(6, 19)
 		Me.CBVideoHardcoreD.Name = "CBVideoHardcoreD"
 		Me.CBVideoHardcoreD.Size = New System.Drawing.Size(70, 17)
 		Me.CBVideoHardcoreD.TabIndex = 50
 		Me.CBVideoHardcoreD.Text = "Hardcore"
-		Me.CBVideoHardcoreD.UseVisualStyleBackColor = true
+		Me.CBVideoHardcoreD.UseVisualStyleBackColor = True
 		'
 		'CBVideoSoftCoreD
 		'
-		Me.CBVideoSoftCoreD.AutoSize = true
+		Me.CBVideoSoftCoreD.AutoSize = True
 		Me.CBVideoSoftCoreD.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoSoftCoreD.Location = New System.Drawing.Point(6, 43)
 		Me.CBVideoSoftCoreD.Name = "CBVideoSoftCoreD"
 		Me.CBVideoSoftCoreD.Size = New System.Drawing.Size(66, 17)
 		Me.CBVideoSoftCoreD.TabIndex = 51
 		Me.CBVideoSoftCoreD.Text = "Softcore"
-		Me.CBVideoSoftCoreD.UseVisualStyleBackColor = true
+		Me.CBVideoSoftCoreD.UseVisualStyleBackColor = True
 		'
 		'CBVideoLesbianD
 		'
-		Me.CBVideoLesbianD.AutoSize = true
+		Me.CBVideoLesbianD.AutoSize = True
 		Me.CBVideoLesbianD.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoLesbianD.Location = New System.Drawing.Point(6, 66)
 		Me.CBVideoLesbianD.Name = "CBVideoLesbianD"
 		Me.CBVideoLesbianD.Size = New System.Drawing.Size(63, 17)
 		Me.CBVideoLesbianD.TabIndex = 52
 		Me.CBVideoLesbianD.Text = "Lesbian"
-		Me.CBVideoLesbianD.UseVisualStyleBackColor = true
+		Me.CBVideoLesbianD.UseVisualStyleBackColor = True
 		'
 		'CBVideoBlowjobD
 		'
-		Me.CBVideoBlowjobD.AutoSize = true
+		Me.CBVideoBlowjobD.AutoSize = True
 		Me.CBVideoBlowjobD.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoBlowjobD.Location = New System.Drawing.Point(6, 89)
 		Me.CBVideoBlowjobD.Name = "CBVideoBlowjobD"
 		Me.CBVideoBlowjobD.Size = New System.Drawing.Size(63, 17)
 		Me.CBVideoBlowjobD.TabIndex = 53
 		Me.CBVideoBlowjobD.Text = "Blowjob"
-		Me.CBVideoBlowjobD.UseVisualStyleBackColor = true
+		Me.CBVideoBlowjobD.UseVisualStyleBackColor = True
 		'
 		'CBVideoFemsubD
 		'
-		Me.CBVideoFemsubD.AutoSize = true
+		Me.CBVideoFemsubD.AutoSize = True
 		Me.CBVideoFemsubD.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoFemsubD.Location = New System.Drawing.Point(6, 137)
 		Me.CBVideoFemsubD.Name = "CBVideoFemsubD"
 		Me.CBVideoFemsubD.Size = New System.Drawing.Size(63, 17)
 		Me.CBVideoFemsubD.TabIndex = 55
 		Me.CBVideoFemsubD.Text = "Femsub"
-		Me.CBVideoFemsubD.UseVisualStyleBackColor = true
+		Me.CBVideoFemsubD.UseVisualStyleBackColor = True
 		'
 		'CBVideoFemdomD
 		'
-		Me.CBVideoFemdomD.AutoSize = true
+		Me.CBVideoFemdomD.AutoSize = True
 		Me.CBVideoFemdomD.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoFemdomD.Location = New System.Drawing.Point(6, 113)
 		Me.CBVideoFemdomD.Name = "CBVideoFemdomD"
 		Me.CBVideoFemdomD.Size = New System.Drawing.Size(66, 17)
 		Me.CBVideoFemdomD.TabIndex = 54
 		Me.CBVideoFemdomD.Text = "Femdom"
-		Me.CBVideoFemdomD.UseVisualStyleBackColor = true
+		Me.CBVideoFemdomD.UseVisualStyleBackColor = True
 		'
 		'GroupBox8
 		'
@@ -8584,21 +8696,21 @@ Partial Class FrmSettings
 		Me.GroupBox8.Name = "GroupBox8"
 		Me.GroupBox8.Size = New System.Drawing.Size(692, 92)
 		Me.GroupBox8.TabIndex = 65
-		Me.GroupBox8.TabStop = false
+		Me.GroupBox8.TabStop = False
 		Me.GroupBox8.Text = "Description"
 		'
 		'VideoDescriptionLabel
 		'
 		Me.VideoDescriptionLabel.BackColor = System.Drawing.Color.Transparent
-		Me.VideoDescriptionLabel.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.VideoDescriptionLabel.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.VideoDescriptionLabel.ForeColor = System.Drawing.Color.Black
 		Me.VideoDescriptionLabel.Location = New System.Drawing.Point(6, 16)
 		Me.VideoDescriptionLabel.Name = "VideoDescriptionLabel"
 		Me.VideoDescriptionLabel.Size = New System.Drawing.Size(680, 73)
 		Me.VideoDescriptionLabel.TabIndex = 62
-		Me.VideoDescriptionLabel.Text = "Use this page to select the videos you would like the program to use and set thei"& _ 
-    "r paths."&Global.Microsoft.VisualBasic.ChrW(13)&Global.Microsoft.VisualBasic.ChrW(10)&Global.Microsoft.VisualBasic.ChrW(13)&Global.Microsoft.VisualBasic.ChrW(10)&"The Domme Genre paths are for videos that feature the model you are "& _ 
-    "using as your domme."
+		Me.VideoDescriptionLabel.Text = "Use this page to select the videos you would like the program to use and set thei" &
+	"r paths." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "The Domme Genre paths are for videos that feature the model you are " &
+	"using as your domme."
 		Me.VideoDescriptionLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
 		'
 		'GroupBox4
@@ -8613,13 +8725,13 @@ Partial Class FrmSettings
 		Me.GroupBox4.Name = "GroupBox4"
 		Me.GroupBox4.Size = New System.Drawing.Size(340, 48)
 		Me.GroupBox4.TabIndex = 64
-		Me.GroupBox4.TabStop = false
+		Me.GroupBox4.TabStop = False
 		Me.GroupBox4.Text = "General"
 		'
 		'LblVideoGeneralTotal
 		'
 		Me.LblVideoGeneralTotal.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoGeneralTotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoGeneralTotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoGeneralTotal.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoGeneralTotal.Location = New System.Drawing.Point(299, 19)
 		Me.LblVideoGeneralTotal.Name = "LblVideoGeneralTotal"
@@ -8632,7 +8744,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoGeneral.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoGeneral.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoGeneral.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoGeneral.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoGeneral.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoGeneral.Location = New System.Drawing.Point(113, 18)
 		Me.LblVideoGeneral.Name = "LblVideoGeneral"
@@ -8644,25 +8756,25 @@ Partial Class FrmSettings
 		'BTNVideoGeneral
 		'
 		Me.BTNVideoGeneral.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoGeneral.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoGeneral.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoGeneral.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoGeneral.Location = New System.Drawing.Point(73, 13)
 		Me.BTNVideoGeneral.Name = "BTNVideoGeneral"
 		Me.BTNVideoGeneral.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoGeneral.TabIndex = 131
 		Me.BTNVideoGeneral.Text = "1"
-		Me.BTNVideoGeneral.UseVisualStyleBackColor = false
+		Me.BTNVideoGeneral.UseVisualStyleBackColor = False
 		'
 		'CBVideoGeneral
 		'
-		Me.CBVideoGeneral.AutoSize = true
+		Me.CBVideoGeneral.AutoSize = True
 		Me.CBVideoGeneral.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoGeneral.Location = New System.Drawing.Point(6, 19)
 		Me.CBVideoGeneral.Name = "CBVideoGeneral"
 		Me.CBVideoGeneral.Size = New System.Drawing.Size(63, 17)
 		Me.CBVideoGeneral.TabIndex = 56
 		Me.CBVideoGeneral.Text = "General"
-		Me.CBVideoGeneral.UseVisualStyleBackColor = true
+		Me.CBVideoGeneral.UseVisualStyleBackColor = True
 		'
 		'GroupBox3
 		'
@@ -8680,13 +8792,13 @@ Partial Class FrmSettings
 		Me.GroupBox3.Name = "GroupBox3"
 		Me.GroupBox3.Size = New System.Drawing.Size(340, 70)
 		Me.GroupBox3.TabIndex = 63
-		Me.GroupBox3.TabStop = false
+		Me.GroupBox3.TabStop = False
 		Me.GroupBox3.Text = "Special"
 		'
 		'LblVideoCHTotal
 		'
 		Me.LblVideoCHTotal.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoCHTotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoCHTotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoCHTotal.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoCHTotal.Location = New System.Drawing.Point(299, 41)
 		Me.LblVideoCHTotal.Name = "LblVideoCHTotal"
@@ -8698,7 +8810,7 @@ Partial Class FrmSettings
 		'LblVideoJOITotal
 		'
 		Me.LblVideoJOITotal.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoJOITotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoJOITotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoJOITotal.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoJOITotal.Location = New System.Drawing.Point(299, 18)
 		Me.LblVideoJOITotal.Name = "LblVideoJOITotal"
@@ -8711,7 +8823,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoCH.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoCH.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoCH.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoCH.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoCH.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoCH.Location = New System.Drawing.Point(113, 41)
 		Me.LblVideoCH.Name = "LblVideoCH"
@@ -8724,7 +8836,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoJOI.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoJOI.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoJOI.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoJOI.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoJOI.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoJOI.Location = New System.Drawing.Point(113, 18)
 		Me.LblVideoJOI.Name = "LblVideoJOI"
@@ -8736,48 +8848,48 @@ Partial Class FrmSettings
 		'BTNVideoCH
 		'
 		Me.BTNVideoCH.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoCH.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoCH.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoCH.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoCH.Location = New System.Drawing.Point(73, 36)
 		Me.BTNVideoCH.Name = "BTNVideoCH"
 		Me.BTNVideoCH.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoCH.TabIndex = 132
 		Me.BTNVideoCH.Text = "1"
-		Me.BTNVideoCH.UseVisualStyleBackColor = false
+		Me.BTNVideoCH.UseVisualStyleBackColor = False
 		'
 		'BTNVideoJOI
 		'
 		Me.BTNVideoJOI.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoJOI.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoJOI.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoJOI.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoJOI.Location = New System.Drawing.Point(73, 13)
 		Me.BTNVideoJOI.Name = "BTNVideoJOI"
 		Me.BTNVideoJOI.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoJOI.TabIndex = 131
 		Me.BTNVideoJOI.Text = "1"
-		Me.BTNVideoJOI.UseVisualStyleBackColor = false
+		Me.BTNVideoJOI.UseVisualStyleBackColor = False
 		'
 		'CBVideoJOI
 		'
-		Me.CBVideoJOI.AutoSize = true
+		Me.CBVideoJOI.AutoSize = True
 		Me.CBVideoJOI.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoJOI.Location = New System.Drawing.Point(6, 19)
 		Me.CBVideoJOI.Name = "CBVideoJOI"
 		Me.CBVideoJOI.Size = New System.Drawing.Size(42, 17)
 		Me.CBVideoJOI.TabIndex = 56
 		Me.CBVideoJOI.Text = "JOI"
-		Me.CBVideoJOI.UseVisualStyleBackColor = true
+		Me.CBVideoJOI.UseVisualStyleBackColor = True
 		'
 		'CBVideoCH
 		'
-		Me.CBVideoCH.AutoSize = true
+		Me.CBVideoCH.AutoSize = True
 		Me.CBVideoCH.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoCH.Location = New System.Drawing.Point(6, 43)
 		Me.CBVideoCH.Name = "CBVideoCH"
 		Me.CBVideoCH.Size = New System.Drawing.Size(41, 17)
 		Me.CBVideoCH.TabIndex = 57
 		Me.CBVideoCH.Text = "CH"
-		Me.CBVideoCH.UseVisualStyleBackColor = true
+		Me.CBVideoCH.UseVisualStyleBackColor = True
 		'
 		'GroupBox2
 		'
@@ -8811,13 +8923,13 @@ Partial Class FrmSettings
 		Me.GroupBox2.Name = "GroupBox2"
 		Me.GroupBox2.Size = New System.Drawing.Size(340, 165)
 		Me.GroupBox2.TabIndex = 62
-		Me.GroupBox2.TabStop = false
+		Me.GroupBox2.TabStop = False
 		Me.GroupBox2.Text = "Genre"
 		'
 		'LblVideoFemsubTotal
 		'
 		Me.LblVideoFemsubTotal.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoFemsubTotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoFemsubTotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoFemsubTotal.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoFemsubTotal.Location = New System.Drawing.Point(299, 136)
 		Me.LblVideoFemsubTotal.Name = "LblVideoFemsubTotal"
@@ -8830,7 +8942,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoFemsub.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoFemsub.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoFemsub.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoFemsub.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoFemsub.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoFemsub.Location = New System.Drawing.Point(113, 136)
 		Me.LblVideoFemsub.Name = "LblVideoFemsub"
@@ -8842,7 +8954,7 @@ Partial Class FrmSettings
 		'LblVideoFemdomTotal
 		'
 		Me.LblVideoFemdomTotal.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoFemdomTotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoFemdomTotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoFemdomTotal.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoFemdomTotal.Location = New System.Drawing.Point(299, 112)
 		Me.LblVideoFemdomTotal.Name = "LblVideoFemdomTotal"
@@ -8855,7 +8967,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoFemdom.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoFemdom.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoFemdom.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoFemdom.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoFemdom.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoFemdom.Location = New System.Drawing.Point(113, 112)
 		Me.LblVideoFemdom.Name = "LblVideoFemdom"
@@ -8868,7 +8980,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoBlowjob.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoBlowjob.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoBlowjob.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoBlowjob.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoBlowjob.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoBlowjob.Location = New System.Drawing.Point(113, 88)
 		Me.LblVideoBlowjob.Name = "LblVideoBlowjob"
@@ -8880,7 +8992,7 @@ Partial Class FrmSettings
 		'LblVideoBlowjobTotal
 		'
 		Me.LblVideoBlowjobTotal.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoBlowjobTotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoBlowjobTotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoBlowjobTotal.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoBlowjobTotal.Location = New System.Drawing.Point(299, 88)
 		Me.LblVideoBlowjobTotal.Name = "LblVideoBlowjobTotal"
@@ -8893,7 +9005,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoLesbian.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoLesbian.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoLesbian.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoLesbian.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoLesbian.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoLesbian.Location = New System.Drawing.Point(113, 65)
 		Me.LblVideoLesbian.Name = "LblVideoLesbian"
@@ -8906,7 +9018,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoSoftCore.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoSoftCore.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoSoftCore.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoSoftCore.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoSoftCore.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoSoftCore.Location = New System.Drawing.Point(113, 42)
 		Me.LblVideoSoftCore.Name = "LblVideoSoftCore"
@@ -8918,7 +9030,7 @@ Partial Class FrmSettings
 		'LblVideoLesbianTotal
 		'
 		Me.LblVideoLesbianTotal.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoLesbianTotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoLesbianTotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoLesbianTotal.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoLesbianTotal.Location = New System.Drawing.Point(299, 66)
 		Me.LblVideoLesbianTotal.Name = "LblVideoLesbianTotal"
@@ -8931,7 +9043,7 @@ Partial Class FrmSettings
 		'
 		Me.LblVideoHardCore.BackColor = System.Drawing.Color.Transparent
 		Me.LblVideoHardCore.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LblVideoHardCore.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoHardCore.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoHardCore.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoHardCore.Location = New System.Drawing.Point(113, 19)
 		Me.LblVideoHardCore.Name = "LblVideoHardCore"
@@ -8943,19 +9055,19 @@ Partial Class FrmSettings
 		'BTNVideoFemSub
 		'
 		Me.BTNVideoFemSub.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoFemSub.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoFemSub.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoFemSub.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoFemSub.Location = New System.Drawing.Point(73, 130)
 		Me.BTNVideoFemSub.Name = "BTNVideoFemSub"
 		Me.BTNVideoFemSub.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoFemSub.TabIndex = 131
 		Me.BTNVideoFemSub.Text = "1"
-		Me.BTNVideoFemSub.UseVisualStyleBackColor = false
+		Me.BTNVideoFemSub.UseVisualStyleBackColor = False
 		'
 		'LblVideoSoftCoreTotal
 		'
 		Me.LblVideoSoftCoreTotal.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoSoftCoreTotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoSoftCoreTotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoSoftCoreTotal.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoSoftCoreTotal.Location = New System.Drawing.Point(299, 43)
 		Me.LblVideoSoftCoreTotal.Name = "LblVideoSoftCoreTotal"
@@ -8967,31 +9079,31 @@ Partial Class FrmSettings
 		'BTNVideoFemDom
 		'
 		Me.BTNVideoFemDom.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoFemDom.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoFemDom.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoFemDom.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoFemDom.Location = New System.Drawing.Point(73, 106)
 		Me.BTNVideoFemDom.Name = "BTNVideoFemDom"
 		Me.BTNVideoFemDom.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoFemDom.TabIndex = 130
 		Me.BTNVideoFemDom.Text = "1"
-		Me.BTNVideoFemDom.UseVisualStyleBackColor = false
+		Me.BTNVideoFemDom.UseVisualStyleBackColor = False
 		'
 		'BTNVideoBlowjob
 		'
 		Me.BTNVideoBlowjob.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoBlowjob.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoBlowjob.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoBlowjob.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoBlowjob.Location = New System.Drawing.Point(73, 82)
 		Me.BTNVideoBlowjob.Name = "BTNVideoBlowjob"
 		Me.BTNVideoBlowjob.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoBlowjob.TabIndex = 129
 		Me.BTNVideoBlowjob.Text = "1"
-		Me.BTNVideoBlowjob.UseVisualStyleBackColor = false
+		Me.BTNVideoBlowjob.UseVisualStyleBackColor = False
 		'
 		'LblVideoHardCoreTotal
 		'
 		Me.LblVideoHardCoreTotal.BackColor = System.Drawing.Color.Transparent
-		Me.LblVideoHardCoreTotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LblVideoHardCoreTotal.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LblVideoHardCoreTotal.ForeColor = System.Drawing.Color.Black
 		Me.LblVideoHardCoreTotal.Location = New System.Drawing.Point(299, 19)
 		Me.LblVideoHardCoreTotal.Name = "LblVideoHardCoreTotal"
@@ -9003,109 +9115,109 @@ Partial Class FrmSettings
 		'BTNVideoLesbian
 		'
 		Me.BTNVideoLesbian.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoLesbian.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoLesbian.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoLesbian.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoLesbian.Location = New System.Drawing.Point(73, 59)
 		Me.BTNVideoLesbian.Name = "BTNVideoLesbian"
 		Me.BTNVideoLesbian.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoLesbian.TabIndex = 128
 		Me.BTNVideoLesbian.Text = "1"
-		Me.BTNVideoLesbian.UseVisualStyleBackColor = false
+		Me.BTNVideoLesbian.UseVisualStyleBackColor = False
 		'
 		'BTNVideoSoftCore
 		'
 		Me.BTNVideoSoftCore.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoSoftCore.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoSoftCore.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoSoftCore.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoSoftCore.Location = New System.Drawing.Point(73, 36)
 		Me.BTNVideoSoftCore.Name = "BTNVideoSoftCore"
 		Me.BTNVideoSoftCore.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoSoftCore.TabIndex = 127
 		Me.BTNVideoSoftCore.Text = "1"
-		Me.BTNVideoSoftCore.UseVisualStyleBackColor = false
+		Me.BTNVideoSoftCore.UseVisualStyleBackColor = False
 		'
 		'BTNVideoHardCore
 		'
 		Me.BTNVideoHardCore.BackColor = System.Drawing.Color.LightGray
-		Me.BTNVideoHardCore.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.BTNVideoHardCore.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.BTNVideoHardCore.ForeColor = System.Drawing.Color.Black
 		Me.BTNVideoHardCore.Location = New System.Drawing.Point(73, 12)
 		Me.BTNVideoHardCore.Name = "BTNVideoHardCore"
 		Me.BTNVideoHardCore.Size = New System.Drawing.Size(34, 28)
 		Me.BTNVideoHardCore.TabIndex = 126
 		Me.BTNVideoHardCore.Text = "1"
-		Me.BTNVideoHardCore.UseVisualStyleBackColor = false
+		Me.BTNVideoHardCore.UseVisualStyleBackColor = False
 		'
 		'CBVideoHardcore
 		'
-		Me.CBVideoHardcore.AutoSize = true
+		Me.CBVideoHardcore.AutoSize = True
 		Me.CBVideoHardcore.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoHardcore.Location = New System.Drawing.Point(6, 19)
 		Me.CBVideoHardcore.Name = "CBVideoHardcore"
 		Me.CBVideoHardcore.Size = New System.Drawing.Size(70, 17)
 		Me.CBVideoHardcore.TabIndex = 50
 		Me.CBVideoHardcore.Text = "Hardcore"
-		Me.CBVideoHardcore.UseVisualStyleBackColor = true
+		Me.CBVideoHardcore.UseVisualStyleBackColor = True
 		'
 		'CBVideoSoftCore
 		'
-		Me.CBVideoSoftCore.AutoSize = true
+		Me.CBVideoSoftCore.AutoSize = True
 		Me.CBVideoSoftCore.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoSoftCore.Location = New System.Drawing.Point(6, 43)
 		Me.CBVideoSoftCore.Name = "CBVideoSoftCore"
 		Me.CBVideoSoftCore.Size = New System.Drawing.Size(66, 17)
 		Me.CBVideoSoftCore.TabIndex = 51
 		Me.CBVideoSoftCore.Text = "Softcore"
-		Me.CBVideoSoftCore.UseVisualStyleBackColor = true
+		Me.CBVideoSoftCore.UseVisualStyleBackColor = True
 		'
 		'CBVideoLesbian
 		'
-		Me.CBVideoLesbian.AutoSize = true
+		Me.CBVideoLesbian.AutoSize = True
 		Me.CBVideoLesbian.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoLesbian.Location = New System.Drawing.Point(6, 66)
 		Me.CBVideoLesbian.Name = "CBVideoLesbian"
 		Me.CBVideoLesbian.Size = New System.Drawing.Size(63, 17)
 		Me.CBVideoLesbian.TabIndex = 52
 		Me.CBVideoLesbian.Text = "Lesbian"
-		Me.CBVideoLesbian.UseVisualStyleBackColor = true
+		Me.CBVideoLesbian.UseVisualStyleBackColor = True
 		'
 		'CBVideoBlowjob
 		'
-		Me.CBVideoBlowjob.AutoSize = true
+		Me.CBVideoBlowjob.AutoSize = True
 		Me.CBVideoBlowjob.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoBlowjob.Location = New System.Drawing.Point(6, 89)
 		Me.CBVideoBlowjob.Name = "CBVideoBlowjob"
 		Me.CBVideoBlowjob.Size = New System.Drawing.Size(63, 17)
 		Me.CBVideoBlowjob.TabIndex = 53
 		Me.CBVideoBlowjob.Text = "Blowjob"
-		Me.CBVideoBlowjob.UseVisualStyleBackColor = true
+		Me.CBVideoBlowjob.UseVisualStyleBackColor = True
 		'
 		'CBVideoFemsub
 		'
-		Me.CBVideoFemsub.AutoSize = true
+		Me.CBVideoFemsub.AutoSize = True
 		Me.CBVideoFemsub.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoFemsub.Location = New System.Drawing.Point(6, 137)
 		Me.CBVideoFemsub.Name = "CBVideoFemsub"
 		Me.CBVideoFemsub.Size = New System.Drawing.Size(63, 17)
 		Me.CBVideoFemsub.TabIndex = 55
 		Me.CBVideoFemsub.Text = "Femsub"
-		Me.CBVideoFemsub.UseVisualStyleBackColor = true
+		Me.CBVideoFemsub.UseVisualStyleBackColor = True
 		'
 		'CBVideoFemdom
 		'
-		Me.CBVideoFemdom.AutoSize = true
+		Me.CBVideoFemdom.AutoSize = True
 		Me.CBVideoFemdom.ForeColor = System.Drawing.Color.Black
 		Me.CBVideoFemdom.Location = New System.Drawing.Point(6, 113)
 		Me.CBVideoFemdom.Name = "CBVideoFemdom"
 		Me.CBVideoFemdom.Size = New System.Drawing.Size(66, 17)
 		Me.CBVideoFemdom.TabIndex = 54
 		Me.CBVideoFemdom.Text = "Femdom"
-		Me.CBVideoFemdom.UseVisualStyleBackColor = true
+		Me.CBVideoFemdom.UseVisualStyleBackColor = True
 		'
 		'Label8
 		'
 		Me.Label8.BackColor = System.Drawing.Color.Transparent
-		Me.Label8.Font = New System.Drawing.Font("Microsoft Sans Serif", 12!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label8.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label8.ForeColor = System.Drawing.Color.Black
 		Me.Label8.Location = New System.Drawing.Point(7, 6)
 		Me.Label8.Name = "Label8"
@@ -9166,41 +9278,41 @@ Partial Class FrmSettings
 		'Button15
 		'
 		Me.Button15.BackColor = System.Drawing.Color.LightGray
-		Me.Button15.BackgroundImage = CType(resources.GetObject("Button15.BackgroundImage"),System.Drawing.Image)
+		Me.Button15.BackgroundImage = CType(resources.GetObject("Button15.BackgroundImage"), System.Drawing.Image)
 		Me.Button15.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch
 		Me.Button15.FlatAppearance.BorderSize = 0
 		Me.Button15.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Gray
 		Me.Button15.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Silver
 		Me.Button15.FlatStyle = System.Windows.Forms.FlatStyle.Flat
-		Me.Button15.Font = New System.Drawing.Font("Arial", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Button15.Font = New System.Drawing.Font("Arial", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Button15.ForeColor = System.Drawing.Color.Black
 		Me.Button15.Location = New System.Drawing.Point(670, 366)
 		Me.Button15.Name = "Button15"
 		Me.Button15.Size = New System.Drawing.Size(30, 26)
 		Me.Button15.TabIndex = 163
-		Me.Button15.UseVisualStyleBackColor = false
+		Me.Button15.UseVisualStyleBackColor = False
 		'
 		'Button16
 		'
 		Me.Button16.BackColor = System.Drawing.Color.LightGray
-		Me.Button16.BackgroundImage = CType(resources.GetObject("Button16.BackgroundImage"),System.Drawing.Image)
+		Me.Button16.BackgroundImage = CType(resources.GetObject("Button16.BackgroundImage"), System.Drawing.Image)
 		Me.Button16.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch
 		Me.Button16.FlatAppearance.BorderSize = 0
 		Me.Button16.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Gray
 		Me.Button16.FlatAppearance.MouseOverBackColor = System.Drawing.Color.Silver
 		Me.Button16.FlatStyle = System.Windows.Forms.FlatStyle.Flat
-		Me.Button16.Font = New System.Drawing.Font("Arial", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Button16.Font = New System.Drawing.Font("Arial", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Button16.ForeColor = System.Drawing.Color.Black
 		Me.Button16.Location = New System.Drawing.Point(667, 324)
 		Me.Button16.Name = "Button16"
 		Me.Button16.Size = New System.Drawing.Size(30, 26)
 		Me.Button16.TabIndex = 164
-		Me.Button16.UseVisualStyleBackColor = false
+		Me.Button16.UseVisualStyleBackColor = False
 		'
 		'Label121
 		'
-		Me.Label121.AutoSize = true
-		Me.Label121.Font = New System.Drawing.Font("Microsoft Sans Serif", 7!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label121.AutoSize = True
+		Me.Label121.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label121.ForeColor = System.Drawing.Color.Black
 		Me.Label121.Location = New System.Drawing.Point(669, 352)
 		Me.Label121.Name = "Label121"
@@ -9211,8 +9323,8 @@ Partial Class FrmSettings
 		'
 		'Label122
 		'
-		Me.Label122.AutoSize = true
-		Me.Label122.Font = New System.Drawing.Font("Microsoft Sans Serif", 7!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label122.AutoSize = True
+		Me.Label122.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label122.ForeColor = System.Drawing.Color.Black
 		Me.Label122.Location = New System.Drawing.Point(667, 313)
 		Me.Label122.Name = "Label122"
@@ -9244,46 +9356,46 @@ Partial Class FrmSettings
 		Me.GBGlitterD.Name = "GBGlitterD"
 		Me.GBGlitterD.Size = New System.Drawing.Size(344, 150)
 		Me.GBGlitterD.TabIndex = 162
-		Me.GBGlitterD.TabStop = false
+		Me.GBGlitterD.TabStop = False
 		Me.GBGlitterD.Text = "Domme"
 		'
 		'CBGlitterFeedOff
 		'
-		Me.CBGlitterFeedOff.AutoSize = true
+		Me.CBGlitterFeedOff.AutoSize = True
 		Me.CBGlitterFeedOff.Location = New System.Drawing.Point(149, 34)
 		Me.CBGlitterFeedOff.Name = "CBGlitterFeedOff"
 		Me.CBGlitterFeedOff.Size = New System.Drawing.Size(39, 17)
 		Me.CBGlitterFeedOff.TabIndex = 147
-		Me.CBGlitterFeedOff.TabStop = true
+		Me.CBGlitterFeedOff.TabStop = True
 		Me.CBGlitterFeedOff.Text = "Off"
-		Me.CBGlitterFeedOff.UseVisualStyleBackColor = true
+		Me.CBGlitterFeedOff.UseVisualStyleBackColor = True
 		'
 		'CBGlitterFeedScripts
 		'
-		Me.CBGlitterFeedScripts.AutoSize = true
+		Me.CBGlitterFeedScripts.AutoSize = True
 		Me.CBGlitterFeedScripts.Location = New System.Drawing.Point(82, 34)
 		Me.CBGlitterFeedScripts.Name = "CBGlitterFeedScripts"
 		Me.CBGlitterFeedScripts.Size = New System.Drawing.Size(57, 17)
 		Me.CBGlitterFeedScripts.TabIndex = 146
-		Me.CBGlitterFeedScripts.TabStop = true
+		Me.CBGlitterFeedScripts.TabStop = True
 		Me.CBGlitterFeedScripts.Text = "Scripts"
-		Me.CBGlitterFeedScripts.UseVisualStyleBackColor = true
+		Me.CBGlitterFeedScripts.UseVisualStyleBackColor = True
 		'
 		'CBGlitterFeed
 		'
-		Me.CBGlitterFeed.AutoSize = true
+		Me.CBGlitterFeed.AutoSize = True
 		Me.CBGlitterFeed.Location = New System.Drawing.Point(149, 17)
 		Me.CBGlitterFeed.Name = "CBGlitterFeed"
 		Me.CBGlitterFeed.Size = New System.Drawing.Size(39, 17)
 		Me.CBGlitterFeed.TabIndex = 145
-		Me.CBGlitterFeed.TabStop = true
+		Me.CBGlitterFeed.TabStop = True
 		Me.CBGlitterFeed.Text = "On"
-		Me.CBGlitterFeed.UseVisualStyleBackColor = true
+		Me.CBGlitterFeed.UseVisualStyleBackColor = True
 		'
 		'Label118
 		'
 		Me.Label118.BackColor = System.Drawing.Color.Transparent
-		Me.Label118.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label118.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label118.ForeColor = System.Drawing.Color.Black
 		Me.Label118.Location = New System.Drawing.Point(79, 16)
 		Me.Label118.Name = "Label118"
@@ -9295,20 +9407,20 @@ Partial Class FrmSettings
 		'BTNGlitterD
 		'
 		Me.BTNGlitterD.BackColor = System.Drawing.Color.LightGray
-		Me.BTNGlitterD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNGlitterD.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNGlitterD.ForeColor = System.Drawing.Color.Black
 		Me.BTNGlitterD.Location = New System.Drawing.Point(220, 23)
 		Me.BTNGlitterD.Name = "BTNGlitterD"
 		Me.BTNGlitterD.Size = New System.Drawing.Size(115, 24)
 		Me.BTNGlitterD.TabIndex = 166
 		Me.BTNGlitterD.Text = "Choose Name Color"
-		Me.BTNGlitterD.UseVisualStyleBackColor = false
+		Me.BTNGlitterD.UseVisualStyleBackColor = False
 		'
 		'LBLGlitterNCDomme
 		'
 		Me.LBLGlitterNCDomme.BackColor = System.Drawing.Color.White
 		Me.LBLGlitterNCDomme.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLGlitterNCDomme.Font = New System.Drawing.Font("Microsoft Sans Serif", 9!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLGlitterNCDomme.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLGlitterNCDomme.ForeColor = System.Drawing.Color.Black
 		Me.LBLGlitterNCDomme.Location = New System.Drawing.Point(220, 57)
 		Me.LBLGlitterNCDomme.Name = "LBLGlitterNCDomme"
@@ -9320,7 +9432,7 @@ Partial Class FrmSettings
 		'LBLGlitterSlider
 		'
 		Me.LBLGlitterSlider.BackColor = System.Drawing.Color.Transparent
-		Me.LBLGlitterSlider.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLGlitterSlider.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLGlitterSlider.ForeColor = System.Drawing.Color.Black
 		Me.LBLGlitterSlider.Location = New System.Drawing.Point(220, 96)
 		Me.LBLGlitterSlider.Name = "LBLGlitterSlider"
@@ -9331,18 +9443,18 @@ Partial Class FrmSettings
 		'
 		'CBCustom2
 		'
-		Me.CBCustom2.AutoSize = true
+		Me.CBCustom2.AutoSize = True
 		Me.CBCustom2.ForeColor = System.Drawing.Color.Black
 		Me.CBCustom2.Location = New System.Drawing.Point(149, 121)
 		Me.CBCustom2.Name = "CBCustom2"
 		Me.CBCustom2.Size = New System.Drawing.Size(70, 17)
 		Me.CBCustom2.TabIndex = 161
 		Me.CBCustom2.Text = "Custom 2"
-		Me.CBCustom2.UseVisualStyleBackColor = true
+		Me.CBCustom2.UseVisualStyleBackColor = True
 		'
 		'GlitterSlider
 		'
-		Me.GlitterSlider.AutoSize = false
+		Me.GlitterSlider.AutoSize = False
 		Me.GlitterSlider.LargeChange = 1
 		Me.GlitterSlider.Location = New System.Drawing.Point(220, 118)
 		Me.GlitterSlider.Maximum = 9
@@ -9354,41 +9466,41 @@ Partial Class FrmSettings
 		'
 		'CBCustom1
 		'
-		Me.CBCustom1.AutoSize = true
+		Me.CBCustom1.AutoSize = True
 		Me.CBCustom1.ForeColor = System.Drawing.Color.Black
 		Me.CBCustom1.Location = New System.Drawing.Point(149, 98)
 		Me.CBCustom1.Name = "CBCustom1"
 		Me.CBCustom1.Size = New System.Drawing.Size(70, 17)
 		Me.CBCustom1.TabIndex = 157
 		Me.CBCustom1.Text = "Custom 1"
-		Me.CBCustom1.UseVisualStyleBackColor = true
+		Me.CBCustom1.UseVisualStyleBackColor = True
 		'
 		'CBDaily
 		'
-		Me.CBDaily.AutoSize = true
+		Me.CBDaily.AutoSize = True
 		Me.CBDaily.ForeColor = System.Drawing.Color.Black
 		Me.CBDaily.Location = New System.Drawing.Point(79, 121)
 		Me.CBDaily.Name = "CBDaily"
 		Me.CBDaily.Size = New System.Drawing.Size(49, 17)
 		Me.CBDaily.TabIndex = 156
 		Me.CBDaily.Text = "Daily"
-		Me.CBDaily.UseVisualStyleBackColor = true
+		Me.CBDaily.UseVisualStyleBackColor = True
 		'
 		'CBTrivia
 		'
-		Me.CBTrivia.AutoSize = true
+		Me.CBTrivia.AutoSize = True
 		Me.CBTrivia.ForeColor = System.Drawing.Color.Black
 		Me.CBTrivia.Location = New System.Drawing.Point(79, 98)
 		Me.CBTrivia.Name = "CBTrivia"
 		Me.CBTrivia.Size = New System.Drawing.Size(52, 17)
 		Me.CBTrivia.TabIndex = 155
 		Me.CBTrivia.Text = "Trivia"
-		Me.CBTrivia.UseVisualStyleBackColor = true
+		Me.CBTrivia.UseVisualStyleBackColor = True
 		'
 		'TBGlitterShortName
 		'
 		Me.TBGlitterShortName.BackColor = System.Drawing.Color.White
-		Me.TBGlitterShortName.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.TBGlitterShortName.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.TBGlitterShortName.ForeColor = System.Drawing.Color.Black
 		Me.TBGlitterShortName.Location = New System.Drawing.Point(79, 57)
 		Me.TBGlitterShortName.Name = "TBGlitterShortName"
@@ -9399,25 +9511,25 @@ Partial Class FrmSettings
 		'
 		'CBEgotist
 		'
-		Me.CBEgotist.AutoSize = true
+		Me.CBEgotist.AutoSize = True
 		Me.CBEgotist.ForeColor = System.Drawing.Color.Black
 		Me.CBEgotist.Location = New System.Drawing.Point(9, 121)
 		Me.CBEgotist.Name = "CBEgotist"
 		Me.CBEgotist.Size = New System.Drawing.Size(58, 17)
 		Me.CBEgotist.TabIndex = 153
 		Me.CBEgotist.Text = "Egotist"
-		Me.CBEgotist.UseVisualStyleBackColor = true
+		Me.CBEgotist.UseVisualStyleBackColor = True
 		'
 		'CBTease
 		'
-		Me.CBTease.AutoSize = true
+		Me.CBTease.AutoSize = True
 		Me.CBTease.ForeColor = System.Drawing.Color.Black
 		Me.CBTease.Location = New System.Drawing.Point(9, 98)
 		Me.CBTease.Name = "CBTease"
 		Me.CBTease.Size = New System.Drawing.Size(56, 17)
 		Me.CBTease.TabIndex = 152
 		Me.CBTease.Text = "Tease"
-		Me.CBTease.UseVisualStyleBackColor = true
+		Me.CBTease.UseVisualStyleBackColor = True
 		'
 		'GlitterAV
 		'
@@ -9427,7 +9539,7 @@ Partial Class FrmSettings
 		Me.GlitterAV.Size = New System.Drawing.Size(64, 64)
 		Me.GlitterAV.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.GlitterAV.TabIndex = 149
-		Me.GlitterAV.TabStop = false
+		Me.GlitterAV.TabStop = False
 		'
 		'GBGlitter1
 		'
@@ -9446,38 +9558,38 @@ Partial Class FrmSettings
 		Me.GBGlitter1.Name = "GBGlitter1"
 		Me.GBGlitter1.Size = New System.Drawing.Size(344, 150)
 		Me.GBGlitter1.TabIndex = 161
-		Me.GBGlitter1.TabStop = false
+		Me.GBGlitter1.TabStop = False
 		Me.GBGlitter1.Text = "Contact 1"
 		'
 		'Button14
 		'
 		Me.Button14.BackColor = System.Drawing.Color.LightGray
-		Me.Button14.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Button14.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Button14.ForeColor = System.Drawing.Color.Black
 		Me.Button14.Location = New System.Drawing.Point(174, 93)
 		Me.Button14.Name = "Button14"
 		Me.Button14.Size = New System.Drawing.Size(39, 22)
 		Me.Button14.TabIndex = 181
 		Me.Button14.Text = "Clear"
-		Me.Button14.UseVisualStyleBackColor = false
+		Me.Button14.UseVisualStyleBackColor = False
 		'
 		'Button2
 		'
 		Me.Button2.BackColor = System.Drawing.Color.LightGray
-		Me.Button2.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Button2.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Button2.ForeColor = System.Drawing.Color.Black
 		Me.Button2.Location = New System.Drawing.Point(9, 93)
 		Me.Button2.Name = "Button2"
 		Me.Button2.Size = New System.Drawing.Size(160, 22)
 		Me.Button2.TabIndex = 177
 		Me.Button2.Text = "Set Contact1 Images Directory"
-		Me.Button2.UseVisualStyleBackColor = false
+		Me.Button2.UseVisualStyleBackColor = False
 		'
 		'LBLContact1ImageDir
 		'
 		Me.LBLContact1ImageDir.BackColor = System.Drawing.Color.Transparent
 		Me.LBLContact1ImageDir.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLContact1ImageDir.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLContact1ImageDir.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLContact1ImageDir.ForeColor = System.Drawing.Color.Black
 		Me.LBLContact1ImageDir.Location = New System.Drawing.Point(9, 121)
 		Me.LBLContact1ImageDir.Name = "LBLContact1ImageDir"
@@ -9489,20 +9601,20 @@ Partial Class FrmSettings
 		'BTNGlitter1
 		'
 		Me.BTNGlitter1.BackColor = System.Drawing.Color.LightGray
-		Me.BTNGlitter1.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNGlitter1.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNGlitter1.ForeColor = System.Drawing.Color.Black
 		Me.BTNGlitter1.Location = New System.Drawing.Point(220, 23)
 		Me.BTNGlitter1.Name = "BTNGlitter1"
 		Me.BTNGlitter1.Size = New System.Drawing.Size(115, 24)
 		Me.BTNGlitter1.TabIndex = 175
 		Me.BTNGlitter1.Text = "Choose Name Color"
-		Me.BTNGlitter1.UseVisualStyleBackColor = false
+		Me.BTNGlitter1.UseVisualStyleBackColor = False
 		'
 		'LBLGlitterNC1
 		'
 		Me.LBLGlitterNC1.BackColor = System.Drawing.Color.White
 		Me.LBLGlitterNC1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLGlitterNC1.Font = New System.Drawing.Font("Microsoft Sans Serif", 9!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLGlitterNC1.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLGlitterNC1.ForeColor = System.Drawing.Color.Black
 		Me.LBLGlitterNC1.Location = New System.Drawing.Point(220, 57)
 		Me.LBLGlitterNC1.Name = "LBLGlitterNC1"
@@ -9514,7 +9626,7 @@ Partial Class FrmSettings
 		'LBLGlitterSlider1
 		'
 		Me.LBLGlitterSlider1.BackColor = System.Drawing.Color.Transparent
-		Me.LBLGlitterSlider1.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLGlitterSlider1.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLGlitterSlider1.ForeColor = System.Drawing.Color.Black
 		Me.LBLGlitterSlider1.Location = New System.Drawing.Point(220, 96)
 		Me.LBLGlitterSlider1.Name = "LBLGlitterSlider1"
@@ -9525,7 +9637,7 @@ Partial Class FrmSettings
 		'
 		'GlitterSlider1
 		'
-		Me.GlitterSlider1.AutoSize = false
+		Me.GlitterSlider1.AutoSize = False
 		Me.GlitterSlider1.LargeChange = 1
 		Me.GlitterSlider1.Location = New System.Drawing.Point(220, 118)
 		Me.GlitterSlider1.Maximum = 9
@@ -9537,19 +9649,19 @@ Partial Class FrmSettings
 		'
 		'CBGlitter1
 		'
-		Me.CBGlitter1.AutoSize = true
+		Me.CBGlitter1.AutoSize = True
 		Me.CBGlitter1.ForeColor = System.Drawing.Color.Black
 		Me.CBGlitter1.Location = New System.Drawing.Point(79, 26)
 		Me.CBGlitter1.Name = "CBGlitter1"
 		Me.CBGlitter1.Size = New System.Drawing.Size(122, 17)
 		Me.CBGlitter1.TabIndex = 151
 		Me.CBGlitter1.Text = "Enable This Contact"
-		Me.CBGlitter1.UseVisualStyleBackColor = true
+		Me.CBGlitter1.UseVisualStyleBackColor = True
 		'
 		'TBGlitter1
 		'
 		Me.TBGlitter1.BackColor = System.Drawing.Color.White
-		Me.TBGlitter1.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.TBGlitter1.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.TBGlitter1.ForeColor = System.Drawing.Color.Black
 		Me.TBGlitter1.Location = New System.Drawing.Point(79, 57)
 		Me.TBGlitter1.Name = "TBGlitter1"
@@ -9566,7 +9678,7 @@ Partial Class FrmSettings
 		Me.GlitterAV1.Size = New System.Drawing.Size(64, 64)
 		Me.GlitterAV1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.GlitterAV1.TabIndex = 149
-		Me.GlitterAV1.TabStop = false
+		Me.GlitterAV1.TabStop = False
 		'
 		'GBGlitter3
 		'
@@ -9585,38 +9697,38 @@ Partial Class FrmSettings
 		Me.GBGlitter3.Name = "GBGlitter3"
 		Me.GBGlitter3.Size = New System.Drawing.Size(344, 150)
 		Me.GBGlitter3.TabIndex = 160
-		Me.GBGlitter3.TabStop = false
+		Me.GBGlitter3.TabStop = False
 		Me.GBGlitter3.Text = "Contact 3"
 		'
 		'Button12
 		'
 		Me.Button12.BackColor = System.Drawing.Color.LightGray
-		Me.Button12.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Button12.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Button12.ForeColor = System.Drawing.Color.Black
 		Me.Button12.Location = New System.Drawing.Point(174, 93)
 		Me.Button12.Name = "Button12"
 		Me.Button12.Size = New System.Drawing.Size(39, 22)
 		Me.Button12.TabIndex = 180
 		Me.Button12.Text = "Clear"
-		Me.Button12.UseVisualStyleBackColor = false
+		Me.Button12.UseVisualStyleBackColor = False
 		'
 		'Button10
 		'
 		Me.Button10.BackColor = System.Drawing.Color.LightGray
-		Me.Button10.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Button10.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Button10.ForeColor = System.Drawing.Color.Black
 		Me.Button10.Location = New System.Drawing.Point(9, 93)
 		Me.Button10.Name = "Button10"
 		Me.Button10.Size = New System.Drawing.Size(160, 22)
 		Me.Button10.TabIndex = 179
 		Me.Button10.Text = "Set Contact3 Images Directory"
-		Me.Button10.UseVisualStyleBackColor = false
+		Me.Button10.UseVisualStyleBackColor = False
 		'
 		'LBLContact3ImageDir
 		'
 		Me.LBLContact3ImageDir.BackColor = System.Drawing.Color.Transparent
 		Me.LBLContact3ImageDir.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLContact3ImageDir.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLContact3ImageDir.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLContact3ImageDir.ForeColor = System.Drawing.Color.Black
 		Me.LBLContact3ImageDir.Location = New System.Drawing.Point(9, 121)
 		Me.LBLContact3ImageDir.Name = "LBLContact3ImageDir"
@@ -9628,20 +9740,20 @@ Partial Class FrmSettings
 		'BTNGlitter3
 		'
 		Me.BTNGlitter3.BackColor = System.Drawing.Color.LightGray
-		Me.BTNGlitter3.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNGlitter3.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNGlitter3.ForeColor = System.Drawing.Color.Black
 		Me.BTNGlitter3.Location = New System.Drawing.Point(220, 23)
 		Me.BTNGlitter3.Name = "BTNGlitter3"
 		Me.BTNGlitter3.Size = New System.Drawing.Size(115, 24)
 		Me.BTNGlitter3.TabIndex = 175
 		Me.BTNGlitter3.Text = "Choose Name Color"
-		Me.BTNGlitter3.UseVisualStyleBackColor = false
+		Me.BTNGlitter3.UseVisualStyleBackColor = False
 		'
 		'LBLGlitterNC3
 		'
 		Me.LBLGlitterNC3.BackColor = System.Drawing.Color.White
 		Me.LBLGlitterNC3.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLGlitterNC3.Font = New System.Drawing.Font("Microsoft Sans Serif", 9!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLGlitterNC3.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLGlitterNC3.ForeColor = System.Drawing.Color.Black
 		Me.LBLGlitterNC3.Location = New System.Drawing.Point(220, 57)
 		Me.LBLGlitterNC3.Name = "LBLGlitterNC3"
@@ -9653,7 +9765,7 @@ Partial Class FrmSettings
 		'LBLGlitterSlider3
 		'
 		Me.LBLGlitterSlider3.BackColor = System.Drawing.Color.Transparent
-		Me.LBLGlitterSlider3.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLGlitterSlider3.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLGlitterSlider3.ForeColor = System.Drawing.Color.Black
 		Me.LBLGlitterSlider3.Location = New System.Drawing.Point(220, 96)
 		Me.LBLGlitterSlider3.Name = "LBLGlitterSlider3"
@@ -9664,7 +9776,7 @@ Partial Class FrmSettings
 		'
 		'GlitterSlider3
 		'
-		Me.GlitterSlider3.AutoSize = false
+		Me.GlitterSlider3.AutoSize = False
 		Me.GlitterSlider3.LargeChange = 1
 		Me.GlitterSlider3.Location = New System.Drawing.Point(220, 118)
 		Me.GlitterSlider3.Maximum = 9
@@ -9676,19 +9788,19 @@ Partial Class FrmSettings
 		'
 		'CBGlitter3
 		'
-		Me.CBGlitter3.AutoSize = true
+		Me.CBGlitter3.AutoSize = True
 		Me.CBGlitter3.ForeColor = System.Drawing.Color.Black
 		Me.CBGlitter3.Location = New System.Drawing.Point(79, 26)
 		Me.CBGlitter3.Name = "CBGlitter3"
 		Me.CBGlitter3.Size = New System.Drawing.Size(122, 17)
 		Me.CBGlitter3.TabIndex = 151
 		Me.CBGlitter3.Text = "Enable This Contact"
-		Me.CBGlitter3.UseVisualStyleBackColor = true
+		Me.CBGlitter3.UseVisualStyleBackColor = True
 		'
 		'TBGlitter3
 		'
 		Me.TBGlitter3.BackColor = System.Drawing.Color.White
-		Me.TBGlitter3.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.TBGlitter3.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.TBGlitter3.ForeColor = System.Drawing.Color.Black
 		Me.TBGlitter3.Location = New System.Drawing.Point(79, 57)
 		Me.TBGlitter3.Name = "TBGlitter3"
@@ -9705,7 +9817,7 @@ Partial Class FrmSettings
 		Me.GlitterAV3.Size = New System.Drawing.Size(64, 64)
 		Me.GlitterAV3.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.GlitterAV3.TabIndex = 149
-		Me.GlitterAV3.TabStop = false
+		Me.GlitterAV3.TabStop = False
 		'
 		'GBGlitter2
 		'
@@ -9724,38 +9836,38 @@ Partial Class FrmSettings
 		Me.GBGlitter2.Name = "GBGlitter2"
 		Me.GBGlitter2.Size = New System.Drawing.Size(344, 150)
 		Me.GBGlitter2.TabIndex = 151
-		Me.GBGlitter2.TabStop = false
+		Me.GBGlitter2.TabStop = False
 		Me.GBGlitter2.Text = "Contact 2"
 		'
 		'Button13
 		'
 		Me.Button13.BackColor = System.Drawing.Color.LightGray
-		Me.Button13.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Button13.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Button13.ForeColor = System.Drawing.Color.Black
 		Me.Button13.Location = New System.Drawing.Point(174, 93)
 		Me.Button13.Name = "Button13"
 		Me.Button13.Size = New System.Drawing.Size(39, 22)
 		Me.Button13.TabIndex = 181
 		Me.Button13.Text = "Clear"
-		Me.Button13.UseVisualStyleBackColor = false
+		Me.Button13.UseVisualStyleBackColor = False
 		'
 		'Button8
 		'
 		Me.Button8.BackColor = System.Drawing.Color.LightGray
-		Me.Button8.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Button8.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Button8.ForeColor = System.Drawing.Color.Black
 		Me.Button8.Location = New System.Drawing.Point(9, 93)
 		Me.Button8.Name = "Button8"
 		Me.Button8.Size = New System.Drawing.Size(160, 22)
 		Me.Button8.TabIndex = 179
 		Me.Button8.Text = "Set Contact2 Images Directory"
-		Me.Button8.UseVisualStyleBackColor = false
+		Me.Button8.UseVisualStyleBackColor = False
 		'
 		'LBLContact2ImageDir
 		'
 		Me.LBLContact2ImageDir.BackColor = System.Drawing.Color.Transparent
 		Me.LBLContact2ImageDir.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLContact2ImageDir.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLContact2ImageDir.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLContact2ImageDir.ForeColor = System.Drawing.Color.Black
 		Me.LBLContact2ImageDir.Location = New System.Drawing.Point(9, 121)
 		Me.LBLContact2ImageDir.Name = "LBLContact2ImageDir"
@@ -9767,20 +9879,20 @@ Partial Class FrmSettings
 		'BTNGlitter2
 		'
 		Me.BTNGlitter2.BackColor = System.Drawing.Color.LightGray
-		Me.BTNGlitter2.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNGlitter2.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNGlitter2.ForeColor = System.Drawing.Color.Black
 		Me.BTNGlitter2.Location = New System.Drawing.Point(220, 23)
 		Me.BTNGlitter2.Name = "BTNGlitter2"
 		Me.BTNGlitter2.Size = New System.Drawing.Size(115, 24)
 		Me.BTNGlitter2.TabIndex = 167
 		Me.BTNGlitter2.Text = "Choose Name Color"
-		Me.BTNGlitter2.UseVisualStyleBackColor = false
+		Me.BTNGlitter2.UseVisualStyleBackColor = False
 		'
 		'LBLGlitterNC2
 		'
 		Me.LBLGlitterNC2.BackColor = System.Drawing.Color.White
 		Me.LBLGlitterNC2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.LBLGlitterNC2.Font = New System.Drawing.Font("Microsoft Sans Serif", 9!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLGlitterNC2.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLGlitterNC2.ForeColor = System.Drawing.Color.Black
 		Me.LBLGlitterNC2.Location = New System.Drawing.Point(220, 57)
 		Me.LBLGlitterNC2.Name = "LBLGlitterNC2"
@@ -9792,7 +9904,7 @@ Partial Class FrmSettings
 		'LBLGlitterSlider2
 		'
 		Me.LBLGlitterSlider2.BackColor = System.Drawing.Color.Transparent
-		Me.LBLGlitterSlider2.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLGlitterSlider2.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLGlitterSlider2.ForeColor = System.Drawing.Color.Black
 		Me.LBLGlitterSlider2.Location = New System.Drawing.Point(220, 96)
 		Me.LBLGlitterSlider2.Name = "LBLGlitterSlider2"
@@ -9803,7 +9915,7 @@ Partial Class FrmSettings
 		'
 		'GlitterSlider2
 		'
-		Me.GlitterSlider2.AutoSize = false
+		Me.GlitterSlider2.AutoSize = False
 		Me.GlitterSlider2.LargeChange = 1
 		Me.GlitterSlider2.Location = New System.Drawing.Point(220, 118)
 		Me.GlitterSlider2.Maximum = 9
@@ -9815,19 +9927,19 @@ Partial Class FrmSettings
 		'
 		'CBGlitter2
 		'
-		Me.CBGlitter2.AutoSize = true
+		Me.CBGlitter2.AutoSize = True
 		Me.CBGlitter2.ForeColor = System.Drawing.Color.Black
 		Me.CBGlitter2.Location = New System.Drawing.Point(79, 26)
 		Me.CBGlitter2.Name = "CBGlitter2"
 		Me.CBGlitter2.Size = New System.Drawing.Size(122, 17)
 		Me.CBGlitter2.TabIndex = 151
 		Me.CBGlitter2.Text = "Enable This Contact"
-		Me.CBGlitter2.UseVisualStyleBackColor = true
+		Me.CBGlitter2.UseVisualStyleBackColor = True
 		'
 		'TBGlitter2
 		'
 		Me.TBGlitter2.BackColor = System.Drawing.Color.White
-		Me.TBGlitter2.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.TBGlitter2.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.TBGlitter2.ForeColor = System.Drawing.Color.Black
 		Me.TBGlitter2.Location = New System.Drawing.Point(79, 57)
 		Me.TBGlitter2.Name = "TBGlitter2"
@@ -9844,7 +9956,7 @@ Partial Class FrmSettings
 		Me.GlitterAV2.Size = New System.Drawing.Size(64, 64)
 		Me.GlitterAV2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.GlitterAV2.TabIndex = 149
-		Me.GlitterAV2.TabStop = false
+		Me.GlitterAV2.TabStop = False
 		'
 		'TabPage23
 		'
@@ -9865,39 +9977,39 @@ Partial Class FrmSettings
 		'
 		'CBIncludeGifs
 		'
-		Me.CBIncludeGifs.AutoSize = true
+		Me.CBIncludeGifs.AutoSize = True
 		Me.CBIncludeGifs.Location = New System.Drawing.Point(528, 351)
 		Me.CBIncludeGifs.Name = "CBIncludeGifs"
 		Me.CBIncludeGifs.Size = New System.Drawing.Size(154, 17)
 		Me.CBIncludeGifs.TabIndex = 245
 		Me.CBIncludeGifs.Text = "Match Game Includes Gifs "
-		Me.CBIncludeGifs.UseVisualStyleBackColor = true
+		Me.CBIncludeGifs.UseVisualStyleBackColor = True
 		'
 		'Label53
 		'
 		Me.Label53.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D
-		Me.Label53.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label53.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label53.Location = New System.Drawing.Point(523, 249)
 		Me.Label53.Name = "Label53"
 		Me.Label53.Size = New System.Drawing.Size(171, 93)
 		Me.Label53.TabIndex = 23
-		Me.Label53.Text = "Each of the pictures in this tab MUST be set before the Games app can be selected"& _ 
-    "!"
+		Me.Label53.Text = "Each of the pictures in this tab MUST be set before the Games app can be selected" &
+	"!"
 		Me.Label53.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
 		'
 		'CBGameSounds
 		'
-		Me.CBGameSounds.AutoSize = true
-		Me.CBGameSounds.Checked = true
+		Me.CBGameSounds.AutoSize = True
+		Me.CBGameSounds.Checked = True
 		Me.CBGameSounds.CheckState = System.Windows.Forms.CheckState.Checked
-		Me.CBGameSounds.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.CBGameSounds.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.CBGameSounds.ForeColor = System.Drawing.Color.Black
 		Me.CBGameSounds.Location = New System.Drawing.Point(528, 379)
 		Me.CBGameSounds.Name = "CBGameSounds"
 		Me.CBGameSounds.Size = New System.Drawing.Size(116, 17)
 		Me.CBGameSounds.TabIndex = 22
 		Me.CBGameSounds.Text = "Play Game Sounds"
-		Me.CBGameSounds.UseVisualStyleBackColor = true
+		Me.CBGameSounds.UseVisualStyleBackColor = True
 		'
 		'GroupBox61
 		'
@@ -9917,7 +10029,7 @@ Partial Class FrmSettings
 		Me.GroupBox61.Name = "GroupBox61"
 		Me.GroupBox61.Size = New System.Drawing.Size(166, 398)
 		Me.GroupBox61.TabIndex = 19
-		Me.GroupBox61.TabStop = false
+		Me.GroupBox61.TabStop = False
 		Me.GroupBox61.Text = "Gold Cards"
 		'
 		'GN6
@@ -9938,7 +10050,7 @@ Partial Class FrmSettings
 		Me.GP6.Size = New System.Drawing.Size(71, 93)
 		Me.GP6.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.GP6.TabIndex = 17
-		Me.GP6.TabStop = false
+		Me.GP6.TabStop = False
 		'
 		'GN2
 		'
@@ -9958,7 +10070,7 @@ Partial Class FrmSettings
 		Me.GP2.Size = New System.Drawing.Size(71, 94)
 		Me.GP2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.GP2.TabIndex = 9
-		Me.GP2.TabStop = false
+		Me.GP2.TabStop = False
 		'
 		'GP5
 		'
@@ -9969,7 +10081,7 @@ Partial Class FrmSettings
 		Me.GP5.Size = New System.Drawing.Size(71, 93)
 		Me.GP5.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.GP5.TabIndex = 15
-		Me.GP5.TabStop = false
+		Me.GP5.TabStop = False
 		'
 		'GN1
 		'
@@ -9989,7 +10101,7 @@ Partial Class FrmSettings
 		Me.GP1.Size = New System.Drawing.Size(71, 94)
 		Me.GP1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.GP1.TabIndex = 0
-		Me.GP1.TabStop = false
+		Me.GP1.TabStop = False
 		'
 		'GN5
 		'
@@ -10018,7 +10130,7 @@ Partial Class FrmSettings
 		Me.GP3.Size = New System.Drawing.Size(71, 93)
 		Me.GP3.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.GP3.TabIndex = 11
-		Me.GP3.TabStop = false
+		Me.GP3.TabStop = False
 		'
 		'GP4
 		'
@@ -10029,7 +10141,7 @@ Partial Class FrmSettings
 		Me.GP4.Size = New System.Drawing.Size(71, 93)
 		Me.GP4.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.GP4.TabIndex = 13
-		Me.GP4.TabStop = false
+		Me.GP4.TabStop = False
 		'
 		'GN4
 		'
@@ -10047,7 +10159,7 @@ Partial Class FrmSettings
 		Me.GroupBox60.Name = "GroupBox60"
 		Me.GroupBox60.Size = New System.Drawing.Size(172, 236)
 		Me.GroupBox60.TabIndex = 15
-		Me.GroupBox60.TabStop = false
+		Me.GroupBox60.TabStop = False
 		Me.GroupBox60.Text = "Card Background"
 		'
 		'CardBack
@@ -10059,7 +10171,7 @@ Partial Class FrmSettings
 		Me.CardBack.Size = New System.Drawing.Size(138, 179)
 		Me.CardBack.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.CardBack.TabIndex = 18
-		Me.CardBack.TabStop = false
+		Me.CardBack.TabStop = False
 		'
 		'GroupBox58
 		'
@@ -10079,7 +10191,7 @@ Partial Class FrmSettings
 		Me.GroupBox58.Name = "GroupBox58"
 		Me.GroupBox58.Size = New System.Drawing.Size(166, 399)
 		Me.GroupBox58.TabIndex = 1
-		Me.GroupBox58.TabStop = false
+		Me.GroupBox58.TabStop = False
 		Me.GroupBox58.Text = "Bronze Cards"
 		'
 		'BN6
@@ -10109,7 +10221,7 @@ Partial Class FrmSettings
 		Me.BP3.Size = New System.Drawing.Size(71, 93)
 		Me.BP3.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.BP3.TabIndex = 11
-		Me.BP3.TabStop = false
+		Me.BP3.TabStop = False
 		'
 		'BP6
 		'
@@ -10120,7 +10232,7 @@ Partial Class FrmSettings
 		Me.BP6.Size = New System.Drawing.Size(71, 93)
 		Me.BP6.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.BP6.TabIndex = 17
-		Me.BP6.TabStop = false
+		Me.BP6.TabStop = False
 		'
 		'BN2
 		'
@@ -10149,7 +10261,7 @@ Partial Class FrmSettings
 		Me.BP5.Size = New System.Drawing.Size(71, 93)
 		Me.BP5.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.BP5.TabIndex = 15
-		Me.BP5.TabStop = false
+		Me.BP5.TabStop = False
 		'
 		'BP2
 		'
@@ -10160,7 +10272,7 @@ Partial Class FrmSettings
 		Me.BP2.Size = New System.Drawing.Size(71, 93)
 		Me.BP2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.BP2.TabIndex = 9
-		Me.BP2.TabStop = false
+		Me.BP2.TabStop = False
 		'
 		'BN1
 		'
@@ -10189,7 +10301,7 @@ Partial Class FrmSettings
 		Me.BP4.Size = New System.Drawing.Size(71, 93)
 		Me.BP4.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.BP4.TabIndex = 13
-		Me.BP4.TabStop = false
+		Me.BP4.TabStop = False
 		'
 		'BP1
 		'
@@ -10200,7 +10312,7 @@ Partial Class FrmSettings
 		Me.BP1.Size = New System.Drawing.Size(71, 93)
 		Me.BP1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.BP1.TabIndex = 0
-		Me.BP1.TabStop = false
+		Me.BP1.TabStop = False
 		'
 		'GroupBox59
 		'
@@ -10220,7 +10332,7 @@ Partial Class FrmSettings
 		Me.GroupBox59.Name = "GroupBox59"
 		Me.GroupBox59.Size = New System.Drawing.Size(166, 399)
 		Me.GroupBox59.TabIndex = 19
-		Me.GroupBox59.TabStop = false
+		Me.GroupBox59.TabStop = False
 		Me.GroupBox59.Text = "Silver Cards"
 		'
 		'SN6
@@ -10241,7 +10353,7 @@ Partial Class FrmSettings
 		Me.SP6.Size = New System.Drawing.Size(71, 93)
 		Me.SP6.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.SP6.TabIndex = 17
-		Me.SP6.TabStop = false
+		Me.SP6.TabStop = False
 		'
 		'SN2
 		'
@@ -10261,7 +10373,7 @@ Partial Class FrmSettings
 		Me.SP2.Size = New System.Drawing.Size(71, 93)
 		Me.SP2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.SP2.TabIndex = 9
-		Me.SP2.TabStop = false
+		Me.SP2.TabStop = False
 		'
 		'SN1
 		'
@@ -10281,7 +10393,7 @@ Partial Class FrmSettings
 		Me.SP5.Size = New System.Drawing.Size(71, 93)
 		Me.SP5.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.SP5.TabIndex = 15
-		Me.SP5.TabStop = false
+		Me.SP5.TabStop = False
 		'
 		'SP1
 		'
@@ -10292,7 +10404,7 @@ Partial Class FrmSettings
 		Me.SP1.Size = New System.Drawing.Size(71, 93)
 		Me.SP1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.SP1.TabIndex = 0
-		Me.SP1.TabStop = false
+		Me.SP1.TabStop = False
 		'
 		'SN5
 		'
@@ -10330,7 +10442,7 @@ Partial Class FrmSettings
 		Me.SP3.Size = New System.Drawing.Size(71, 93)
 		Me.SP3.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.SP3.TabIndex = 11
-		Me.SP3.TabStop = false
+		Me.SP3.TabStop = False
 		'
 		'SP4
 		'
@@ -10341,7 +10453,7 @@ Partial Class FrmSettings
 		Me.SP4.Size = New System.Drawing.Size(71, 93)
 		Me.SP4.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.SP4.TabIndex = 13
-		Me.SP4.TabStop = false
+		Me.SP4.TabStop = False
 		'
 		'TabPage6
 		'
@@ -10379,14 +10491,14 @@ Partial Class FrmSettings
 		'TBWishlistComment
 		'
 		Me.TBWishlistComment.Location = New System.Drawing.Point(16, 173)
-		Me.TBWishlistComment.Multiline = true
+		Me.TBWishlistComment.Multiline = True
 		Me.TBWishlistComment.Name = "TBWishlistComment"
 		Me.TBWishlistComment.Size = New System.Drawing.Size(217, 118)
 		Me.TBWishlistComment.TabIndex = 172
 		'
 		'Label32
 		'
-		Me.Label32.AutoSize = true
+		Me.Label32.AutoSize = True
 		Me.Label32.Location = New System.Drawing.Point(13, 4)
 		Me.Label32.Name = "Label32"
 		Me.Label32.Size = New System.Drawing.Size(58, 13)
@@ -10402,17 +10514,17 @@ Partial Class FrmSettings
 		'
 		'radioGold
 		'
-		Me.radioGold.AutoSize = true
+		Me.radioGold.AutoSize = True
 		Me.radioGold.Location = New System.Drawing.Point(167, 125)
 		Me.radioGold.Name = "radioGold"
 		Me.radioGold.Size = New System.Drawing.Size(47, 17)
 		Me.radioGold.TabIndex = 176
 		Me.radioGold.Text = "Gold"
-		Me.radioGold.UseVisualStyleBackColor = true
+		Me.radioGold.UseVisualStyleBackColor = True
 		'
 		'Label42
 		'
-		Me.Label42.AutoSize = true
+		Me.Label42.AutoSize = True
 		Me.Label42.Location = New System.Drawing.Point(13, 56)
 		Me.Label42.Name = "Label42"
 		Me.Label42.Size = New System.Drawing.Size(75, 13)
@@ -10421,15 +10533,15 @@ Partial Class FrmSettings
 		'
 		'radioSilver
 		'
-		Me.radioSilver.AutoSize = true
-		Me.radioSilver.Checked = true
+		Me.radioSilver.AutoSize = True
+		Me.radioSilver.Checked = True
 		Me.radioSilver.Location = New System.Drawing.Point(100, 125)
 		Me.radioSilver.Name = "radioSilver"
 		Me.radioSilver.Size = New System.Drawing.Size(51, 17)
 		Me.radioSilver.TabIndex = 175
-		Me.radioSilver.TabStop = true
+		Me.radioSilver.TabStop = True
 		Me.radioSilver.Text = "Silver"
-		Me.radioSilver.UseVisualStyleBackColor = true
+		Me.radioSilver.UseVisualStyleBackColor = True
 		'
 		'TBWishlistURL
 		'
@@ -10450,7 +10562,7 @@ Partial Class FrmSettings
 		'
 		'Label48
 		'
-		Me.Label48.AutoSize = true
+		Me.Label48.AutoSize = True
 		Me.Label48.Location = New System.Drawing.Point(13, 157)
 		Me.Label48.Name = "Label48"
 		Me.Label48.Size = New System.Drawing.Size(74, 13)
@@ -10459,7 +10571,7 @@ Partial Class FrmSettings
 		'
 		'Label73
 		'
-		Me.Label73.AutoSize = true
+		Me.Label73.AutoSize = True
 		Me.Label73.Location = New System.Drawing.Point(13, 108)
 		Me.Label73.Name = "Label73"
 		Me.Label73.Size = New System.Drawing.Size(51, 13)
@@ -10468,7 +10580,7 @@ Partial Class FrmSettings
 		'
 		'Label107
 		'
-		Me.Label107.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label107.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label107.Location = New System.Drawing.Point(38, 5)
 		Me.Label107.Name = "Label107"
 		Me.Label107.Size = New System.Drawing.Size(252, 47)
@@ -10483,11 +10595,11 @@ Partial Class FrmSettings
 		Me.BTNWishlistCreate.Size = New System.Drawing.Size(252, 33)
 		Me.BTNWishlistCreate.TabIndex = 177
 		Me.BTNWishlistCreate.Text = "Create Wishlist File"
-		Me.BTNWishlistCreate.UseVisualStyleBackColor = true
+		Me.BTNWishlistCreate.UseVisualStyleBackColor = True
 		'
 		'Label18
 		'
-		Me.Label18.Font = New System.Drawing.Font("Microsoft Sans Serif", 12!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label18.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label18.Location = New System.Drawing.Point(409, 5)
 		Me.Label18.Name = "Label18"
 		Me.Label18.Size = New System.Drawing.Size(250, 23)
@@ -10513,17 +10625,17 @@ Partial Class FrmSettings
 		'WishlistCostSilver
 		'
 		Me.WishlistCostSilver.BackColor = System.Drawing.Color.Transparent
-		Me.WishlistCostSilver.Image = CType(resources.GetObject("WishlistCostSilver.Image"),System.Drawing.Image)
+		Me.WishlistCostSilver.Image = CType(resources.GetObject("WishlistCostSilver.Image"), System.Drawing.Image)
 		Me.WishlistCostSilver.Location = New System.Drawing.Point(107, 206)
 		Me.WishlistCostSilver.Name = "WishlistCostSilver"
 		Me.WishlistCostSilver.Size = New System.Drawing.Size(28, 28)
 		Me.WishlistCostSilver.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.WishlistCostSilver.TabIndex = 111
-		Me.WishlistCostSilver.TabStop = false
+		Me.WishlistCostSilver.TabStop = False
 		'
 		'LBLWishListText
 		'
-		Me.LBLWishListText.Font = New System.Drawing.Font("Microsoft Sans Serif", 9!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLWishListText.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLWishListText.Location = New System.Drawing.Point(14, 247)
 		Me.LBLWishListText.Name = "LBLWishListText"
 		Me.LBLWishListText.Size = New System.Drawing.Size(220, 109)
@@ -10531,7 +10643,7 @@ Partial Class FrmSettings
 		'
 		'LBLWishlistCost
 		'
-		Me.LBLWishlistCost.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLWishlistCost.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLWishlistCost.ForeColor = System.Drawing.Color.Black
 		Me.LBLWishlistCost.Location = New System.Drawing.Point(139, 206)
 		Me.LBLWishlistCost.Name = "LBLWishlistCost"
@@ -10543,18 +10655,18 @@ Partial Class FrmSettings
 		'WishlistCostGold
 		'
 		Me.WishlistCostGold.BackColor = System.Drawing.Color.Transparent
-		Me.WishlistCostGold.Image = CType(resources.GetObject("WishlistCostGold.Image"),System.Drawing.Image)
+		Me.WishlistCostGold.Image = CType(resources.GetObject("WishlistCostGold.Image"), System.Drawing.Image)
 		Me.WishlistCostGold.Location = New System.Drawing.Point(107, 206)
 		Me.WishlistCostGold.Name = "WishlistCostGold"
 		Me.WishlistCostGold.Size = New System.Drawing.Size(28, 28)
 		Me.WishlistCostGold.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.WishlistCostGold.TabIndex = 106
-		Me.WishlistCostGold.TabStop = false
-		Me.WishlistCostGold.Visible = false
+		Me.WishlistCostGold.TabStop = False
+		Me.WishlistCostGold.Visible = False
 		'
 		'LBLWishListName
 		'
-		Me.LBLWishListName.Font = New System.Drawing.Font("Microsoft Sans Serif", 11!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLWishListName.Font = New System.Drawing.Font("Microsoft Sans Serif", 11.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLWishListName.ForeColor = System.Drawing.Color.CornflowerBlue
 		Me.LBLWishListName.Location = New System.Drawing.Point(14, 22)
 		Me.LBLWishListName.Name = "LBLWishListName"
@@ -10571,7 +10683,7 @@ Partial Class FrmSettings
 		Me.WishlistPreview.Size = New System.Drawing.Size(145, 143)
 		Me.WishlistPreview.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
 		Me.WishlistPreview.TabIndex = 101
-		Me.WishlistPreview.TabStop = false
+		Me.WishlistPreview.TabStop = False
 		'
 		'TabPage26
 		'
@@ -10607,13 +10719,13 @@ Partial Class FrmSettings
 		Me.GroupBox9.Name = "GroupBox9"
 		Me.GroupBox9.Size = New System.Drawing.Size(348, 94)
 		Me.GroupBox9.TabIndex = 152
-		Me.GroupBox9.TabStop = false
+		Me.GroupBox9.TabStop = False
 		Me.GroupBox9.Text = "System"
 		'
 		'Button32
 		'
 		Me.Button32.BackColor = System.Drawing.Color.Transparent
-		Me.Button32.Image = CType(resources.GetObject("Button32.Image"),System.Drawing.Image)
+		Me.Button32.Image = CType(resources.GetObject("Button32.Image"), System.Drawing.Image)
 		Me.Button32.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
 		Me.Button32.Location = New System.Drawing.Point(196, 24)
 		Me.Button32.Name = "Button32"
@@ -10621,12 +10733,12 @@ Partial Class FrmSettings
 		Me.Button32.TabIndex = 55
 		Me.Button32.Text = "  Save Theme"
 		Me.Button32.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText
-		Me.Button32.UseVisualStyleBackColor = false
+		Me.Button32.UseVisualStyleBackColor = False
 		'
 		'Button31
 		'
 		Me.Button31.BackColor = System.Drawing.Color.Transparent
-		Me.Button31.Image = CType(resources.GetObject("Button31.Image"),System.Drawing.Image)
+		Me.Button31.Image = CType(resources.GetObject("Button31.Image"), System.Drawing.Image)
 		Me.Button31.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
 		Me.Button31.Location = New System.Drawing.Point(17, 24)
 		Me.Button31.Name = "Button31"
@@ -10634,18 +10746,18 @@ Partial Class FrmSettings
 		Me.Button31.TabIndex = 54
 		Me.Button31.Text = "  Open Theme"
 		Me.Button31.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText
-		Me.Button31.UseVisualStyleBackColor = false
+		Me.Button31.UseVisualStyleBackColor = False
 		'
 		'PictureBox10
 		'
 		Me.PictureBox10.BackColor = System.Drawing.Color.LightGray
-		Me.PictureBox10.Image = CType(resources.GetObject("PictureBox10.Image"),System.Drawing.Image)
+		Me.PictureBox10.Image = CType(resources.GetObject("PictureBox10.Image"), System.Drawing.Image)
 		Me.PictureBox10.Location = New System.Drawing.Point(9, 6)
 		Me.PictureBox10.Name = "PictureBox10"
 		Me.PictureBox10.Size = New System.Drawing.Size(160, 19)
 		Me.PictureBox10.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage
 		Me.PictureBox10.TabIndex = 151
-		Me.PictureBox10.TabStop = false
+		Me.PictureBox10.TabStop = False
 		'
 		'GroupBox5
 		'
@@ -10675,18 +10787,18 @@ Partial Class FrmSettings
 		Me.GroupBox5.Name = "GroupBox5"
 		Me.GroupBox5.Size = New System.Drawing.Size(336, 294)
 		Me.GroupBox5.TabIndex = 58
-		Me.GroupBox5.TabStop = false
+		Me.GroupBox5.TabStop = False
 		Me.GroupBox5.Text = "UI Colors"
 		'
 		'CBTransparentTime
 		'
-		Me.CBTransparentTime.AutoSize = true
+		Me.CBTransparentTime.AutoSize = True
 		Me.CBTransparentTime.Location = New System.Drawing.Point(7, 262)
 		Me.CBTransparentTime.Name = "CBTransparentTime"
 		Me.CBTransparentTime.Size = New System.Drawing.Size(179, 17)
 		Me.CBTransparentTime.TabIndex = 23
 		Me.CBTransparentTime.Text = "Transparent Date/Time Window"
-		Me.CBTransparentTime.UseVisualStyleBackColor = true
+		Me.CBTransparentTime.UseVisualStyleBackColor = True
 		'
 		'LBLDateTimeColor2
 		'
@@ -10720,24 +10832,24 @@ Partial Class FrmSettings
 		'Button28
 		'
 		Me.Button28.BackColor = System.Drawing.Color.Transparent
-		Me.Button28.BackgroundImage = CType(resources.GetObject("Button28.BackgroundImage"),System.Drawing.Image)
+		Me.Button28.BackgroundImage = CType(resources.GetObject("Button28.BackgroundImage"), System.Drawing.Image)
 		Me.Button28.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch
 		Me.Button28.Location = New System.Drawing.Point(296, 221)
 		Me.Button28.Name = "Button28"
 		Me.Button28.Size = New System.Drawing.Size(32, 32)
 		Me.Button28.TabIndex = 21
-		Me.Button28.UseVisualStyleBackColor = false
+		Me.Button28.UseVisualStyleBackColor = False
 		'
 		'Button30
 		'
 		Me.Button30.BackColor = System.Drawing.Color.Transparent
-		Me.Button30.BackgroundImage = CType(resources.GetObject("Button30.BackgroundImage"),System.Drawing.Image)
+		Me.Button30.BackgroundImage = CType(resources.GetObject("Button30.BackgroundImage"), System.Drawing.Image)
 		Me.Button30.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch
 		Me.Button30.Location = New System.Drawing.Point(296, 187)
 		Me.Button30.Name = "Button30"
 		Me.Button30.Size = New System.Drawing.Size(32, 32)
 		Me.Button30.TabIndex = 18
-		Me.Button30.UseVisualStyleBackColor = false
+		Me.Button30.UseVisualStyleBackColor = False
 		'
 		'LBLDateBackColor2
 		'
@@ -10770,13 +10882,13 @@ Partial Class FrmSettings
 		'Button20
 		'
 		Me.Button20.BackColor = System.Drawing.Color.Transparent
-		Me.Button20.BackgroundImage = CType(resources.GetObject("Button20.BackgroundImage"),System.Drawing.Image)
+		Me.Button20.BackgroundImage = CType(resources.GetObject("Button20.BackgroundImage"), System.Drawing.Image)
 		Me.Button20.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch
 		Me.Button20.Location = New System.Drawing.Point(296, 85)
 		Me.Button20.Name = "Button20"
 		Me.Button20.Size = New System.Drawing.Size(32, 32)
 		Me.Button20.TabIndex = 8
-		Me.Button20.UseVisualStyleBackColor = false
+		Me.Button20.UseVisualStyleBackColor = False
 		'
 		'LBLTextColor2
 		'
@@ -10839,24 +10951,24 @@ Partial Class FrmSettings
 		'Button21
 		'
 		Me.Button21.BackColor = System.Drawing.Color.Transparent
-		Me.Button21.BackgroundImage = CType(resources.GetObject("Button21.BackgroundImage"),System.Drawing.Image)
+		Me.Button21.BackgroundImage = CType(resources.GetObject("Button21.BackgroundImage"), System.Drawing.Image)
 		Me.Button21.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch
 		Me.Button21.Location = New System.Drawing.Point(296, 153)
 		Me.Button21.Name = "Button21"
 		Me.Button21.Size = New System.Drawing.Size(32, 32)
 		Me.Button21.TabIndex = 15
-		Me.Button21.UseVisualStyleBackColor = false
+		Me.Button21.UseVisualStyleBackColor = False
 		'
 		'Button23
 		'
 		Me.Button23.BackColor = System.Drawing.Color.Transparent
-		Me.Button23.BackgroundImage = CType(resources.GetObject("Button23.BackgroundImage"),System.Drawing.Image)
+		Me.Button23.BackgroundImage = CType(resources.GetObject("Button23.BackgroundImage"), System.Drawing.Image)
 		Me.Button23.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch
 		Me.Button23.Location = New System.Drawing.Point(296, 119)
 		Me.Button23.Name = "Button23"
 		Me.Button23.Size = New System.Drawing.Size(32, 32)
 		Me.Button23.TabIndex = 11
-		Me.Button23.UseVisualStyleBackColor = false
+		Me.Button23.UseVisualStyleBackColor = False
 		'
 		'LBLChatTextColor2
 		'
@@ -10870,24 +10982,24 @@ Partial Class FrmSettings
 		'Button25
 		'
 		Me.Button25.BackColor = System.Drawing.Color.Transparent
-		Me.Button25.BackgroundImage = CType(resources.GetObject("Button25.BackgroundImage"),System.Drawing.Image)
+		Me.Button25.BackgroundImage = CType(resources.GetObject("Button25.BackgroundImage"), System.Drawing.Image)
 		Me.Button25.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch
 		Me.Button25.Location = New System.Drawing.Point(296, 17)
 		Me.Button25.Name = "Button25"
 		Me.Button25.Size = New System.Drawing.Size(32, 32)
 		Me.Button25.TabIndex = 2
-		Me.Button25.UseVisualStyleBackColor = false
+		Me.Button25.UseVisualStyleBackColor = False
 		'
 		'Button27
 		'
 		Me.Button27.BackColor = System.Drawing.Color.Transparent
-		Me.Button27.BackgroundImage = CType(resources.GetObject("Button27.BackgroundImage"),System.Drawing.Image)
+		Me.Button27.BackgroundImage = CType(resources.GetObject("Button27.BackgroundImage"), System.Drawing.Image)
 		Me.Button27.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch
 		Me.Button27.Location = New System.Drawing.Point(296, 51)
 		Me.Button27.Name = "Button27"
 		Me.Button27.Size = New System.Drawing.Size(32, 32)
 		Me.Button27.TabIndex = 5
-		Me.Button27.UseVisualStyleBackColor = false
+		Me.Button27.UseVisualStyleBackColor = False
 		'
 		'LBLButtonColor2
 		'
@@ -10907,20 +11019,20 @@ Partial Class FrmSettings
 		Me.GroupBox11.Name = "GroupBox11"
 		Me.GroupBox11.Size = New System.Drawing.Size(692, 92)
 		Me.GroupBox11.TabIndex = 65
-		Me.GroupBox11.TabStop = false
+		Me.GroupBox11.TabStop = False
 		Me.GroupBox11.Text = "Description"
 		'
 		'Label144
 		'
 		Me.Label144.BackColor = System.Drawing.Color.Transparent
-		Me.Label144.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label144.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label144.ForeColor = System.Drawing.Color.Black
 		Me.Label144.Location = New System.Drawing.Point(6, 16)
 		Me.Label144.Name = "Label144"
 		Me.Label144.Size = New System.Drawing.Size(680, 73)
 		Me.Label144.TabIndex = 62
-		Me.Label144.Text = "Use this page to create custom themes for Tease AI."&Global.Microsoft.VisualBasic.ChrW(13)&Global.Microsoft.VisualBasic.ChrW(10)&Global.Microsoft.VisualBasic.ChrW(13)&Global.Microsoft.VisualBasic.ChrW(10)&"Themes can then be saved a"& _ 
-    "nd opened from txt files."
+		Me.Label144.Text = "Use this page to create custom themes for Tease AI." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "Themes can then be saved a" &
+	"nd opened from txt files."
 		Me.Label144.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
 		'
 		'GroupBox1
@@ -10934,7 +11046,7 @@ Partial Class FrmSettings
 		Me.GroupBox1.Name = "GroupBox1"
 		Me.GroupBox1.Size = New System.Drawing.Size(348, 195)
 		Me.GroupBox1.TabIndex = 57
-		Me.GroupBox1.TabStop = false
+		Me.GroupBox1.TabStop = False
 		Me.GroupBox1.Text = "Background"
 		'
 		'CBFlipBack
@@ -10944,7 +11056,7 @@ Partial Class FrmSettings
 		Me.CBFlipBack.Size = New System.Drawing.Size(86, 41)
 		Me.CBFlipBack.TabIndex = 4
 		Me.CBFlipBack.Text = "Flip Background"
-		Me.CBFlipBack.UseVisualStyleBackColor = true
+		Me.CBFlipBack.UseVisualStyleBackColor = True
 		'
 		'PBBackgroundPreview
 		'
@@ -10954,29 +11066,29 @@ Partial Class FrmSettings
 		Me.PBBackgroundPreview.Size = New System.Drawing.Size(202, 133)
 		Me.PBBackgroundPreview.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.PBBackgroundPreview.TabIndex = 0
-		Me.PBBackgroundPreview.TabStop = false
+		Me.PBBackgroundPreview.TabStop = False
 		'
 		'Button17
 		'
 		Me.Button17.BackColor = System.Drawing.Color.Transparent
-		Me.Button17.BackgroundImage = CType(resources.GetObject("Button17.BackgroundImage"),System.Drawing.Image)
+		Me.Button17.BackgroundImage = CType(resources.GetObject("Button17.BackgroundImage"), System.Drawing.Image)
 		Me.Button17.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch
 		Me.Button17.Location = New System.Drawing.Point(228, 36)
 		Me.Button17.Name = "Button17"
 		Me.Button17.Size = New System.Drawing.Size(103, 93)
 		Me.Button17.TabIndex = 1
-		Me.Button17.UseVisualStyleBackColor = false
+		Me.Button17.UseVisualStyleBackColor = False
 		'
 		'CBStretchBack
 		'
-		Me.CBStretchBack.Checked = true
+		Me.CBStretchBack.Checked = True
 		Me.CBStretchBack.CheckState = System.Windows.Forms.CheckState.Checked
 		Me.CBStretchBack.Location = New System.Drawing.Point(122, 153)
 		Me.CBStretchBack.Name = "CBStretchBack"
 		Me.CBStretchBack.Size = New System.Drawing.Size(86, 41)
 		Me.CBStretchBack.TabIndex = 2
 		Me.CBStretchBack.Text = "Stretch Background"
-		Me.CBStretchBack.UseVisualStyleBackColor = true
+		Me.CBStretchBack.UseVisualStyleBackColor = True
 		'
 		'Button18
 		'
@@ -10985,12 +11097,12 @@ Partial Class FrmSettings
 		Me.Button18.Size = New System.Drawing.Size(103, 31)
 		Me.Button18.TabIndex = 3
 		Me.Button18.Text = "Clear"
-		Me.Button18.UseVisualStyleBackColor = true
+		Me.Button18.UseVisualStyleBackColor = True
 		'
 		'Label164
 		'
 		Me.Label164.BackColor = System.Drawing.Color.Transparent
-		Me.Label164.Font = New System.Drawing.Font("Microsoft Sans Serif", 12!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label164.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label164.ForeColor = System.Drawing.Color.Black
 		Me.Label164.Location = New System.Drawing.Point(7, 6)
 		Me.Label164.Name = "Label164"
@@ -11029,6 +11141,61 @@ Partial Class FrmSettings
 		Me.Panel6.Size = New System.Drawing.Size(708, 437)
 		Me.Panel6.TabIndex = 91
 		'
+		'GroupBox69
+		'
+		Me.GroupBox69.Controls.Add(Me.TypesSpeedVal)
+		Me.GroupBox69.Controls.Add(Me.TypeSpeedLabel)
+		Me.GroupBox69.Controls.Add(Me.TimedWriting)
+		Me.GroupBox69.Controls.Add(Me.TypeSpeedSlider)
+		Me.GroupBox69.Location = New System.Drawing.Point(236, 344)
+		Me.GroupBox69.Name = "GroupBox69"
+		Me.GroupBox69.Size = New System.Drawing.Size(166, 83)
+		Me.GroupBox69.TabIndex = 173
+		Me.GroupBox69.TabStop = False
+		Me.GroupBox69.Text = "WritingTasks"
+		'
+		'TypesSpeedVal
+		'
+		Me.TypesSpeedVal.AutoSize = True
+		Me.TypesSpeedVal.Location = New System.Drawing.Point(132, 64)
+		Me.TypesSpeedVal.Name = "TypesSpeedVal"
+		Me.TypesSpeedVal.Size = New System.Drawing.Size(19, 13)
+		Me.TypesSpeedVal.TabIndex = 0
+		Me.TypesSpeedVal.Text = "10"
+		Me.TypesSpeedVal.TextAlign = System.Drawing.ContentAlignment.TopRight
+		'
+		'TypeSpeedLabel
+		'
+		Me.TypeSpeedLabel.AutoSize = True
+		Me.TypeSpeedLabel.Location = New System.Drawing.Point(6, 64)
+		Me.TypeSpeedLabel.Name = "TypeSpeedLabel"
+		Me.TypeSpeedLabel.Size = New System.Drawing.Size(76, 13)
+		Me.TypeSpeedLabel.TabIndex = 2
+		Me.TypeSpeedLabel.Text = "Typing Speed:"
+		'
+		'TimedWriting
+		'
+		Me.TimedWriting.AutoSize = True
+		Me.TimedWriting.Checked = Global.Tease_AI.My.MySettings.Default.TimedWriting
+		Me.TimedWriting.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "TimedWriting", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.TimedWriting.Location = New System.Drawing.Point(9, 19)
+		Me.TimedWriting.Name = "TimedWriting"
+		Me.TimedWriting.Size = New System.Drawing.Size(123, 17)
+		Me.TimedWriting.TabIndex = 1
+		Me.TimedWriting.Text = "Timed Writing Tasks"
+		Me.TimedWriting.UseVisualStyleBackColor = True
+		'
+		'TypeSpeedSlider
+		'
+		Me.TypeSpeedSlider.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TypeSpeed", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.TypeSpeedSlider.Location = New System.Drawing.Point(9, 35)
+		Me.TypeSpeedSlider.Maximum = 100
+		Me.TypeSpeedSlider.Minimum = 33
+		Me.TypeSpeedSlider.Name = "TypeSpeedSlider"
+		Me.TypeSpeedSlider.Size = New System.Drawing.Size(148, 45)
+		Me.TypeSpeedSlider.TabIndex = 3
+		Me.TypeSpeedSlider.Value = Global.Tease_AI.My.MySettings.Default.TypeSpeed
+		'
 		'GroupBox68
 		'
 		Me.GroupBox68.Controls.Add(Me.NBTasksMax)
@@ -11039,12 +11206,12 @@ Partial Class FrmSettings
 		Me.GroupBox68.Name = "GroupBox68"
 		Me.GroupBox68.Size = New System.Drawing.Size(166, 51)
 		Me.GroupBox68.TabIndex = 172
-		Me.GroupBox68.TabStop = false
+		Me.GroupBox68.TabStop = False
 		Me.GroupBox68.Text = "Session Tasks"
 		'
 		'NBTasksMax
 		'
-		Me.NBTasksMax.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TasksMax", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.NBTasksMax.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TasksMax", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
 		Me.NBTasksMax.Location = New System.Drawing.Point(113, 20)
 		Me.NBTasksMax.Maximum = New Decimal(New Integer() {500, 0, 0, 0})
 		Me.NBTasksMax.Minimum = New Decimal(New Integer() {5, 0, 0, 0})
@@ -11055,7 +11222,7 @@ Partial Class FrmSettings
 		'
 		'NBTasksMin
 		'
-		Me.NBTasksMin.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TasksMin", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.NBTasksMin.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TasksMin", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
 		Me.NBTasksMin.Location = New System.Drawing.Point(54, 21)
 		Me.NBTasksMin.Minimum = New Decimal(New Integer() {3, 0, 0, 0})
 		Me.NBTasksMin.Name = "NBTasksMin"
@@ -11066,7 +11233,7 @@ Partial Class FrmSettings
 		'Label165
 		'
 		Me.Label165.BackColor = System.Drawing.Color.Transparent
-		Me.Label165.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label165.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label165.ForeColor = System.Drawing.Color.Black
 		Me.Label165.Location = New System.Drawing.Point(100, 20)
 		Me.Label165.Name = "Label165"
@@ -11078,7 +11245,7 @@ Partial Class FrmSettings
 		'Label166
 		'
 		Me.Label166.BackColor = System.Drawing.Color.Transparent
-		Me.Label166.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label166.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label166.ForeColor = System.Drawing.Color.Black
 		Me.Label166.Location = New System.Drawing.Point(6, 21)
 		Me.Label166.Name = "Label166"
@@ -11116,13 +11283,13 @@ Partial Class FrmSettings
 		Me.GroupBox67.Name = "GroupBox67"
 		Me.GroupBox67.Size = New System.Drawing.Size(291, 139)
 		Me.GroupBox67.TabIndex = 171
-		Me.GroupBox67.TabStop = false
+		Me.GroupBox67.TabStop = False
 		Me.GroupBox67.Text = "Letter Tasks"
 		'
 		'Label161
 		'
 		Me.Label161.BackColor = System.Drawing.Color.Transparent
-		Me.Label161.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label161.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label161.ForeColor = System.Drawing.Color.Black
 		Me.Label161.Location = New System.Drawing.Point(233, 110)
 		Me.Label161.Name = "Label161"
@@ -11131,10 +11298,32 @@ Partial Class FrmSettings
 		Me.Label161.Text = "minutes"
 		Me.Label161.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
 		'
+		'NBTaskCBTTimeMax
+		'
+		Me.NBTaskCBTTimeMax.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskCBTTimeMax", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.NBTaskCBTTimeMax.Location = New System.Drawing.Point(183, 110)
+		Me.NBTaskCBTTimeMax.Maximum = New Decimal(New Integer() {600, 0, 0, 0})
+		Me.NBTaskCBTTimeMax.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
+		Me.NBTaskCBTTimeMax.Name = "NBTaskCBTTimeMax"
+		Me.NBTaskCBTTimeMax.Size = New System.Drawing.Size(44, 20)
+		Me.NBTaskCBTTimeMax.TabIndex = 203
+		Me.NBTaskCBTTimeMax.Value = Global.Tease_AI.My.MySettings.Default.TaskCBTTimeMax
+		'
+		'NBTaskCBTTimeMin
+		'
+		Me.NBTaskCBTTimeMin.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskCBTTimeMin", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.NBTaskCBTTimeMin.Location = New System.Drawing.Point(117, 111)
+		Me.NBTaskCBTTimeMin.Maximum = New Decimal(New Integer() {9999, 0, 0, 0})
+		Me.NBTaskCBTTimeMin.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
+		Me.NBTaskCBTTimeMin.Name = "NBTaskCBTTimeMin"
+		Me.NBTaskCBTTimeMin.Size = New System.Drawing.Size(44, 20)
+		Me.NBTaskCBTTimeMin.TabIndex = 202
+		Me.NBTaskCBTTimeMin.Value = Global.Tease_AI.My.MySettings.Default.TaskCBTTimeMin
+		'
 		'Label162
 		'
 		Me.Label162.BackColor = System.Drawing.Color.Transparent
-		Me.Label162.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label162.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label162.ForeColor = System.Drawing.Color.Black
 		Me.Label162.Location = New System.Drawing.Point(167, 110)
 		Me.Label162.Name = "Label162"
@@ -11146,7 +11335,7 @@ Partial Class FrmSettings
 		'Label163
 		'
 		Me.Label163.BackColor = System.Drawing.Color.Transparent
-		Me.Label163.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label163.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label163.ForeColor = System.Drawing.Color.Black
 		Me.Label163.Location = New System.Drawing.Point(12, 111)
 		Me.Label163.Name = "Label163"
@@ -11158,7 +11347,7 @@ Partial Class FrmSettings
 		'Label158
 		'
 		Me.Label158.BackColor = System.Drawing.Color.Transparent
-		Me.Label158.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label158.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label158.ForeColor = System.Drawing.Color.Black
 		Me.Label158.Location = New System.Drawing.Point(233, 87)
 		Me.Label158.Name = "Label158"
@@ -11167,10 +11356,32 @@ Partial Class FrmSettings
 		Me.Label158.Text = "minutes"
 		Me.Label158.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
 		'
+		'NBTaskEdgeHoldTimeMax
+		'
+		Me.NBTaskEdgeHoldTimeMax.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskEdgeHoldTimeMax", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.NBTaskEdgeHoldTimeMax.Location = New System.Drawing.Point(183, 87)
+		Me.NBTaskEdgeHoldTimeMax.Maximum = New Decimal(New Integer() {600, 0, 0, 0})
+		Me.NBTaskEdgeHoldTimeMax.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
+		Me.NBTaskEdgeHoldTimeMax.Name = "NBTaskEdgeHoldTimeMax"
+		Me.NBTaskEdgeHoldTimeMax.Size = New System.Drawing.Size(44, 20)
+		Me.NBTaskEdgeHoldTimeMax.TabIndex = 198
+		Me.NBTaskEdgeHoldTimeMax.Value = Global.Tease_AI.My.MySettings.Default.TaskEdgeHoldTimeMax
+		'
+		'NBTaskEdgeHoldTimeMin
+		'
+		Me.NBTaskEdgeHoldTimeMin.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskEdgeHoldTimeMin", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.NBTaskEdgeHoldTimeMin.Location = New System.Drawing.Point(117, 88)
+		Me.NBTaskEdgeHoldTimeMin.Maximum = New Decimal(New Integer() {9999, 0, 0, 0})
+		Me.NBTaskEdgeHoldTimeMin.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
+		Me.NBTaskEdgeHoldTimeMin.Name = "NBTaskEdgeHoldTimeMin"
+		Me.NBTaskEdgeHoldTimeMin.Size = New System.Drawing.Size(44, 20)
+		Me.NBTaskEdgeHoldTimeMin.TabIndex = 197
+		Me.NBTaskEdgeHoldTimeMin.Value = Global.Tease_AI.My.MySettings.Default.TaskEdgeHoldTimeMin
+		'
 		'Label159
 		'
 		Me.Label159.BackColor = System.Drawing.Color.Transparent
-		Me.Label159.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label159.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label159.ForeColor = System.Drawing.Color.Black
 		Me.Label159.Location = New System.Drawing.Point(167, 87)
 		Me.Label159.Name = "Label159"
@@ -11182,7 +11393,7 @@ Partial Class FrmSettings
 		'Label160
 		'
 		Me.Label160.BackColor = System.Drawing.Color.Transparent
-		Me.Label160.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label160.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label160.ForeColor = System.Drawing.Color.Black
 		Me.Label160.Location = New System.Drawing.Point(12, 88)
 		Me.Label160.Name = "Label160"
@@ -11191,10 +11402,32 @@ Partial Class FrmSettings
 		Me.Label160.Text = "Edge Hold Time:"
 		Me.Label160.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
 		'
+		'NBTaskEdgesMax
+		'
+		Me.NBTaskEdgesMax.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskEdgesMax", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.NBTaskEdgesMax.Location = New System.Drawing.Point(183, 64)
+		Me.NBTaskEdgesMax.Maximum = New Decimal(New Integer() {1000, 0, 0, 0})
+		Me.NBTaskEdgesMax.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
+		Me.NBTaskEdgesMax.Name = "NBTaskEdgesMax"
+		Me.NBTaskEdgesMax.Size = New System.Drawing.Size(44, 20)
+		Me.NBTaskEdgesMax.TabIndex = 194
+		Me.NBTaskEdgesMax.Value = Global.Tease_AI.My.MySettings.Default.TaskEdgesMax
+		'
+		'NBTaskEdgesMin
+		'
+		Me.NBTaskEdgesMin.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskEdgesMin", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.NBTaskEdgesMin.Location = New System.Drawing.Point(117, 65)
+		Me.NBTaskEdgesMin.Maximum = New Decimal(New Integer() {9999, 0, 0, 0})
+		Me.NBTaskEdgesMin.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
+		Me.NBTaskEdgesMin.Name = "NBTaskEdgesMin"
+		Me.NBTaskEdgesMin.Size = New System.Drawing.Size(44, 20)
+		Me.NBTaskEdgesMin.TabIndex = 193
+		Me.NBTaskEdgesMin.Value = Global.Tease_AI.My.MySettings.Default.TaskEdgesMin
+		'
 		'Label119
 		'
 		Me.Label119.BackColor = System.Drawing.Color.Transparent
-		Me.Label119.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label119.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label119.ForeColor = System.Drawing.Color.Black
 		Me.Label119.Location = New System.Drawing.Point(167, 64)
 		Me.Label119.Name = "Label119"
@@ -11206,7 +11439,7 @@ Partial Class FrmSettings
 		'Label157
 		'
 		Me.Label157.BackColor = System.Drawing.Color.Transparent
-		Me.Label157.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label157.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label157.ForeColor = System.Drawing.Color.Black
 		Me.Label157.Location = New System.Drawing.Point(12, 65)
 		Me.Label157.Name = "Label157"
@@ -11218,7 +11451,7 @@ Partial Class FrmSettings
 		'Label151
 		'
 		Me.Label151.BackColor = System.Drawing.Color.Transparent
-		Me.Label151.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label151.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label151.ForeColor = System.Drawing.Color.Black
 		Me.Label151.Location = New System.Drawing.Point(233, 41)
 		Me.Label151.Name = "Label151"
@@ -11227,10 +11460,32 @@ Partial Class FrmSettings
 		Me.Label151.Text = "minutes"
 		Me.Label151.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
 		'
+		'NBTaskStrokingTimeMax
+		'
+		Me.NBTaskStrokingTimeMax.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskStrokingTimeMax", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.NBTaskStrokingTimeMax.Location = New System.Drawing.Point(183, 41)
+		Me.NBTaskStrokingTimeMax.Maximum = New Decimal(New Integer() {9999, 0, 0, 0})
+		Me.NBTaskStrokingTimeMax.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
+		Me.NBTaskStrokingTimeMax.Name = "NBTaskStrokingTimeMax"
+		Me.NBTaskStrokingTimeMax.Size = New System.Drawing.Size(44, 20)
+		Me.NBTaskStrokingTimeMax.TabIndex = 189
+		Me.NBTaskStrokingTimeMax.Value = Global.Tease_AI.My.MySettings.Default.TaskStrokingTimeMax
+		'
+		'NBTaskStrokingTimeMin
+		'
+		Me.NBTaskStrokingTimeMin.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskStrokingTimeMin", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.NBTaskStrokingTimeMin.Location = New System.Drawing.Point(117, 42)
+		Me.NBTaskStrokingTimeMin.Maximum = New Decimal(New Integer() {9999, 0, 0, 0})
+		Me.NBTaskStrokingTimeMin.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
+		Me.NBTaskStrokingTimeMin.Name = "NBTaskStrokingTimeMin"
+		Me.NBTaskStrokingTimeMin.Size = New System.Drawing.Size(44, 20)
+		Me.NBTaskStrokingTimeMin.TabIndex = 188
+		Me.NBTaskStrokingTimeMin.Value = Global.Tease_AI.My.MySettings.Default.TaskStrokingTimeMin
+		'
 		'Label154
 		'
 		Me.Label154.BackColor = System.Drawing.Color.Transparent
-		Me.Label154.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label154.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label154.ForeColor = System.Drawing.Color.Black
 		Me.Label154.Location = New System.Drawing.Point(167, 41)
 		Me.Label154.Name = "Label154"
@@ -11242,7 +11497,7 @@ Partial Class FrmSettings
 		'Label155
 		'
 		Me.Label155.BackColor = System.Drawing.Color.Transparent
-		Me.Label155.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label155.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label155.ForeColor = System.Drawing.Color.Black
 		Me.Label155.Location = New System.Drawing.Point(12, 42)
 		Me.Label155.Name = "Label155"
@@ -11251,10 +11506,32 @@ Partial Class FrmSettings
 		Me.Label155.Text = "Stroking Time:"
 		Me.Label155.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
 		'
+		'NBTaskStrokesMax
+		'
+		Me.NBTaskStrokesMax.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskStrokesMax", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.NBTaskStrokesMax.Location = New System.Drawing.Point(183, 18)
+		Me.NBTaskStrokesMax.Maximum = New Decimal(New Integer() {9999, 0, 0, 0})
+		Me.NBTaskStrokesMax.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
+		Me.NBTaskStrokesMax.Name = "NBTaskStrokesMax"
+		Me.NBTaskStrokesMax.Size = New System.Drawing.Size(44, 20)
+		Me.NBTaskStrokesMax.TabIndex = 184
+		Me.NBTaskStrokesMax.Value = Global.Tease_AI.My.MySettings.Default.TaskStrokesMax
+		'
+		'NBTaskStrokesMin
+		'
+		Me.NBTaskStrokesMin.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskStrokesMin", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
+		Me.NBTaskStrokesMin.Location = New System.Drawing.Point(117, 19)
+		Me.NBTaskStrokesMin.Maximum = New Decimal(New Integer() {9999, 0, 0, 0})
+		Me.NBTaskStrokesMin.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
+		Me.NBTaskStrokesMin.Name = "NBTaskStrokesMin"
+		Me.NBTaskStrokesMin.Size = New System.Drawing.Size(44, 20)
+		Me.NBTaskStrokesMin.TabIndex = 183
+		Me.NBTaskStrokesMin.Value = Global.Tease_AI.My.MySettings.Default.TaskStrokesMin
+		'
 		'Label146
 		'
 		Me.Label146.BackColor = System.Drawing.Color.Transparent
-		Me.Label146.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label146.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label146.ForeColor = System.Drawing.Color.Black
 		Me.Label146.Location = New System.Drawing.Point(167, 18)
 		Me.Label146.Name = "Label146"
@@ -11266,7 +11543,7 @@ Partial Class FrmSettings
 		'Label149
 		'
 		Me.Label149.BackColor = System.Drawing.Color.Transparent
-		Me.Label149.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label149.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label149.ForeColor = System.Drawing.Color.Black
 		Me.Label149.Location = New System.Drawing.Point(12, 19)
 		Me.Label149.Name = "Label149"
@@ -11284,13 +11561,13 @@ Partial Class FrmSettings
 		Me.GroupBox10.Name = "GroupBox10"
 		Me.GroupBox10.Size = New System.Drawing.Size(291, 54)
 		Me.GroupBox10.TabIndex = 170
-		Me.GroupBox10.TabStop = false
+		Me.GroupBox10.TabStop = False
 		Me.GroupBox10.Text = "Tease Slideshow"
 		'
 		'Label112
 		'
 		Me.Label112.BackColor = System.Drawing.Color.Transparent
-		Me.Label112.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label112.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label112.ForeColor = System.Drawing.Color.Black
 		Me.Label112.Location = New System.Drawing.Point(233, 21)
 		Me.Label112.Name = "Label112"
@@ -11311,7 +11588,7 @@ Partial Class FrmSettings
 		'Label6
 		'
 		Me.Label6.BackColor = System.Drawing.Color.Transparent
-		Me.Label6.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label6.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label6.ForeColor = System.Drawing.Color.Black
 		Me.Label6.Location = New System.Drawing.Point(9, 21)
 		Me.Label6.Name = "Label6"
@@ -11349,13 +11626,13 @@ Partial Class FrmSettings
 		Me.GroupBox57.Name = "GroupBox57"
 		Me.GroupBox57.Size = New System.Drawing.Size(223, 308)
 		Me.GroupBox57.TabIndex = 169
-		Me.GroupBox57.TabStop = false
+		Me.GroupBox57.TabStop = False
 		Me.GroupBox57.Text = "Tease"
 		'
 		'Label139
 		'
 		Me.Label139.BackColor = System.Drawing.Color.Transparent
-		Me.Label139.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label139.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label139.ForeColor = System.Drawing.Color.Black
 		Me.Label139.Location = New System.Drawing.Point(175, 171)
 		Me.Label139.Name = "Label139"
@@ -11375,7 +11652,7 @@ Partial Class FrmSettings
 		'LBLVtf
 		'
 		Me.LBLVtf.BackColor = System.Drawing.Color.Transparent
-		Me.LBLVtf.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLVtf.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLVtf.ForeColor = System.Drawing.Color.Black
 		Me.LBLVtf.Location = New System.Drawing.Point(128, 261)
 		Me.LBLVtf.Name = "LBLVtf"
@@ -11387,7 +11664,7 @@ Partial Class FrmSettings
 		'LBLStf
 		'
 		Me.LBLStf.BackColor = System.Drawing.Color.Transparent
-		Me.LBLStf.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLStf.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLStf.ForeColor = System.Drawing.Color.Black
 		Me.LBLStf.Location = New System.Drawing.Point(130, 220)
 		Me.LBLStf.Name = "LBLStf"
@@ -11398,7 +11675,7 @@ Partial Class FrmSettings
 		'
 		'SliderSTF
 		'
-		Me.SliderSTF.AutoSize = false
+		Me.SliderSTF.AutoSize = False
 		Me.SliderSTF.LargeChange = 1
 		Me.SliderSTF.Location = New System.Drawing.Point(130, 199)
 		Me.SliderSTF.Maximum = 5
@@ -11410,7 +11687,7 @@ Partial Class FrmSettings
 		'
 		'TauntSlider
 		'
-		Me.TauntSlider.AutoSize = false
+		Me.TauntSlider.AutoSize = False
 		Me.TauntSlider.LargeChange = 1
 		Me.TauntSlider.Location = New System.Drawing.Point(130, 240)
 		Me.TauntSlider.Maximum = 9
@@ -11423,7 +11700,7 @@ Partial Class FrmSettings
 		'Label106
 		'
 		Me.Label106.BackColor = System.Drawing.Color.Transparent
-		Me.Label106.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label106.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label106.ForeColor = System.Drawing.Color.Black
 		Me.Label106.Location = New System.Drawing.Point(6, 243)
 		Me.Label106.Name = "Label106"
@@ -11434,30 +11711,30 @@ Partial Class FrmSettings
 		'
 		'CBTauntCycleDD
 		'
-		Me.CBTauntCycleDD.AutoSize = true
+		Me.CBTauntCycleDD.AutoSize = True
 		Me.CBTauntCycleDD.ForeColor = System.Drawing.Color.Black
 		Me.CBTauntCycleDD.Location = New System.Drawing.Point(9, 140)
 		Me.CBTauntCycleDD.Name = "CBTauntCycleDD"
 		Me.CBTauntCycleDD.Size = New System.Drawing.Size(176, 17)
 		Me.CBTauntCycleDD.TabIndex = 185
 		Me.CBTauntCycleDD.Text = "Domme Decide Based on Level"
-		Me.CBTauntCycleDD.UseVisualStyleBackColor = true
+		Me.CBTauntCycleDD.UseVisualStyleBackColor = True
 		'
 		'CBTeaseLengthDD
 		'
-		Me.CBTeaseLengthDD.AutoSize = true
+		Me.CBTeaseLengthDD.AutoSize = True
 		Me.CBTeaseLengthDD.ForeColor = System.Drawing.Color.Black
 		Me.CBTeaseLengthDD.Location = New System.Drawing.Point(9, 69)
 		Me.CBTeaseLengthDD.Name = "CBTeaseLengthDD"
 		Me.CBTeaseLengthDD.Size = New System.Drawing.Size(176, 17)
 		Me.CBTeaseLengthDD.TabIndex = 184
 		Me.CBTeaseLengthDD.Text = "Domme Decide Based on Level"
-		Me.CBTeaseLengthDD.UseVisualStyleBackColor = true
+		Me.CBTeaseLengthDD.UseVisualStyleBackColor = True
 		'
 		'Label103
 		'
 		Me.Label103.BackColor = System.Drawing.Color.Transparent
-		Me.Label103.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label103.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label103.ForeColor = System.Drawing.Color.Black
 		Me.Label103.Location = New System.Drawing.Point(175, 117)
 		Me.Label103.Name = "Label103"
@@ -11479,7 +11756,7 @@ Partial Class FrmSettings
 		'Label105
 		'
 		Me.Label105.BackColor = System.Drawing.Color.Transparent
-		Me.Label105.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label105.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label105.ForeColor = System.Drawing.Color.Black
 		Me.Label105.Location = New System.Drawing.Point(6, 117)
 		Me.Label105.Name = "Label105"
@@ -11491,7 +11768,7 @@ Partial Class FrmSettings
 		'Label101
 		'
 		Me.Label101.BackColor = System.Drawing.Color.Transparent
-		Me.Label101.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label101.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label101.ForeColor = System.Drawing.Color.Black
 		Me.Label101.Location = New System.Drawing.Point(175, 93)
 		Me.Label101.Name = "Label101"
@@ -11513,7 +11790,7 @@ Partial Class FrmSettings
 		'Label102
 		'
 		Me.Label102.BackColor = System.Drawing.Color.Transparent
-		Me.Label102.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label102.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label102.ForeColor = System.Drawing.Color.Black
 		Me.Label102.Location = New System.Drawing.Point(6, 93)
 		Me.Label102.Name = "Label102"
@@ -11525,7 +11802,7 @@ Partial Class FrmSettings
 		'Label97
 		'
 		Me.Label97.BackColor = System.Drawing.Color.Transparent
-		Me.Label97.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label97.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label97.ForeColor = System.Drawing.Color.Black
 		Me.Label97.Location = New System.Drawing.Point(175, 46)
 		Me.Label97.Name = "Label97"
@@ -11547,7 +11824,7 @@ Partial Class FrmSettings
 		'Label99
 		'
 		Me.Label99.BackColor = System.Drawing.Color.Transparent
-		Me.Label99.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label99.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label99.ForeColor = System.Drawing.Color.Black
 		Me.Label99.Location = New System.Drawing.Point(6, 46)
 		Me.Label99.Name = "Label99"
@@ -11559,7 +11836,7 @@ Partial Class FrmSettings
 		'Label96
 		'
 		Me.Label96.BackColor = System.Drawing.Color.Transparent
-		Me.Label96.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label96.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label96.ForeColor = System.Drawing.Color.Black
 		Me.Label96.Location = New System.Drawing.Point(175, 20)
 		Me.Label96.Name = "Label96"
@@ -11581,7 +11858,7 @@ Partial Class FrmSettings
 		'Label95
 		'
 		Me.Label95.BackColor = System.Drawing.Color.Transparent
-		Me.Label95.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label95.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label95.ForeColor = System.Drawing.Color.Black
 		Me.Label95.Location = New System.Drawing.Point(6, 20)
 		Me.Label95.Name = "Label95"
@@ -11593,7 +11870,7 @@ Partial Class FrmSettings
 		'Label49
 		'
 		Me.Label49.BackColor = System.Drawing.Color.Transparent
-		Me.Label49.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label49.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label49.ForeColor = System.Drawing.Color.Black
 		Me.Label49.Location = New System.Drawing.Point(6, 207)
 		Me.Label49.Name = "Label49"
@@ -11605,7 +11882,7 @@ Partial Class FrmSettings
 		'Label141
 		'
 		Me.Label141.BackColor = System.Drawing.Color.Transparent
-		Me.Label141.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label141.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label141.ForeColor = System.Drawing.Color.Black
 		Me.Label141.Location = New System.Drawing.Point(6, 163)
 		Me.Label141.Name = "Label141"
@@ -11627,13 +11904,13 @@ Partial Class FrmSettings
 		Me.GroupBox56.Name = "GroupBox56"
 		Me.GroupBox56.Size = New System.Drawing.Size(166, 122)
 		Me.GroupBox56.TabIndex = 168
-		Me.GroupBox56.TabStop = false
+		Me.GroupBox56.TabStop = False
 		Me.GroupBox56.Text = "Ruin Chance"
 		'
 		'Label90
 		'
 		Me.Label90.BackColor = System.Drawing.Color.Transparent
-		Me.Label90.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label90.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label90.ForeColor = System.Drawing.Color.Black
 		Me.Label90.Location = New System.Drawing.Point(6, 94)
 		Me.Label90.Name = "Label90"
@@ -11644,7 +11921,7 @@ Partial Class FrmSettings
 		'
 		'NBRuinSometimes
 		'
-		Me.NBRuinSometimes.Enabled = false
+		Me.NBRuinSometimes.Enabled = False
 		Me.NBRuinSometimes.Location = New System.Drawing.Point(113, 68)
 		Me.NBRuinSometimes.Maximum = New Decimal(New Integer() {99, 0, 0, 0})
 		Me.NBRuinSometimes.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
@@ -11656,7 +11933,7 @@ Partial Class FrmSettings
 		'Label91
 		'
 		Me.Label91.BackColor = System.Drawing.Color.Transparent
-		Me.Label91.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label91.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label91.ForeColor = System.Drawing.Color.Black
 		Me.Label91.Location = New System.Drawing.Point(6, 68)
 		Me.Label91.Name = "Label91"
@@ -11668,7 +11945,7 @@ Partial Class FrmSettings
 		'Label92
 		'
 		Me.Label92.BackColor = System.Drawing.Color.Transparent
-		Me.Label92.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label92.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label92.ForeColor = System.Drawing.Color.Black
 		Me.Label92.Location = New System.Drawing.Point(6, 42)
 		Me.Label92.Name = "Label92"
@@ -11679,7 +11956,7 @@ Partial Class FrmSettings
 		'
 		'NBRuinRarely
 		'
-		Me.NBRuinRarely.Enabled = false
+		Me.NBRuinRarely.Enabled = False
 		Me.NBRuinRarely.Location = New System.Drawing.Point(113, 94)
 		Me.NBRuinRarely.Maximum = New Decimal(New Integer() {99, 0, 0, 0})
 		Me.NBRuinRarely.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
@@ -11690,7 +11967,7 @@ Partial Class FrmSettings
 		'
 		'NBRuinOften
 		'
-		Me.NBRuinOften.Enabled = false
+		Me.NBRuinOften.Enabled = False
 		Me.NBRuinOften.Location = New System.Drawing.Point(113, 42)
 		Me.NBRuinOften.Maximum = New Decimal(New Integer() {99, 0, 0, 0})
 		Me.NBRuinOften.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
@@ -11701,14 +11978,14 @@ Partial Class FrmSettings
 		'
 		'CBRangeRuin
 		'
-		Me.CBRangeRuin.AutoSize = true
+		Me.CBRangeRuin.AutoSize = True
 		Me.CBRangeRuin.ForeColor = System.Drawing.Color.Black
 		Me.CBRangeRuin.Location = New System.Drawing.Point(9, 19)
 		Me.CBRangeRuin.Name = "CBRangeRuin"
 		Me.CBRangeRuin.Size = New System.Drawing.Size(99, 17)
 		Me.CBRangeRuin.TabIndex = 159
 		Me.CBRangeRuin.Text = "Domme Decide"
-		Me.CBRangeRuin.UseVisualStyleBackColor = true
+		Me.CBRangeRuin.UseVisualStyleBackColor = True
 		'
 		'GroupBox17
 		'
@@ -11718,7 +11995,7 @@ Partial Class FrmSettings
 		Me.GroupBox17.Name = "GroupBox17"
 		Me.GroupBox17.Size = New System.Drawing.Size(291, 190)
 		Me.GroupBox17.TabIndex = 0
-		Me.GroupBox17.TabStop = false
+		Me.GroupBox17.TabStop = False
 		Me.GroupBox17.Text = "Video Teases"
 		'
 		'GroupBox19
@@ -11737,13 +12014,13 @@ Partial Class FrmSettings
 		Me.GroupBox19.Name = "GroupBox19"
 		Me.GroupBox19.Size = New System.Drawing.Size(279, 66)
 		Me.GroupBox19.TabIndex = 2
-		Me.GroupBox19.TabStop = false
+		Me.GroupBox19.TabStop = False
 		Me.GroupBox19.Text = "Red Light, Green Light"
 		'
 		'Label110
 		'
 		Me.Label110.BackColor = System.Drawing.Color.Transparent
-		Me.Label110.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label110.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label110.ForeColor = System.Drawing.Color.Black
 		Me.Label110.Location = New System.Drawing.Point(227, 39)
 		Me.Label110.Name = "Label110"
@@ -11755,7 +12032,7 @@ Partial Class FrmSettings
 		'Label111
 		'
 		Me.Label111.BackColor = System.Drawing.Color.Transparent
-		Me.Label111.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label111.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label111.ForeColor = System.Drawing.Color.Black
 		Me.Label111.Location = New System.Drawing.Point(227, 16)
 		Me.Label111.Name = "Label111"
@@ -11791,7 +12068,7 @@ Partial Class FrmSettings
 		'Label26
 		'
 		Me.Label26.BackColor = System.Drawing.Color.Transparent
-		Me.Label26.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label26.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label26.ForeColor = System.Drawing.Color.Black
 		Me.Label26.Location = New System.Drawing.Point(161, 38)
 		Me.Label26.Name = "Label26"
@@ -11811,7 +12088,7 @@ Partial Class FrmSettings
 		'Label28
 		'
 		Me.Label28.BackColor = System.Drawing.Color.Transparent
-		Me.Label28.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label28.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label28.ForeColor = System.Drawing.Color.Black
 		Me.Label28.Location = New System.Drawing.Point(161, 15)
 		Me.Label28.Name = "Label28"
@@ -11823,7 +12100,7 @@ Partial Class FrmSettings
 		'Label27
 		'
 		Me.Label27.BackColor = System.Drawing.Color.Transparent
-		Me.Label27.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label27.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label27.ForeColor = System.Drawing.Color.Black
 		Me.Label27.Location = New System.Drawing.Point(6, 39)
 		Me.Label27.Name = "Label27"
@@ -11835,7 +12112,7 @@ Partial Class FrmSettings
 		'Label29
 		'
 		Me.Label29.BackColor = System.Drawing.Color.Transparent
-		Me.Label29.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label29.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label29.ForeColor = System.Drawing.Color.Black
 		Me.Label29.Location = New System.Drawing.Point(6, 16)
 		Me.Label29.Name = "Label29"
@@ -11861,13 +12138,13 @@ Partial Class FrmSettings
 		Me.GroupBox18.Name = "GroupBox18"
 		Me.GroupBox18.Size = New System.Drawing.Size(279, 88)
 		Me.GroupBox18.TabIndex = 1
-		Me.GroupBox18.TabStop = false
+		Me.GroupBox18.TabStop = False
 		Me.GroupBox18.Text = "Censorship Sucks"
 		'
 		'Label108
 		'
 		Me.Label108.BackColor = System.Drawing.Color.Transparent
-		Me.Label108.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label108.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label108.ForeColor = System.Drawing.Color.Black
 		Me.Label108.Location = New System.Drawing.Point(227, 39)
 		Me.Label108.Name = "Label108"
@@ -11879,7 +12156,7 @@ Partial Class FrmSettings
 		'Label109
 		'
 		Me.Label109.BackColor = System.Drawing.Color.Transparent
-		Me.Label109.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label109.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label109.ForeColor = System.Drawing.Color.Black
 		Me.Label109.Location = New System.Drawing.Point(227, 16)
 		Me.Label109.Name = "Label109"
@@ -11920,20 +12197,20 @@ Partial Class FrmSettings
 		'
 		'CBCensorConstant
 		'
-		Me.CBCensorConstant.AutoSize = true
-		Me.CBCensorConstant.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.CBCensorConstant.AutoSize = True
+		Me.CBCensorConstant.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.CBCensorConstant.ForeColor = System.Drawing.Color.Black
 		Me.CBCensorConstant.Location = New System.Drawing.Point(6, 65)
 		Me.CBCensorConstant.Name = "CBCensorConstant"
 		Me.CBCensorConstant.Size = New System.Drawing.Size(263, 17)
 		Me.CBCensorConstant.TabIndex = 157
 		Me.CBCensorConstant.Text = "Censorship Bar Always Visible During Video Tease"
-		Me.CBCensorConstant.UseVisualStyleBackColor = true
+		Me.CBCensorConstant.UseVisualStyleBackColor = True
 		'
 		'Label25
 		'
 		Me.Label25.BackColor = System.Drawing.Color.Transparent
-		Me.Label25.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label25.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label25.ForeColor = System.Drawing.Color.Black
 		Me.Label25.Location = New System.Drawing.Point(161, 15)
 		Me.Label25.Name = "Label25"
@@ -11945,7 +12222,7 @@ Partial Class FrmSettings
 		'Label20
 		'
 		Me.Label20.BackColor = System.Drawing.Color.Transparent
-		Me.Label20.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label20.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label20.ForeColor = System.Drawing.Color.Black
 		Me.Label20.Location = New System.Drawing.Point(6, 39)
 		Me.Label20.Name = "Label20"
@@ -11957,7 +12234,7 @@ Partial Class FrmSettings
 		'Label19
 		'
 		Me.Label19.BackColor = System.Drawing.Color.Transparent
-		Me.Label19.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label19.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label19.ForeColor = System.Drawing.Color.Black
 		Me.Label19.Location = New System.Drawing.Point(161, 38)
 		Me.Label19.Name = "Label19"
@@ -11969,7 +12246,7 @@ Partial Class FrmSettings
 		'Label24
 		'
 		Me.Label24.BackColor = System.Drawing.Color.Transparent
-		Me.Label24.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label24.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label24.ForeColor = System.Drawing.Color.Black
 		Me.Label24.Location = New System.Drawing.Point(6, 16)
 		Me.Label24.Name = "Label24"
@@ -12001,13 +12278,13 @@ Partial Class FrmSettings
 		Me.GroupBox52.Name = "GroupBox52"
 		Me.GroupBox52.Size = New System.Drawing.Size(166, 122)
 		Me.GroupBox52.TabIndex = 167
-		Me.GroupBox52.TabStop = false
+		Me.GroupBox52.TabStop = False
 		Me.GroupBox52.Text = "Orgasm Chance"
 		'
 		'Label89
 		'
 		Me.Label89.BackColor = System.Drawing.Color.Transparent
-		Me.Label89.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label89.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label89.ForeColor = System.Drawing.Color.Black
 		Me.Label89.Location = New System.Drawing.Point(6, 94)
 		Me.Label89.Name = "Label89"
@@ -12018,7 +12295,7 @@ Partial Class FrmSettings
 		'
 		'NBAllowSometimes
 		'
-		Me.NBAllowSometimes.Enabled = false
+		Me.NBAllowSometimes.Enabled = False
 		Me.NBAllowSometimes.Location = New System.Drawing.Point(113, 68)
 		Me.NBAllowSometimes.Maximum = New Decimal(New Integer() {99, 0, 0, 0})
 		Me.NBAllowSometimes.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
@@ -12030,7 +12307,7 @@ Partial Class FrmSettings
 		'Label86
 		'
 		Me.Label86.BackColor = System.Drawing.Color.Transparent
-		Me.Label86.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label86.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label86.ForeColor = System.Drawing.Color.Black
 		Me.Label86.Location = New System.Drawing.Point(6, 68)
 		Me.Label86.Name = "Label86"
@@ -12042,7 +12319,7 @@ Partial Class FrmSettings
 		'Label82
 		'
 		Me.Label82.BackColor = System.Drawing.Color.Transparent
-		Me.Label82.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label82.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label82.ForeColor = System.Drawing.Color.Black
 		Me.Label82.Location = New System.Drawing.Point(6, 42)
 		Me.Label82.Name = "Label82"
@@ -12053,7 +12330,7 @@ Partial Class FrmSettings
 		'
 		'NBAllowRarely
 		'
-		Me.NBAllowRarely.Enabled = false
+		Me.NBAllowRarely.Enabled = False
 		Me.NBAllowRarely.Location = New System.Drawing.Point(113, 94)
 		Me.NBAllowRarely.Maximum = New Decimal(New Integer() {99, 0, 0, 0})
 		Me.NBAllowRarely.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
@@ -12064,7 +12341,7 @@ Partial Class FrmSettings
 		'
 		'NBAllowOften
 		'
-		Me.NBAllowOften.Enabled = false
+		Me.NBAllowOften.Enabled = False
 		Me.NBAllowOften.Location = New System.Drawing.Point(113, 42)
 		Me.NBAllowOften.Maximum = New Decimal(New Integer() {99, 0, 0, 0})
 		Me.NBAllowOften.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
@@ -12075,30 +12352,30 @@ Partial Class FrmSettings
 		'
 		'CBRangeOrgasm
 		'
-		Me.CBRangeOrgasm.AutoSize = true
+		Me.CBRangeOrgasm.AutoSize = True
 		Me.CBRangeOrgasm.ForeColor = System.Drawing.Color.Black
 		Me.CBRangeOrgasm.Location = New System.Drawing.Point(9, 19)
 		Me.CBRangeOrgasm.Name = "CBRangeOrgasm"
 		Me.CBRangeOrgasm.Size = New System.Drawing.Size(99, 17)
 		Me.CBRangeOrgasm.TabIndex = 159
 		Me.CBRangeOrgasm.Text = "Domme Decide"
-		Me.CBRangeOrgasm.UseVisualStyleBackColor = true
+		Me.CBRangeOrgasm.UseVisualStyleBackColor = True
 		'
 		'PictureBox8
 		'
 		Me.PictureBox8.BackColor = System.Drawing.Color.LightGray
-		Me.PictureBox8.Image = CType(resources.GetObject("PictureBox8.Image"),System.Drawing.Image)
+		Me.PictureBox8.Image = CType(resources.GetObject("PictureBox8.Image"), System.Drawing.Image)
 		Me.PictureBox8.Location = New System.Drawing.Point(9, 6)
 		Me.PictureBox8.Name = "PictureBox8"
 		Me.PictureBox8.Size = New System.Drawing.Size(160, 19)
 		Me.PictureBox8.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage
 		Me.PictureBox8.TabIndex = 166
-		Me.PictureBox8.TabStop = false
+		Me.PictureBox8.TabStop = False
 		'
 		'Label38
 		'
 		Me.Label38.BackColor = System.Drawing.Color.Transparent
-		Me.Label38.Font = New System.Drawing.Font("Microsoft Sans Serif", 12!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label38.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label38.ForeColor = System.Drawing.Color.Black
 		Me.Label38.Location = New System.Drawing.Point(7, 6)
 		Me.Label38.Name = "Label38"
@@ -12164,68 +12441,68 @@ Partial Class FrmSettings
 		'
 		'BTNPlaylistCtrlZ
 		'
-		Me.BTNPlaylistCtrlZ.Enabled = false
+		Me.BTNPlaylistCtrlZ.Enabled = False
 		Me.BTNPlaylistCtrlZ.Location = New System.Drawing.Point(621, 21)
 		Me.BTNPlaylistCtrlZ.Name = "BTNPlaylistCtrlZ"
 		Me.BTNPlaylistCtrlZ.Size = New System.Drawing.Size(44, 23)
 		Me.BTNPlaylistCtrlZ.TabIndex = 202
 		Me.BTNPlaylistCtrlZ.Text = "Undo"
-		Me.BTNPlaylistCtrlZ.UseVisualStyleBackColor = true
+		Me.BTNPlaylistCtrlZ.UseVisualStyleBackColor = True
 		'
 		'RadioPlaylistRegScripts
 		'
-		Me.RadioPlaylistRegScripts.AutoSize = true
+		Me.RadioPlaylistRegScripts.AutoSize = True
 		Me.RadioPlaylistRegScripts.Location = New System.Drawing.Point(228, 372)
 		Me.RadioPlaylistRegScripts.Name = "RadioPlaylistRegScripts"
 		Me.RadioPlaylistRegScripts.Size = New System.Drawing.Size(127, 17)
 		Me.RadioPlaylistRegScripts.TabIndex = 201
 		Me.RadioPlaylistRegScripts.Text = "Show Regular Scripts"
-		Me.RadioPlaylistRegScripts.UseVisualStyleBackColor = true
+		Me.RadioPlaylistRegScripts.UseVisualStyleBackColor = True
 		'
 		'RadioPlaylistScripts
 		'
-		Me.RadioPlaylistScripts.AutoSize = true
-		Me.RadioPlaylistScripts.Checked = true
+		Me.RadioPlaylistScripts.AutoSize = True
+		Me.RadioPlaylistScripts.Checked = True
 		Me.RadioPlaylistScripts.Location = New System.Drawing.Point(62, 372)
 		Me.RadioPlaylistScripts.Name = "RadioPlaylistScripts"
 		Me.RadioPlaylistScripts.Size = New System.Drawing.Size(122, 17)
 		Me.RadioPlaylistScripts.TabIndex = 200
-		Me.RadioPlaylistScripts.TabStop = true
+		Me.RadioPlaylistScripts.TabStop = True
 		Me.RadioPlaylistScripts.Text = "Show Playlist Scripts"
-		Me.RadioPlaylistScripts.UseVisualStyleBackColor = true
+		Me.RadioPlaylistScripts.UseVisualStyleBackColor = True
 		'
 		'BTNPlaylistEnd
 		'
 		Me.BTNPlaylistEnd.BackColor = System.Drawing.Color.LightGray
-		Me.BTNPlaylistEnd.Enabled = false
-		Me.BTNPlaylistEnd.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.BTNPlaylistEnd.Enabled = False
+		Me.BTNPlaylistEnd.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.BTNPlaylistEnd.ForeColor = System.Drawing.Color.Black
 		Me.BTNPlaylistEnd.Location = New System.Drawing.Point(165, 21)
 		Me.BTNPlaylistEnd.Name = "BTNPlaylistEnd"
 		Me.BTNPlaylistEnd.Size = New System.Drawing.Size(44, 23)
 		Me.BTNPlaylistEnd.TabIndex = 199
 		Me.BTNPlaylistEnd.Text = "End"
-		Me.BTNPlaylistEnd.UseVisualStyleBackColor = false
+		Me.BTNPlaylistEnd.UseVisualStyleBackColor = False
 		'
 		'BTNPlaylistClearAll
 		'
-		Me.BTNPlaylistClearAll.Enabled = false
+		Me.BTNPlaylistClearAll.Enabled = False
 		Me.BTNPlaylistClearAll.Location = New System.Drawing.Point(296, 21)
 		Me.BTNPlaylistClearAll.Name = "BTNPlaylistClearAll"
 		Me.BTNPlaylistClearAll.Size = New System.Drawing.Size(78, 23)
 		Me.BTNPlaylistClearAll.TabIndex = 198
 		Me.BTNPlaylistClearAll.Text = "Clear All"
-		Me.BTNPlaylistClearAll.UseVisualStyleBackColor = true
+		Me.BTNPlaylistClearAll.UseVisualStyleBackColor = True
 		'
 		'BTNPlaylistSave
 		'
-		Me.BTNPlaylistSave.Enabled = false
+		Me.BTNPlaylistSave.Enabled = False
 		Me.BTNPlaylistSave.Location = New System.Drawing.Point(621, 369)
 		Me.BTNPlaylistSave.Name = "BTNPlaylistSave"
 		Me.BTNPlaylistSave.Size = New System.Drawing.Size(44, 23)
 		Me.BTNPlaylistSave.TabIndex = 197
 		Me.BTNPlaylistSave.Text = "Save"
-		Me.BTNPlaylistSave.UseVisualStyleBackColor = true
+		Me.BTNPlaylistSave.UseVisualStyleBackColor = True
 		'
 		'Button7
 		'
@@ -12234,7 +12511,7 @@ Partial Class FrmSettings
 		Me.Button7.Size = New System.Drawing.Size(78, 23)
 		Me.Button7.TabIndex = 196
 		Me.Button7.Text = "Add Random"
-		Me.Button7.UseVisualStyleBackColor = true
+		Me.Button7.UseVisualStyleBackColor = True
 		'
 		'WBPlaylist
 		'
@@ -12246,8 +12523,8 @@ Partial Class FrmSettings
 		'
 		'Label80
 		'
-		Me.Label80.AutoSize = true
-		Me.Label80.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label80.AutoSize = True
+		Me.Label80.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label80.Location = New System.Drawing.Point(410, 27)
 		Me.Label80.Name = "Label80"
 		Me.Label80.Size = New System.Drawing.Size(47, 13)
@@ -12257,8 +12534,8 @@ Partial Class FrmSettings
 		'LBLPlaylIstLink
 		'
 		Me.LBLPlaylIstLink.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D
-		Me.LBLPlaylIstLink.Enabled = false
-		Me.LBLPlaylIstLink.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLPlaylIstLink.Enabled = False
+		Me.LBLPlaylIstLink.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLPlaylIstLink.Location = New System.Drawing.Point(128, 22)
 		Me.LBLPlaylIstLink.Name = "LBLPlaylIstLink"
 		Me.LBLPlaylIstLink.Size = New System.Drawing.Size(34, 21)
@@ -12269,8 +12546,8 @@ Partial Class FrmSettings
 		'LBLPlaylistModule
 		'
 		Me.LBLPlaylistModule.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D
-		Me.LBLPlaylistModule.Enabled = false
-		Me.LBLPlaylistModule.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLPlaylistModule.Enabled = False
+		Me.LBLPlaylistModule.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLPlaylistModule.Location = New System.Drawing.Point(76, 22)
 		Me.LBLPlaylistModule.Name = "LBLPlaylistModule"
 		Me.LBLPlaylistModule.Size = New System.Drawing.Size(50, 21)
@@ -12282,7 +12559,7 @@ Partial Class FrmSettings
 		'
 		Me.LBLPLaylistStart.BackColor = System.Drawing.Color.Green
 		Me.LBLPLaylistStart.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D
-		Me.LBLPLaylistStart.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLPLaylistStart.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLPLaylistStart.ForeColor = System.Drawing.Color.White
 		Me.LBLPLaylistStart.Location = New System.Drawing.Point(38, 22)
 		Me.LBLPLaylistStart.Name = "LBLPLaylistStart"
@@ -12293,8 +12570,8 @@ Partial Class FrmSettings
 		'
 		'LBPlaylist
 		'
-		Me.LBPlaylist.AllowDrop = true
-		Me.LBPlaylist.FormattingEnabled = true
+		Me.LBPlaylist.AllowDrop = True
+		Me.LBPlaylist.FormattingEnabled = True
 		Me.LBPlaylist.Location = New System.Drawing.Point(413, 56)
 		Me.LBPlaylist.Name = "LBPlaylist"
 		Me.LBPlaylist.Size = New System.Drawing.Size(252, 290)
@@ -12336,8 +12613,8 @@ Partial Class FrmSettings
 		Me.Label88.Name = "Label88"
 		Me.Label88.Size = New System.Drawing.Size(194, 53)
 		Me.Label88.TabIndex = 173
-		Me.Label88.Text = "Preview:  Enter any line with a Keyword and press # to generate a random sentence"& _ 
-    " the domme return."
+		Me.Label88.Text = "Preview:  Enter any line with a Keyword and press # to generate a random sentence" &
+	" the domme return."
 		Me.Label88.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
 		'
 		'TBKeywordPreview
@@ -12351,13 +12628,13 @@ Partial Class FrmSettings
 		'
 		'Button37
 		'
-		Me.Button37.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Button37.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Button37.Location = New System.Drawing.Point(638, 358)
 		Me.Button37.Name = "Button37"
 		Me.Button37.Size = New System.Drawing.Size(47, 50)
 		Me.Button37.TabIndex = 171
 		Me.Button37.Text = "#"
-		Me.Button37.UseVisualStyleBackColor = true
+		Me.Button37.UseVisualStyleBackColor = True
 		'
 		'Button50
 		'
@@ -12366,7 +12643,7 @@ Partial Class FrmSettings
 		Me.Button50.Size = New System.Drawing.Size(194, 23)
 		Me.Button50.TabIndex = 169
 		Me.Button50.Text = "Refresh and Clear Keyword List"
-		Me.Button50.UseVisualStyleBackColor = true
+		Me.Button50.UseVisualStyleBackColor = True
 		'
 		'Button22
 		'
@@ -12375,7 +12652,7 @@ Partial Class FrmSettings
 		Me.Button22.Size = New System.Drawing.Size(47, 23)
 		Me.Button22.TabIndex = 167
 		Me.Button22.Text = "Save"
-		Me.Button22.UseVisualStyleBackColor = true
+		Me.Button22.UseVisualStyleBackColor = True
 		'
 		'TBKeyWords
 		'
@@ -12386,11 +12663,11 @@ Partial Class FrmSettings
 		'
 		'LBKeyWords
 		'
-		Me.LBKeyWords.FormattingEnabled = true
+		Me.LBKeyWords.FormattingEnabled = True
 		Me.LBKeyWords.Location = New System.Drawing.Point(6, 36)
 		Me.LBKeyWords.Name = "LBKeyWords"
 		Me.LBKeyWords.Size = New System.Drawing.Size(194, 316)
-		Me.LBKeyWords.Sorted = true
+		Me.LBKeyWords.Sorted = True
 		Me.LBKeyWords.TabIndex = 165
 		'
 		'RTBKeyWords
@@ -12425,11 +12702,11 @@ Partial Class FrmSettings
 		Me.Button9.Size = New System.Drawing.Size(215, 23)
 		Me.Button9.TabIndex = 176
 		Me.Button9.Text = "Response Template"
-		Me.Button9.UseVisualStyleBackColor = true
+		Me.Button9.UseVisualStyleBackColor = True
 		'
 		'RTBResponsesKEY
 		'
-		Me.RTBResponsesKEY.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.RTBResponsesKEY.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.RTBResponsesKEY.Location = New System.Drawing.Point(217, 36)
 		Me.RTBResponsesKEY.Name = "RTBResponsesKEY"
 		Me.RTBResponsesKEY.Size = New System.Drawing.Size(468, 40)
@@ -12443,7 +12720,7 @@ Partial Class FrmSettings
 		Me.Button4.Size = New System.Drawing.Size(194, 23)
 		Me.Button4.TabIndex = 174
 		Me.Button4.Text = "Refresh and Clear Response List"
-		Me.Button4.UseVisualStyleBackColor = true
+		Me.Button4.UseVisualStyleBackColor = True
 		'
 		'Button5
 		'
@@ -12452,7 +12729,7 @@ Partial Class FrmSettings
 		Me.Button5.Size = New System.Drawing.Size(47, 23)
 		Me.Button5.TabIndex = 173
 		Me.Button5.Text = "Save"
-		Me.Button5.UseVisualStyleBackColor = true
+		Me.Button5.UseVisualStyleBackColor = True
 		'
 		'TBResponses
 		'
@@ -12463,11 +12740,11 @@ Partial Class FrmSettings
 		'
 		'LBResponses
 		'
-		Me.LBResponses.FormattingEnabled = true
+		Me.LBResponses.FormattingEnabled = True
 		Me.LBResponses.Location = New System.Drawing.Point(6, 36)
 		Me.LBResponses.Name = "LBResponses"
 		Me.LBResponses.Size = New System.Drawing.Size(194, 355)
-		Me.LBResponses.Sorted = true
+		Me.LBResponses.Sorted = True
 		Me.LBResponses.TabIndex = 171
 		'
 		'RTBResponses
@@ -12496,7 +12773,7 @@ Partial Class FrmSettings
 		'
 		'RTBVideoMod
 		'
-		Me.RTBVideoMod.Enabled = false
+		Me.RTBVideoMod.Enabled = False
 		Me.RTBVideoMod.Location = New System.Drawing.Point(167, 17)
 		Me.RTBVideoMod.Name = "RTBVideoMod"
 		Me.RTBVideoMod.Size = New System.Drawing.Size(525, 286)
@@ -12512,13 +12789,13 @@ Partial Class FrmSettings
 		Me.GroupBox29.Name = "GroupBox29"
 		Me.GroupBox29.Size = New System.Drawing.Size(692, 92)
 		Me.GroupBox29.TabIndex = 66
-		Me.GroupBox29.TabStop = false
+		Me.GroupBox29.TabStop = False
 		Me.GroupBox29.Text = "Description"
 		'
 		'Label51
 		'
 		Me.Label51.BackColor = System.Drawing.Color.Transparent
-		Me.Label51.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label51.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label51.ForeColor = System.Drawing.Color.Black
 		Me.Label51.Location = New System.Drawing.Point(6, 16)
 		Me.Label51.Name = "Label51"
@@ -12529,13 +12806,13 @@ Partial Class FrmSettings
 		'
 		'BTNVideoModClear
 		'
-		Me.BTNVideoModClear.Enabled = false
+		Me.BTNVideoModClear.Enabled = False
 		Me.BTNVideoModClear.Location = New System.Drawing.Point(6, 227)
 		Me.BTNVideoModClear.Name = "BTNVideoModClear"
 		Me.BTNVideoModClear.Size = New System.Drawing.Size(155, 35)
 		Me.BTNVideoModClear.TabIndex = 153
 		Me.BTNVideoModClear.Text = "Clear Text and Select New Video Tease Type/Script"
-		Me.BTNVideoModClear.UseVisualStyleBackColor = true
+		Me.BTNVideoModClear.UseVisualStyleBackColor = True
 		'
 		'GroupBox28
 		'
@@ -12544,13 +12821,13 @@ Partial Class FrmSettings
 		Me.GroupBox28.Name = "GroupBox28"
 		Me.GroupBox28.Size = New System.Drawing.Size(155, 46)
 		Me.GroupBox28.TabIndex = 148
-		Me.GroupBox28.TabStop = false
+		Me.GroupBox28.TabStop = False
 		Me.GroupBox28.Text = "Video Tease Type"
 		'
 		'CBVTType
 		'
 		Me.CBVTType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
-		Me.CBVTType.FormattingEnabled = true
+		Me.CBVTType.FormattingEnabled = True
 		Me.CBVTType.Items.AddRange(New Object() {"Avoid The Edge", "Censorship Sucks", "Red Light Green Light"})
 		Me.CBVTType.Location = New System.Drawing.Point(9, 15)
 		Me.CBVTType.Name = "CBVTType"
@@ -12564,7 +12841,7 @@ Partial Class FrmSettings
 		Me.BTNVideoModLoad.Size = New System.Drawing.Size(155, 35)
 		Me.BTNVideoModLoad.TabIndex = 152
 		Me.BTNVideoModLoad.Text = "Load Script"
-		Me.BTNVideoModLoad.UseVisualStyleBackColor = true
+		Me.BTNVideoModLoad.UseVisualStyleBackColor = True
 		'
 		'GroupBox30
 		'
@@ -12573,12 +12850,12 @@ Partial Class FrmSettings
 		Me.GroupBox30.Name = "GroupBox30"
 		Me.GroupBox30.Size = New System.Drawing.Size(155, 100)
 		Me.GroupBox30.TabIndex = 149
-		Me.GroupBox30.TabStop = false
+		Me.GroupBox30.TabStop = False
 		Me.GroupBox30.Text = "Script"
 		'
 		'LBVidScript
 		'
-		Me.LBVidScript.FormattingEnabled = true
+		Me.LBVidScript.FormattingEnabled = True
 		Me.LBVidScript.Location = New System.Drawing.Point(9, 20)
 		Me.LBVidScript.Name = "LBVidScript"
 		Me.LBVidScript.Size = New System.Drawing.Size(137, 69)
@@ -12586,13 +12863,13 @@ Partial Class FrmSettings
 		'
 		'BTNVideoModSave
 		'
-		Me.BTNVideoModSave.Enabled = false
+		Me.BTNVideoModSave.Enabled = False
 		Me.BTNVideoModSave.Location = New System.Drawing.Point(6, 268)
 		Me.BTNVideoModSave.Name = "BTNVideoModSave"
 		Me.BTNVideoModSave.Size = New System.Drawing.Size(155, 35)
 		Me.BTNVideoModSave.TabIndex = 151
 		Me.BTNVideoModSave.Text = "Save Changes"
-		Me.BTNVideoModSave.UseVisualStyleBackColor = true
+		Me.BTNVideoModSave.UseVisualStyleBackColor = True
 		'
 		'TabPage15
 		'
@@ -12683,13 +12960,13 @@ Partial Class FrmSettings
 		Me.GroupBox34.Name = "GroupBox34"
 		Me.GroupBox34.Size = New System.Drawing.Size(683, 107)
 		Me.GroupBox34.TabIndex = 66
-		Me.GroupBox34.TabStop = false
+		Me.GroupBox34.TabStop = False
 		Me.GroupBox34.Text = "Description"
 		'
 		'Label52
 		'
 		Me.Label52.BackColor = System.Drawing.Color.Transparent
-		Me.Label52.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label52.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label52.ForeColor = System.Drawing.Color.Black
 		Me.Label52.Location = New System.Drawing.Point(6, 16)
 		Me.Label52.Name = "Label52"
@@ -12713,7 +12990,7 @@ Partial Class FrmSettings
 		Me.Button26.Size = New System.Drawing.Size(120, 23)
 		Me.Button26.TabIndex = 174
 		Me.Button26.Text = "Clear Fields"
-		Me.Button26.UseVisualStyleBackColor = true
+		Me.Button26.UseVisualStyleBackColor = True
 		'
 		'Label56
 		'
@@ -12734,7 +13011,7 @@ Partial Class FrmSettings
 		'
 		'LBGlitModScripts
 		'
-		Me.LBGlitModScripts.FormattingEnabled = true
+		Me.LBGlitModScripts.FormattingEnabled = True
 		Me.LBGlitModScripts.Location = New System.Drawing.Point(27, 106)
 		Me.LBGlitModScripts.Name = "LBGlitModScripts"
 		Me.LBGlitModScripts.Size = New System.Drawing.Size(136, 186)
@@ -12751,7 +13028,7 @@ Partial Class FrmSettings
 		'
 		'LBLGlitModDomType
 		'
-		Me.LBLGlitModDomType.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLGlitModDomType.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.75!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLGlitModDomType.Location = New System.Drawing.Point(191, 103)
 		Me.LBLGlitModDomType.Name = "LBLGlitModDomType"
 		Me.LBLGlitModDomType.Size = New System.Drawing.Size(123, 23)
@@ -12766,12 +13043,12 @@ Partial Class FrmSettings
 		Me.Button29.Size = New System.Drawing.Size(120, 23)
 		Me.Button29.TabIndex = 151
 		Me.Button29.Text = "Save Glitter File"
-		Me.Button29.UseVisualStyleBackColor = true
+		Me.Button29.UseVisualStyleBackColor = True
 		'
 		'CBGlitModType
 		'
 		Me.CBGlitModType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
-		Me.CBGlitModType.FormattingEnabled = true
+		Me.CBGlitModType.FormattingEnabled = True
 		Me.CBGlitModType.Items.AddRange(New Object() {"Tease", "Egotist", "Trivia", "Daily", "Custom 1", "Custom 2"})
 		Me.CBGlitModType.Location = New System.Drawing.Point(27, 35)
 		Me.CBGlitModType.Name = "CBGlitModType"
@@ -12832,30 +13109,30 @@ Partial Class FrmSettings
 		Me.GroupBox62.Name = "GroupBox62"
 		Me.GroupBox62.Size = New System.Drawing.Size(277, 107)
 		Me.GroupBox62.TabIndex = 178
-		Me.GroupBox62.TabStop = false
+		Me.GroupBox62.TabStop = False
 		Me.GroupBox62.Text = "Language"
 		'
 		'RBGerman
 		'
-		Me.RBGerman.AutoSize = true
+		Me.RBGerman.AutoSize = True
 		Me.RBGerman.Location = New System.Drawing.Point(180, 20)
 		Me.RBGerman.Name = "RBGerman"
 		Me.RBGerman.Size = New System.Drawing.Size(65, 17)
 		Me.RBGerman.TabIndex = 1
 		Me.RBGerman.Text = "Deutsch"
-		Me.RBGerman.UseVisualStyleBackColor = true
+		Me.RBGerman.UseVisualStyleBackColor = True
 		'
 		'RBEnglish
 		'
-		Me.RBEnglish.AutoSize = true
-		Me.RBEnglish.Checked = true
+		Me.RBEnglish.AutoSize = True
+		Me.RBEnglish.Checked = True
 		Me.RBEnglish.Location = New System.Drawing.Point(36, 19)
 		Me.RBEnglish.Name = "RBEnglish"
 		Me.RBEnglish.Size = New System.Drawing.Size(59, 17)
 		Me.RBEnglish.TabIndex = 0
-		Me.RBEnglish.TabStop = true
+		Me.RBEnglish.TabStop = True
 		Me.RBEnglish.Text = "English"
-		Me.RBEnglish.UseVisualStyleBackColor = true
+		Me.RBEnglish.UseVisualStyleBackColor = True
 		'
 		'GroupBox33
 		'
@@ -12869,7 +13146,7 @@ Partial Class FrmSettings
 		Me.GroupBox33.Name = "GroupBox33"
 		Me.GroupBox33.Size = New System.Drawing.Size(277, 159)
 		Me.GroupBox33.TabIndex = 177
-		Me.GroupBox33.TabStop = false
+		Me.GroupBox33.TabStop = False
 		Me.GroupBox33.Text = "System States"
 		'
 		'BTNOfflineMode
@@ -12879,13 +13156,13 @@ Partial Class FrmSettings
 		Me.BTNOfflineMode.Size = New System.Drawing.Size(99, 23)
 		Me.BTNOfflineMode.TabIndex = 180
 		Me.BTNOfflineMode.Text = "Toggle"
-		Me.BTNOfflineMode.UseVisualStyleBackColor = true
+		Me.BTNOfflineMode.UseVisualStyleBackColor = True
 		'
 		'LBLOfflineMode
 		'
 		Me.LBLOfflineMode.BackColor = System.Drawing.Color.LightGray
 		Me.LBLOfflineMode.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D
-		Me.LBLOfflineMode.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLOfflineMode.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLOfflineMode.ForeColor = System.Drawing.Color.Red
 		Me.LBLOfflineMode.Location = New System.Drawing.Point(120, 70)
 		Me.LBLOfflineMode.Name = "LBLOfflineMode"
@@ -12898,7 +13175,7 @@ Partial Class FrmSettings
 		'
 		Me.Label140.BackColor = System.Drawing.Color.LightGray
 		Me.Label140.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D
-		Me.Label140.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label140.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label140.Location = New System.Drawing.Point(17, 70)
 		Me.Label140.Name = "Label140"
 		Me.Label140.Size = New System.Drawing.Size(98, 23)
@@ -12913,13 +13190,13 @@ Partial Class FrmSettings
 		Me.Button11.Size = New System.Drawing.Size(99, 23)
 		Me.Button11.TabIndex = 177
 		Me.Button11.Text = "Toggle"
-		Me.Button11.UseVisualStyleBackColor = true
+		Me.Button11.UseVisualStyleBackColor = True
 		'
 		'LBLChastityState
 		'
 		Me.LBLChastityState.BackColor = System.Drawing.Color.LightGray
 		Me.LBLChastityState.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D
-		Me.LBLChastityState.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLChastityState.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLChastityState.ForeColor = System.Drawing.Color.Red
 		Me.LBLChastityState.Location = New System.Drawing.Point(120, 33)
 		Me.LBLChastityState.Name = "LBLChastityState"
@@ -12932,7 +13209,7 @@ Partial Class FrmSettings
 		'
 		Me.Label120.BackColor = System.Drawing.Color.LightGray
 		Me.Label120.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D
-		Me.Label120.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label120.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label120.Location = New System.Drawing.Point(17, 33)
 		Me.Label120.Name = "Label120"
 		Me.Label120.Size = New System.Drawing.Size(98, 23)
@@ -12952,7 +13229,7 @@ Partial Class FrmSettings
 		Me.GroupBox27.Name = "GroupBox27"
 		Me.GroupBox27.Size = New System.Drawing.Size(279, 117)
 		Me.GroupBox27.TabIndex = 176
-		Me.GroupBox27.TabStop = false
+		Me.GroupBox27.TabStop = False
 		Me.GroupBox27.Text = "Session Images"
 		'
 		'Button6
@@ -12962,7 +13239,7 @@ Partial Class FrmSettings
 		Me.Button6.Size = New System.Drawing.Size(117, 23)
 		Me.Button6.TabIndex = 176
 		Me.Button6.Text = "Delete All Files"
-		Me.Button6.UseVisualStyleBackColor = true
+		Me.Button6.UseVisualStyleBackColor = True
 		'
 		'LBLSesSpace
 		'
@@ -12978,7 +13255,7 @@ Partial Class FrmSettings
 		Me.Button3.Size = New System.Drawing.Size(117, 23)
 		Me.Button3.TabIndex = 175
 		Me.Button3.Text = "Open Folder"
-		Me.Button3.UseVisualStyleBackColor = true
+		Me.Button3.UseVisualStyleBackColor = True
 		'
 		'LBLSesFiles
 		'
@@ -12989,7 +13266,7 @@ Partial Class FrmSettings
 		'
 		'Label125
 		'
-		Me.Label125.AutoSize = true
+		Me.Label125.AutoSize = True
 		Me.Label125.Location = New System.Drawing.Point(17, 53)
 		Me.Label125.Name = "Label125"
 		Me.Label125.Size = New System.Drawing.Size(120, 13)
@@ -12998,7 +13275,7 @@ Partial Class FrmSettings
 		'
 		'Label124
 		'
-		Me.Label124.AutoSize = true
+		Me.Label124.AutoSize = True
 		Me.Label124.Location = New System.Drawing.Point(17, 24)
 		Me.Label124.Name = "Label124"
 		Me.Label124.Size = New System.Drawing.Size(126, 13)
@@ -13022,18 +13299,18 @@ Partial Class FrmSettings
 		Me.GroupBox20.Name = "GroupBox20"
 		Me.GroupBox20.Size = New System.Drawing.Size(408, 230)
 		Me.GroupBox20.TabIndex = 174
-		Me.GroupBox20.TabStop = false
+		Me.GroupBox20.TabStop = False
 		Me.GroupBox20.Text = "Maintenance"
 		'
 		'Button1
 		'
-		Me.Button1.Enabled = false
+		Me.Button1.Enabled = False
 		Me.Button1.Location = New System.Drawing.Point(270, 19)
 		Me.Button1.Name = "Button1"
 		Me.Button1.Size = New System.Drawing.Size(121, 23)
 		Me.Button1.TabIndex = 176
 		Me.Button1.Text = "Reset Settings"
-		Me.Button1.UseVisualStyleBackColor = true
+		Me.Button1.UseVisualStyleBackColor = True
 		'
 		'BTNMaintenanceScripts
 		'
@@ -13042,7 +13319,7 @@ Partial Class FrmSettings
 		Me.BTNMaintenanceScripts.Size = New System.Drawing.Size(121, 23)
 		Me.BTNMaintenanceScripts.TabIndex = 175
 		Me.BTNMaintenanceScripts.Text = "Audit Scripts"
-		Me.BTNMaintenanceScripts.UseVisualStyleBackColor = true
+		Me.BTNMaintenanceScripts.UseVisualStyleBackColor = True
 		'
 		'BTNMaintenanceValidate
 		'
@@ -13051,7 +13328,7 @@ Partial Class FrmSettings
 		Me.BTNMaintenanceValidate.Size = New System.Drawing.Size(121, 23)
 		Me.BTNMaintenanceValidate.TabIndex = 8
 		Me.BTNMaintenanceValidate.Text = "Validate Local Files"
-		Me.BTNMaintenanceValidate.UseVisualStyleBackColor = true
+		Me.BTNMaintenanceValidate.UseVisualStyleBackColor = True
 		'
 		'BTNMaintenanceRefresh
 		'
@@ -13060,11 +13337,11 @@ Partial Class FrmSettings
 		Me.BTNMaintenanceRefresh.Size = New System.Drawing.Size(121, 23)
 		Me.BTNMaintenanceRefresh.TabIndex = 7
 		Me.BTNMaintenanceRefresh.Text = "Refresh URL Files"
-		Me.BTNMaintenanceRefresh.UseVisualStyleBackColor = true
+		Me.BTNMaintenanceRefresh.UseVisualStyleBackColor = True
 		'
 		'Label117
 		'
-		Me.Label117.AutoSize = true
+		Me.Label117.AutoSize = True
 		Me.Label117.Location = New System.Drawing.Point(15, 182)
 		Me.Label117.Name = "Label117"
 		Me.Label117.Size = New System.Drawing.Size(84, 13)
@@ -13073,7 +13350,7 @@ Partial Class FrmSettings
 		'
 		'Label116
 		'
-		Me.Label116.AutoSize = true
+		Me.Label116.AutoSize = True
 		Me.Label116.Location = New System.Drawing.Point(15, 140)
 		Me.Label116.Name = "Label116"
 		Me.Label116.Size = New System.Drawing.Size(85, 13)
@@ -13089,13 +13366,13 @@ Partial Class FrmSettings
 		'
 		'BTNMaintenanceCancel
 		'
-		Me.BTNMaintenanceCancel.Enabled = false
+		Me.BTNMaintenanceCancel.Enabled = False
 		Me.BTNMaintenanceCancel.Location = New System.Drawing.Point(270, 48)
 		Me.BTNMaintenanceCancel.Name = "BTNMaintenanceCancel"
 		Me.BTNMaintenanceCancel.Size = New System.Drawing.Size(121, 23)
 		Me.BTNMaintenanceCancel.TabIndex = 3
 		Me.BTNMaintenanceCancel.Text = "Cancel"
-		Me.BTNMaintenanceCancel.UseVisualStyleBackColor = true
+		Me.BTNMaintenanceCancel.UseVisualStyleBackColor = True
 		'
 		'PBMaintenance
 		'
@@ -13120,7 +13397,7 @@ Partial Class FrmSettings
 		Me.BTNMaintenanceRebuild.Size = New System.Drawing.Size(121, 23)
 		Me.BTNMaintenanceRebuild.TabIndex = 0
 		Me.BTNMaintenanceRebuild.Text = "Rebuild URL Files"
-		Me.BTNMaintenanceRebuild.UseVisualStyleBackColor = true
+		Me.BTNMaintenanceRebuild.UseVisualStyleBackColor = True
 		'
 		'WebToy
 		'
@@ -13140,12 +13417,12 @@ Partial Class FrmSettings
 		Me.GroupBox15.Name = "GroupBox15"
 		Me.GroupBox15.Size = New System.Drawing.Size(408, 159)
 		Me.GroupBox15.TabIndex = 173
-		Me.GroupBox15.TabStop = false
+		Me.GroupBox15.TabStop = False
 		Me.GroupBox15.Text = "Web-Controlled Sex Toy"
 		'
 		'Label115
 		'
-		Me.Label115.AutoSize = true
+		Me.Label115.AutoSize = True
 		Me.Label115.Location = New System.Drawing.Point(12, 58)
 		Me.Label115.Name = "Label115"
 		Me.Label115.Size = New System.Drawing.Size(54, 13)
@@ -13168,7 +13445,7 @@ Partial Class FrmSettings
 		'
 		'Label114
 		'
-		Me.Label114.AutoSize = true
+		Me.Label114.AutoSize = True
 		Me.Label114.Location = New System.Drawing.Point(12, 17)
 		Me.Label114.Name = "Label114"
 		Me.Label114.Size = New System.Drawing.Size(54, 13)
@@ -13178,18 +13455,18 @@ Partial Class FrmSettings
 		'PictureBox9
 		'
 		Me.PictureBox9.BackColor = System.Drawing.Color.LightGray
-		Me.PictureBox9.Image = CType(resources.GetObject("PictureBox9.Image"),System.Drawing.Image)
+		Me.PictureBox9.Image = CType(resources.GetObject("PictureBox9.Image"), System.Drawing.Image)
 		Me.PictureBox9.Location = New System.Drawing.Point(9, 6)
 		Me.PictureBox9.Name = "PictureBox9"
 		Me.PictureBox9.Size = New System.Drawing.Size(160, 19)
 		Me.PictureBox9.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage
 		Me.PictureBox9.TabIndex = 166
-		Me.PictureBox9.TabStop = false
+		Me.PictureBox9.TabStop = False
 		'
 		'Label148
 		'
 		Me.Label148.BackColor = System.Drawing.Color.Transparent
-		Me.Label148.Font = New System.Drawing.Font("Microsoft Sans Serif", 12!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label148.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label148.ForeColor = System.Drawing.Color.Black
 		Me.Label148.Location = New System.Drawing.Point(7, 6)
 		Me.Label148.Name = "Label148"
@@ -13274,7 +13551,7 @@ Partial Class FrmSettings
 		Me.BTNDebugHoldEdgeTimer.Size = New System.Drawing.Size(75, 23)
 		Me.BTNDebugHoldEdgeTimer.TabIndex = 14
 		Me.BTNDebugHoldEdgeTimer.Text = "Set to 5"
-		Me.BTNDebugHoldEdgeTimer.UseVisualStyleBackColor = true
+		Me.BTNDebugHoldEdgeTimer.UseVisualStyleBackColor = True
 		'
 		'GroupBox26
 		'
@@ -13293,7 +13570,7 @@ Partial Class FrmSettings
 		Me.GroupBox26.Name = "GroupBox26"
 		Me.GroupBox26.Size = New System.Drawing.Size(346, 178)
 		Me.GroupBox26.TabIndex = 0
-		Me.GroupBox26.TabStop = false
+		Me.GroupBox26.TabStop = False
 		Me.GroupBox26.Text = "Taunt Cycle"
 		'
 		'LBLCycleDebugCountdown
@@ -13313,7 +13590,7 @@ Partial Class FrmSettings
 		Me.Button19.Size = New System.Drawing.Size(146, 30)
 		Me.Button19.TabIndex = 9
 		Me.Button19.Text = "Countdown to 5 Seconds"
-		Me.Button19.UseVisualStyleBackColor = true
+		Me.Button19.UseVisualStyleBackColor = True
 		'
 		'BTNDebugTauntsClear
 		'
@@ -13322,7 +13599,7 @@ Partial Class FrmSettings
 		Me.BTNDebugTauntsClear.Size = New System.Drawing.Size(146, 30)
 		Me.BTNDebugTauntsClear.TabIndex = 8
 		Me.BTNDebugTauntsClear.Text = "Clear"
-		Me.BTNDebugTauntsClear.UseVisualStyleBackColor = true
+		Me.BTNDebugTauntsClear.UseVisualStyleBackColor = True
 		'
 		'TBDebugTaunts3
 		'
@@ -13347,55 +13624,55 @@ Partial Class FrmSettings
 		'
 		'RBDebugTaunts3
 		'
-		Me.RBDebugTaunts3.AutoSize = true
+		Me.RBDebugTaunts3.AutoSize = True
 		Me.RBDebugTaunts3.Location = New System.Drawing.Point(127, 41)
 		Me.RBDebugTaunts3.Name = "RBDebugTaunts3"
 		Me.RBDebugTaunts3.Size = New System.Drawing.Size(59, 17)
 		Me.RBDebugTaunts3.TabIndex = 4
 		Me.RBDebugTaunts3.Text = "3 Lines"
-		Me.RBDebugTaunts3.UseVisualStyleBackColor = true
+		Me.RBDebugTaunts3.UseVisualStyleBackColor = True
 		'
 		'RBDebugTaunts2
 		'
-		Me.RBDebugTaunts2.AutoSize = true
+		Me.RBDebugTaunts2.AutoSize = True
 		Me.RBDebugTaunts2.Location = New System.Drawing.Point(66, 41)
 		Me.RBDebugTaunts2.Name = "RBDebugTaunts2"
 		Me.RBDebugTaunts2.Size = New System.Drawing.Size(59, 17)
 		Me.RBDebugTaunts2.TabIndex = 3
 		Me.RBDebugTaunts2.Text = "2 Lines"
-		Me.RBDebugTaunts2.UseVisualStyleBackColor = true
+		Me.RBDebugTaunts2.UseVisualStyleBackColor = True
 		'
 		'RBDebugTaunts1
 		'
-		Me.RBDebugTaunts1.AutoSize = true
-		Me.RBDebugTaunts1.Checked = true
+		Me.RBDebugTaunts1.AutoSize = True
+		Me.RBDebugTaunts1.Checked = True
 		Me.RBDebugTaunts1.Location = New System.Drawing.Point(7, 41)
 		Me.RBDebugTaunts1.Name = "RBDebugTaunts1"
 		Me.RBDebugTaunts1.Size = New System.Drawing.Size(54, 17)
 		Me.RBDebugTaunts1.TabIndex = 2
-		Me.RBDebugTaunts1.TabStop = true
+		Me.RBDebugTaunts1.TabStop = True
 		Me.RBDebugTaunts1.Text = "1 Line"
-		Me.RBDebugTaunts1.UseVisualStyleBackColor = true
+		Me.RBDebugTaunts1.UseVisualStyleBackColor = True
 		'
 		'CBDebugTauntsEndless
 		'
-		Me.CBDebugTauntsEndless.AutoSize = true
+		Me.CBDebugTauntsEndless.AutoSize = True
 		Me.CBDebugTauntsEndless.Location = New System.Drawing.Point(7, 150)
 		Me.CBDebugTauntsEndless.Name = "CBDebugTauntsEndless"
 		Me.CBDebugTauntsEndless.Size = New System.Drawing.Size(92, 17)
 		Me.CBDebugTauntsEndless.TabIndex = 1
 		Me.CBDebugTauntsEndless.Text = "Endless Cycle"
-		Me.CBDebugTauntsEndless.UseVisualStyleBackColor = true
+		Me.CBDebugTauntsEndless.UseVisualStyleBackColor = True
 		'
 		'CBDebugTaunts
 		'
-		Me.CBDebugTaunts.AutoSize = true
+		Me.CBDebugTaunts.AutoSize = True
 		Me.CBDebugTaunts.Location = New System.Drawing.Point(7, 20)
 		Me.CBDebugTaunts.Name = "CBDebugTaunts"
 		Me.CBDebugTaunts.Size = New System.Drawing.Size(174, 17)
 		Me.CBDebugTaunts.TabIndex = 0
 		Me.CBDebugTaunts.Text = "Enable Taunt Cycle Debugging"
-		Me.CBDebugTaunts.UseVisualStyleBackColor = true
+		Me.CBDebugTaunts.UseVisualStyleBackColor = True
 		'
 		'BTNDebugStrokeTauntTimer
 		'
@@ -13404,7 +13681,7 @@ Partial Class FrmSettings
 		Me.BTNDebugStrokeTauntTimer.Size = New System.Drawing.Size(75, 23)
 		Me.BTNDebugStrokeTauntTimer.TabIndex = 8
 		Me.BTNDebugStrokeTauntTimer.Text = "Set to 5"
-		Me.BTNDebugStrokeTauntTimer.UseVisualStyleBackColor = true
+		Me.BTNDebugStrokeTauntTimer.UseVisualStyleBackColor = True
 		'
 		'LBLDebugHoldEdgeTime
 		'
@@ -13433,7 +13710,7 @@ Partial Class FrmSettings
 		Me.BTNDebugStrokeTime.Size = New System.Drawing.Size(75, 23)
 		Me.BTNDebugStrokeTime.TabIndex = 2
 		Me.BTNDebugStrokeTime.Text = "Set to 5"
-		Me.BTNDebugStrokeTime.UseVisualStyleBackColor = true
+		Me.BTNDebugStrokeTime.UseVisualStyleBackColor = True
 		'
 		'BTNDebugEdgeTauntTimer
 		'
@@ -13442,7 +13719,7 @@ Partial Class FrmSettings
 		Me.BTNDebugEdgeTauntTimer.Size = New System.Drawing.Size(75, 23)
 		Me.BTNDebugEdgeTauntTimer.TabIndex = 11
 		Me.BTNDebugEdgeTauntTimer.Text = "Set to 5"
-		Me.BTNDebugEdgeTauntTimer.UseVisualStyleBackColor = true
+		Me.BTNDebugEdgeTauntTimer.UseVisualStyleBackColor = True
 		'
 		'LBLDebugTeaseTime
 		'
@@ -13484,7 +13761,7 @@ Partial Class FrmSettings
 		Me.BTNDebugTeaseTimer.Size = New System.Drawing.Size(75, 23)
 		Me.BTNDebugTeaseTimer.TabIndex = 5
 		Me.BTNDebugTeaseTimer.Text = "Set to 5"
-		Me.BTNDebugTeaseTimer.UseVisualStyleBackColor = true
+		Me.BTNDebugTeaseTimer.UseVisualStyleBackColor = True
 		'
 		'Label142
 		'
@@ -13575,27 +13852,27 @@ Partial Class FrmSettings
 		'
 		'Label130
 		'
-		Me.Label130.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label130.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label130.Location = New System.Drawing.Point(361, 314)
 		Me.Label130.Name = "Label130"
 		Me.Label130.Size = New System.Drawing.Size(254, 54)
 		Me.Label130.TabIndex = 176
-		Me.Label130.Text = "q55x8x"&Global.Microsoft.VisualBasic.ChrW(13)&Global.Microsoft.VisualBasic.ChrW(10)&"Stefaf"&Global.Microsoft.VisualBasic.ChrW(13)&Global.Microsoft.VisualBasic.ChrW(10)&"OxiKlein"&Global.Microsoft.VisualBasic.ChrW(13)&Global.Microsoft.VisualBasic.ChrW(10)
+		Me.Label130.Text = "q55x8x" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "Stefaf" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "OxiKlein" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10)
 		Me.Label130.TextAlign = System.Drawing.ContentAlignment.TopCenter
 		'
 		'Label123
 		'
-		Me.Label123.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label123.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label123.Location = New System.Drawing.Point(81, 314)
 		Me.Label123.Name = "Label123"
 		Me.Label123.Size = New System.Drawing.Size(254, 54)
 		Me.Label123.TabIndex = 175
-		Me.Label123.Text = "pepsifreak"&Global.Microsoft.VisualBasic.ChrW(13)&Global.Microsoft.VisualBasic.ChrW(10)&"Daragorn"&Global.Microsoft.VisualBasic.ChrW(13)&Global.Microsoft.VisualBasic.ChrW(10)&"Ambossli"
+		Me.Label123.Text = "pepsifreak" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "Daragorn" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "Ambossli"
 		Me.Label123.TextAlign = System.Drawing.ContentAlignment.TopCenter
 		'
 		'Label69
 		'
-		Me.Label69.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label69.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label69.Location = New System.Drawing.Point(35, 295)
 		Me.Label69.Name = "Label69"
 		Me.Label69.Size = New System.Drawing.Size(638, 22)
@@ -13605,17 +13882,17 @@ Partial Class FrmSettings
 		'
 		'Label113
 		'
-		Me.Label113.AutoSize = true
+		Me.Label113.AutoSize = True
 		Me.Label113.Location = New System.Drawing.Point(4, 417)
 		Me.Label113.Name = "Label113"
 		Me.Label113.Size = New System.Drawing.Size(452, 13)
 		Me.Label113.TabIndex = 173
-		Me.Label113.Text = "All content contained in or viewed through this program are property of their res"& _ 
-    "pective owners."
+		Me.Label113.Text = "All content contained in or viewed through this program are property of their res" &
+	"pective owners."
 		'
 		'Label40
 		'
-		Me.Label40.Font = New System.Drawing.Font("Microsoft Sans Serif", 12!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label40.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label40.Location = New System.Drawing.Point(35, 273)
 		Me.Label40.Name = "Label40"
 		Me.Label40.Size = New System.Drawing.Size(638, 24)
@@ -13625,19 +13902,19 @@ Partial Class FrmSettings
 		'
 		'Label35
 		'
-		Me.Label35.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label35.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label35.Location = New System.Drawing.Point(32, 107)
 		Me.Label35.Name = "Label35"
 		Me.Label35.Size = New System.Drawing.Size(641, 77)
 		Me.Label35.TabIndex = 170
-		Me.Label35.Text = "This program is freeware. It may be freely distributed."&Global.Microsoft.VisualBasic.ChrW(13)&Global.Microsoft.VisualBasic.ChrW(10)&Global.Microsoft.VisualBasic.ChrW(13)&Global.Microsoft.VisualBasic.ChrW(10)&"Do not package or dist"& _ 
-    "ribute this program with any scripts or additional content."&Global.Microsoft.VisualBasic.ChrW(13)&Global.Microsoft.VisualBasic.ChrW(10)&"Please distribute a"& _ 
-    "dditional files separately."
+		Me.Label35.Text = "This program is freeware. It may be freely distributed." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "Do not package or dist" &
+	"ribute this program with any scripts or additional content." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "Please distribute a" &
+	"dditional files separately."
 		Me.Label35.TextAlign = System.Drawing.ContentAlignment.TopCenter
 		'
 		'Label33
 		'
-		Me.Label33.Font = New System.Drawing.Font("Microsoft Sans Serif", 10!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label33.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label33.Location = New System.Drawing.Point(32, 191)
 		Me.Label33.Name = "Label33"
 		Me.Label33.Size = New System.Drawing.Size(641, 77)
@@ -13647,7 +13924,7 @@ Partial Class FrmSettings
 		'
 		'Label17
 		'
-		Me.Label17.AutoSize = true
+		Me.Label17.AutoSize = True
 		Me.Label17.Location = New System.Drawing.Point(522, 78)
 		Me.Label17.Name = "Label17"
 		Me.Label17.Size = New System.Drawing.Size(93, 13)
@@ -13656,7 +13933,7 @@ Partial Class FrmSettings
 		'
 		'Label3
 		'
-		Me.Label3.AutoSize = true
+		Me.Label3.AutoSize = True
 		Me.Label3.Location = New System.Drawing.Point(489, 417)
 		Me.Label3.Name = "Label3"
 		Me.Label3.Size = New System.Drawing.Size(215, 13)
@@ -13666,24 +13943,24 @@ Partial Class FrmSettings
 		'PictureBox3
 		'
 		Me.PictureBox3.BackColor = System.Drawing.Color.LightGray
-		Me.PictureBox3.Image = CType(resources.GetObject("PictureBox3.Image"),System.Drawing.Image)
+		Me.PictureBox3.Image = CType(resources.GetObject("PictureBox3.Image"), System.Drawing.Image)
 		Me.PictureBox3.Location = New System.Drawing.Point(84, 17)
 		Me.PictureBox3.Name = "PictureBox3"
 		Me.PictureBox3.Size = New System.Drawing.Size(531, 58)
 		Me.PictureBox3.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
 		Me.PictureBox3.TabIndex = 166
-		Me.PictureBox3.TabStop = false
+		Me.PictureBox3.TabStop = False
 		'
 		'Label41
 		'
-		Me.Label41.Font = New System.Drawing.Font("Microsoft Sans Serif", 9!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label41.Font = New System.Drawing.Font("Microsoft Sans Serif", 9.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label41.Location = New System.Drawing.Point(35, 372)
 		Me.Label41.Name = "Label41"
 		Me.Label41.Size = New System.Drawing.Size(638, 39)
 		Me.Label41.TabIndex = 172
-		Me.Label41.Text = "Thank you to everyone who has provided help and feedback."&Global.Microsoft.VisualBasic.ChrW(13)&Global.Microsoft.VisualBasic.ChrW(10)&"Thank you to the commu"& _ 
-    "nity who's been supportive of my work over the years. Tease AI exists because of"& _ 
-    " you."&Global.Microsoft.VisualBasic.ChrW(13)&Global.Microsoft.VisualBasic.ChrW(10)
+		Me.Label41.Text = "Thank you to everyone who has provided help and feedback." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "Thank you to the commu" &
+	"nity who's been supportive of my work over the years. Tease AI exists because of" &
+	" you." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10)
 		Me.Label41.TextAlign = System.Drawing.ContentAlignment.TopCenter
 		'
 		'GroupBox47
@@ -13696,7 +13973,7 @@ Partial Class FrmSettings
 		Me.GroupBox47.Name = "GroupBox47"
 		Me.GroupBox47.Size = New System.Drawing.Size(310, 190)
 		Me.GroupBox47.TabIndex = 63
-		Me.GroupBox47.TabStop = false
+		Me.GroupBox47.TabStop = False
 		Me.GroupBox47.Text = "Boobs and Butts Paths"
 		'
 		'GroupBox41
@@ -13706,20 +13983,20 @@ Partial Class FrmSettings
 		Me.GroupBox41.Name = "GroupBox41"
 		Me.GroupBox41.Size = New System.Drawing.Size(298, 74)
 		Me.GroupBox41.TabIndex = 153
-		Me.GroupBox41.TabStop = false
+		Me.GroupBox41.TabStop = False
 		Me.GroupBox41.Text = "Butts"
 		'
 		'Button34
 		'
 		Me.Button34.BackColor = System.Drawing.Color.LightGray
-		Me.Button34.Font = New System.Drawing.Font("Wingdings", 10!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2,Byte))
+		Me.Button34.Font = New System.Drawing.Font("Wingdings", 10.0!, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, CType(2, Byte))
 		Me.Button34.ForeColor = System.Drawing.Color.Black
 		Me.Button34.Location = New System.Drawing.Point(85, 25)
 		Me.Button34.Name = "Button34"
 		Me.Button34.Size = New System.Drawing.Size(34, 28)
 		Me.Button34.TabIndex = 131
 		Me.Button34.Text = "1"
-		Me.Button34.UseVisualStyleBackColor = false
+		Me.Button34.UseVisualStyleBackColor = False
 		'
 		'GroupBox40
 		'
@@ -13727,7 +14004,7 @@ Partial Class FrmSettings
 		Me.GroupBox40.Name = "GroupBox40"
 		Me.GroupBox40.Size = New System.Drawing.Size(298, 74)
 		Me.GroupBox40.TabIndex = 152
-		Me.GroupBox40.TabStop = false
+		Me.GroupBox40.TabStop = False
 		Me.GroupBox40.Text = "Boobs"
 		'
 		'GroupBox44
@@ -13739,13 +14016,13 @@ Partial Class FrmSettings
 		Me.GroupBox44.Name = "GroupBox44"
 		Me.GroupBox44.Size = New System.Drawing.Size(310, 92)
 		Me.GroupBox44.TabIndex = 65
-		Me.GroupBox44.TabStop = false
+		Me.GroupBox44.TabStop = False
 		Me.GroupBox44.Text = "Description"
 		'
 		'Label100
 		'
 		Me.Label100.BackColor = System.Drawing.Color.Transparent
-		Me.Label100.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label100.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label100.ForeColor = System.Drawing.Color.Black
 		Me.Label100.Location = New System.Drawing.Point(11, 16)
 		Me.Label100.Name = "Label100"
@@ -13771,12 +14048,12 @@ Partial Class FrmSettings
 		Me.GroupBox6.Name = "GroupBox6"
 		Me.GroupBox6.Size = New System.Drawing.Size(283, 102)
 		Me.GroupBox6.TabIndex = 156
-		Me.GroupBox6.TabStop = false
+		Me.GroupBox6.TabStop = False
 		Me.GroupBox6.Text = "Performance"
 		'
 		'Label4
 		'
-		Me.Label4.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label4.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label4.Location = New System.Drawing.Point(26, 16)
 		Me.Label4.Name = "Label4"
 		Me.Label4.Size = New System.Drawing.Size(77, 17)
@@ -13786,7 +14063,7 @@ Partial Class FrmSettings
 		'
 		'LBLAvgEdgeStroking
 		'
-		Me.LBLAvgEdgeStroking.AutoSize = true
+		Me.LBLAvgEdgeStroking.AutoSize = True
 		Me.LBLAvgEdgeStroking.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
 		Me.LBLAvgEdgeStroking.Location = New System.Drawing.Point(113, 68)
 		Me.LBLAvgEdgeStroking.Name = "LBLAvgEdgeStroking"
@@ -13807,7 +14084,7 @@ Partial Class FrmSettings
 		'Label94
 		'
 		Me.Label94.BackColor = System.Drawing.Color.Transparent
-		Me.Label94.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label94.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label94.ForeColor = System.Drawing.Color.Black
 		Me.Label94.Location = New System.Drawing.Point(189, 16)
 		Me.Label94.Name = "Label94"
@@ -13828,7 +14105,7 @@ Partial Class FrmSettings
 		'Label65
 		'
 		Me.Label65.BackColor = System.Drawing.Color.Transparent
-		Me.Label65.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label65.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label65.ForeColor = System.Drawing.Color.Black
 		Me.Label65.Location = New System.Drawing.Point(103, 16)
 		Me.Label65.Name = "Label65"
@@ -13839,7 +14116,7 @@ Partial Class FrmSettings
 		'
 		'LBLAvgEdgeNoTouch
 		'
-		Me.LBLAvgEdgeNoTouch.AutoSize = true
+		Me.LBLAvgEdgeNoTouch.AutoSize = True
 		Me.LBLAvgEdgeNoTouch.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
 		Me.LBLAvgEdgeNoTouch.Location = New System.Drawing.Point(215, 68)
 		Me.LBLAvgEdgeNoTouch.Name = "LBLAvgEdgeNoTouch"
@@ -13860,7 +14137,7 @@ Partial Class FrmSettings
 		'Label14
 		'
 		Me.Label14.BackColor = System.Drawing.Color.Transparent
-		Me.Label14.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label14.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label14.ForeColor = System.Drawing.Color.Black
 		Me.Label14.Location = New System.Drawing.Point(25, 48)
 		Me.Label14.Name = "Label14"
@@ -13871,7 +14148,7 @@ Partial Class FrmSettings
 		'
 		'Label13
 		'
-		Me.Label13.AutoSize = true
+		Me.Label13.AutoSize = True
 		Me.Label13.Location = New System.Drawing.Point(177, 68)
 		Me.Label13.Name = "Label13"
 		Me.Label13.Size = New System.Drawing.Size(32, 13)
@@ -13881,7 +14158,7 @@ Partial Class FrmSettings
 		'
 		'Label1
 		'
-		Me.Label1.AutoSize = true
+		Me.Label1.AutoSize = True
 		Me.Label1.Location = New System.Drawing.Point(28, 68)
 		Me.Label1.Name = "Label1"
 		Me.Label1.Size = New System.Drawing.Size(79, 13)
@@ -13901,14 +14178,14 @@ Partial Class FrmSettings
 		Me.GroupBox21.Name = "GroupBox21"
 		Me.GroupBox21.Size = New System.Drawing.Size(316, 136)
 		Me.GroupBox21.TabIndex = 66
-		Me.GroupBox21.TabStop = false
+		Me.GroupBox21.TabStop = False
 		Me.GroupBox21.Text = "Description"
 		'
 		'Label153
 		'
 		Me.Label153.BackColor = System.Drawing.Color.Transparent
 		Me.Label153.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.Label153.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label153.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label153.ForeColor = System.Drawing.Color.Black
 		Me.Label153.Location = New System.Drawing.Point(78, 94)
 		Me.Label153.Name = "Label153"
@@ -13920,21 +14197,21 @@ Partial Class FrmSettings
 		'LBLRangeSettingsDescription
 		'
 		Me.LBLRangeSettingsDescription.BackColor = System.Drawing.Color.Transparent
-		Me.LBLRangeSettingsDescription.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLRangeSettingsDescription.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLRangeSettingsDescription.ForeColor = System.Drawing.Color.Black
 		Me.LBLRangeSettingsDescription.Location = New System.Drawing.Point(6, 16)
 		Me.LBLRangeSettingsDescription.Name = "LBLRangeSettingsDescription"
 		Me.LBLRangeSettingsDescription.Size = New System.Drawing.Size(680, 117)
 		Me.LBLRangeSettingsDescription.TabIndex = 62
-		Me.LBLRangeSettingsDescription.Text = "Hover over any setting in the menu for a more detailed description of its functio"& _ 
-    "n."
+		Me.LBLRangeSettingsDescription.Text = "Hover over any setting in the menu for a more detailed description of its functio" &
+	"n."
 		Me.LBLRangeSettingsDescription.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
 		'
 		'Label156
 		'
 		Me.Label156.BackColor = System.Drawing.Color.Transparent
 		Me.Label156.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-		Me.Label156.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.Label156.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.Label156.ForeColor = System.Drawing.Color.Black
 		Me.Label156.Location = New System.Drawing.Point(133, 23)
 		Me.Label156.Name = "Label156"
@@ -13952,26 +14229,26 @@ Partial Class FrmSettings
 		Me.GroupBox12.Name = "GroupBox12"
 		Me.GroupBox12.Size = New System.Drawing.Size(171, 124)
 		Me.GroupBox12.TabIndex = 65
-		Me.GroupBox12.TabStop = false
+		Me.GroupBox12.TabStop = False
 		Me.GroupBox12.Text = "Description"
 		'
 		'LBLSubSettingsDescription
 		'
 		Me.LBLSubSettingsDescription.BackColor = System.Drawing.Color.Transparent
-		Me.LBLSubSettingsDescription.Font = New System.Drawing.Font("Microsoft Sans Serif", 8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+		Me.LBLSubSettingsDescription.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
 		Me.LBLSubSettingsDescription.ForeColor = System.Drawing.Color.Black
 		Me.LBLSubSettingsDescription.Location = New System.Drawing.Point(10, 19)
 		Me.LBLSubSettingsDescription.Name = "LBLSubSettingsDescription"
 		Me.LBLSubSettingsDescription.Size = New System.Drawing.Size(150, 89)
 		Me.LBLSubSettingsDescription.TabIndex = 62
-		Me.LBLSubSettingsDescription.Text = "Hover over any setting in the menu for a more detailed description of its functio"& _ 
-    "n."
+		Me.LBLSubSettingsDescription.Text = "Hover over any setting in the menu for a more detailed description of its functio" &
+	"n."
 		'
 		'OpenFileDialog1
 		'
 		Me.OpenFileDialog1.FileName = "OpenFileDialog1"
-		Me.OpenFileDialog1.Filter = "JPEG Files (*.jpg)|*.jpg|PNG Files (*.png)|*.png|BMP Files (*.bmp)|*.bmp|All file"& _ 
-    "s (*.*)|*.*"
+		Me.OpenFileDialog1.Filter = "JPEG Files (*.jpg)|*.jpg|PNG Files (*.png)|*.png|BMP Files (*.bmp)|*.bmp|All file" &
+	"s (*.*)|*.*"
 		Me.OpenFileDialog1.Title = "Select an image file"
 		'
 		'GetColor
@@ -14017,12 +14294,12 @@ Partial Class FrmSettings
 		Me.GroupBox65.Name = "GroupBox65"
 		Me.GroupBox65.Size = New System.Drawing.Size(259, 117)
 		Me.GroupBox65.TabIndex = 157
-		Me.GroupBox65.TabStop = false
+		Me.GroupBox65.TabStop = False
 		Me.GroupBox65.Text = "Text to Speech"
 		'
 		'Label136
 		'
-		Me.Label136.AutoSize = true
+		Me.Label136.AutoSize = True
 		Me.Label136.Location = New System.Drawing.Point(14, 52)
 		Me.Label136.Name = "Label136"
 		Me.Label136.Size = New System.Drawing.Size(45, 13)
@@ -14031,7 +14308,7 @@ Partial Class FrmSettings
 		'
 		'Label134
 		'
-		Me.Label134.AutoSize = true
+		Me.Label134.AutoSize = True
 		Me.Label134.Location = New System.Drawing.Point(141, 52)
 		Me.Label134.Name = "Label134"
 		Me.Label134.Size = New System.Drawing.Size(33, 13)
@@ -14060,24 +14337,24 @@ Partial Class FrmSettings
 		Me.ComboBox1.BackColor = System.Drawing.SystemColors.Window
 		Me.ComboBox1.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
 		Me.ComboBox1.ForeColor = System.Drawing.SystemColors.WindowText
-		Me.ComboBox1.FormattingEnabled = true
+		Me.ComboBox1.FormattingEnabled = True
 		Me.ComboBox1.Location = New System.Drawing.Point(71, 16)
 		Me.ComboBox1.Name = "ComboBox1"
 		Me.ComboBox1.Size = New System.Drawing.Size(178, 21)
 		Me.ComboBox1.TabIndex = 29
-		Me.ComboBox1.TabStop = false
+		Me.ComboBox1.TabStop = False
 		'
 		'CheckBox1
 		'
-		Me.CheckBox1.AutoSize = true
+		Me.CheckBox1.AutoSize = True
 		Me.CheckBox1.ForeColor = System.Drawing.Color.Black
 		Me.CheckBox1.Location = New System.Drawing.Point(10, 18)
 		Me.CheckBox1.Name = "CheckBox1"
 		Me.CheckBox1.Size = New System.Drawing.Size(59, 17)
 		Me.CheckBox1.TabIndex = 28
-		Me.CheckBox1.TabStop = false
+		Me.CheckBox1.TabStop = False
 		Me.CheckBox1.Text = "Enable"
-		Me.CheckBox1.UseVisualStyleBackColor = true
+		Me.CheckBox1.UseVisualStyleBackColor = True
 		'
 		'Label135
 		'
@@ -14097,197 +14374,32 @@ Partial Class FrmSettings
 		Me.TrackBar2.TabIndex = 30
 		Me.TrackBar2.Value = 50
 		'
-		'BWURLFiles
+		'TxbImgUrlHardcore
 		'
-		Me.BWURLFiles.DislikeListPath = "Images\System\DislikedImageURLs.txt"
-		Me.BWURLFiles.ImageURLFileDir = "Images\System\URL Files\"
-		Me.BWURLFiles.LikeListPath = "Images\System\LikedImageURLs.txt"
-		Me.BWURLFiles.WorkerReportsProgress = true
-		Me.BWURLFiles.WorkerSupportsCancellation = true
+		Me.TxbImgUrlHardcore.BackColor = System.Drawing.Color.LightGray
+		Me.TxbImgUrlHardcore.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+		Me.TxbImgUrlHardcore.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.TxbImgUrlHardcore.Location = New System.Drawing.Point(116, 6)
+		Me.TxbImgUrlHardcore.Name = "TxbImgUrlHardcore"
+		Me.TxbImgUrlHardcore.ReadOnly = True
+		Me.TxbImgUrlHardcore.Size = New System.Drawing.Size(189, 20)
+		Me.TxbImgUrlHardcore.TabIndex = 145
 		'
-		'GroupBox69
+		'TextBox2
 		'
-		Me.GroupBox69.Controls.Add(Me.TypesSpeedVal)
-		Me.GroupBox69.Controls.Add(Me.TypeSpeedLabel)
-		Me.GroupBox69.Controls.Add(Me.TimedWriting)
-		Me.GroupBox69.Controls.Add(Me.TypeSpeedSlider)
-		Me.GroupBox69.Location = New System.Drawing.Point(236, 344)
-		Me.GroupBox69.Name = "GroupBox69"
-		Me.GroupBox69.Size = New System.Drawing.Size(166, 83)
-		Me.GroupBox69.TabIndex = 173
-		Me.GroupBox69.TabStop = false
-		Me.GroupBox69.Text = "WritingTasks"
-		'
-		'TypesSpeedVal
-		'
-		Me.TypesSpeedVal.AutoSize = true
-		Me.TypesSpeedVal.Location = New System.Drawing.Point(132, 64)
-		Me.TypesSpeedVal.Name = "TypesSpeedVal"
-		Me.TypesSpeedVal.Size = New System.Drawing.Size(19, 13)
-		Me.TypesSpeedVal.TabIndex = 0
-		Me.TypesSpeedVal.Text = "10"
-		Me.TypesSpeedVal.TextAlign = System.Drawing.ContentAlignment.TopRight
-		'
-		'TimedWriting
-		'
-		Me.TimedWriting.AutoSize = true
-		Me.TimedWriting.Checked = Global.Tease_AI.My.MySettings.Default.TimedWriting
-		Me.TimedWriting.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "TimedWriting", True, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
-		Me.TimedWriting.Location = New System.Drawing.Point(9, 19)
-		Me.TimedWriting.Name = "TimedWriting"
-		Me.TimedWriting.Size = New System.Drawing.Size(123, 17)
-		Me.TimedWriting.TabIndex = 1
-		Me.TimedWriting.Text = "Timed Writing Tasks"
-		Me.TimedWriting.UseVisualStyleBackColor = true
-		'
-		'TypeSpeedLabel
-		'
-		Me.TypeSpeedLabel.AutoSize = true
-		Me.TypeSpeedLabel.Location = New System.Drawing.Point(6, 64)
-		Me.TypeSpeedLabel.Name = "TypeSpeedLabel"
-		Me.TypeSpeedLabel.Size = New System.Drawing.Size(76, 13)
-		Me.TypeSpeedLabel.TabIndex = 2
-		Me.TypeSpeedLabel.Text = "Typing Speed:"
-		'
-		'TypeSpeedSlider
-		'
-		Me.TypeSpeedSlider.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TypeSpeed", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
-		Me.TypeSpeedSlider.Location = New System.Drawing.Point(9, 35)
-		Me.TypeSpeedSlider.Maximum = 100
-		Me.TypeSpeedSlider.Minimum = 33
-		Me.TypeSpeedSlider.Name = "TypeSpeedSlider"
-		Me.TypeSpeedSlider.Size = New System.Drawing.Size(148, 45)
-		Me.TypeSpeedSlider.TabIndex = 3
-		Me.TypeSpeedSlider.Value = Global.Tease_AI.My.MySettings.Default.TypeSpeed
-		'
-		'CBMuteMedia
-		'
-		Me.CBMuteMedia.AutoSize = true
-		Me.CBMuteMedia.Checked = Global.Tease_AI.My.MySettings.Default.MuteMedia
-		Me.CBMuteMedia.DataBindings.Add(New System.Windows.Forms.Binding("Checked", Global.Tease_AI.My.MySettings.Default, "MuteMedia", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
-		Me.CBMuteMedia.ForeColor = System.Drawing.Color.Black
-		Me.CBMuteMedia.Location = New System.Drawing.Point(7, 21)
-		Me.CBMuteMedia.Name = "CBMuteMedia"
-		Me.CBMuteMedia.Size = New System.Drawing.Size(241, 17)
-		Me.CBMuteMedia.TabIndex = 6
-		Me.CBMuteMedia.TabStop = false
-		Me.CBMuteMedia.Text = "Mute Video and Audio Played in Media Player"
-		Me.CBMuteMedia.UseVisualStyleBackColor = true
-		'
-		'NBTaskCBTTimeMax
-		'
-		Me.NBTaskCBTTimeMax.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskCBTTimeMax", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
-		Me.NBTaskCBTTimeMax.Location = New System.Drawing.Point(183, 110)
-		Me.NBTaskCBTTimeMax.Maximum = New Decimal(New Integer() {600, 0, 0, 0})
-		Me.NBTaskCBTTimeMax.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
-		Me.NBTaskCBTTimeMax.Name = "NBTaskCBTTimeMax"
-		Me.NBTaskCBTTimeMax.Size = New System.Drawing.Size(44, 20)
-		Me.NBTaskCBTTimeMax.TabIndex = 203
-		Me.NBTaskCBTTimeMax.Value = Global.Tease_AI.My.MySettings.Default.TaskCBTTimeMax
-		'
-		'NBTaskCBTTimeMin
-		'
-		Me.NBTaskCBTTimeMin.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskCBTTimeMin", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
-		Me.NBTaskCBTTimeMin.Location = New System.Drawing.Point(117, 111)
-		Me.NBTaskCBTTimeMin.Maximum = New Decimal(New Integer() {9999, 0, 0, 0})
-		Me.NBTaskCBTTimeMin.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
-		Me.NBTaskCBTTimeMin.Name = "NBTaskCBTTimeMin"
-		Me.NBTaskCBTTimeMin.Size = New System.Drawing.Size(44, 20)
-		Me.NBTaskCBTTimeMin.TabIndex = 202
-		Me.NBTaskCBTTimeMin.Value = Global.Tease_AI.My.MySettings.Default.TaskCBTTimeMin
-		'
-		'NBTaskEdgeHoldTimeMax
-		'
-		Me.NBTaskEdgeHoldTimeMax.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskEdgeHoldTimeMax", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
-		Me.NBTaskEdgeHoldTimeMax.Location = New System.Drawing.Point(183, 87)
-		Me.NBTaskEdgeHoldTimeMax.Maximum = New Decimal(New Integer() {600, 0, 0, 0})
-		Me.NBTaskEdgeHoldTimeMax.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
-		Me.NBTaskEdgeHoldTimeMax.Name = "NBTaskEdgeHoldTimeMax"
-		Me.NBTaskEdgeHoldTimeMax.Size = New System.Drawing.Size(44, 20)
-		Me.NBTaskEdgeHoldTimeMax.TabIndex = 198
-		Me.NBTaskEdgeHoldTimeMax.Value = Global.Tease_AI.My.MySettings.Default.TaskEdgeHoldTimeMax
-		'
-		'NBTaskEdgeHoldTimeMin
-		'
-		Me.NBTaskEdgeHoldTimeMin.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskEdgeHoldTimeMin", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
-		Me.NBTaskEdgeHoldTimeMin.Location = New System.Drawing.Point(117, 88)
-		Me.NBTaskEdgeHoldTimeMin.Maximum = New Decimal(New Integer() {9999, 0, 0, 0})
-		Me.NBTaskEdgeHoldTimeMin.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
-		Me.NBTaskEdgeHoldTimeMin.Name = "NBTaskEdgeHoldTimeMin"
-		Me.NBTaskEdgeHoldTimeMin.Size = New System.Drawing.Size(44, 20)
-		Me.NBTaskEdgeHoldTimeMin.TabIndex = 197
-		Me.NBTaskEdgeHoldTimeMin.Value = Global.Tease_AI.My.MySettings.Default.TaskEdgeHoldTimeMin
-		'
-		'NBTaskEdgesMax
-		'
-		Me.NBTaskEdgesMax.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskEdgesMax", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
-		Me.NBTaskEdgesMax.Location = New System.Drawing.Point(183, 64)
-		Me.NBTaskEdgesMax.Maximum = New Decimal(New Integer() {1000, 0, 0, 0})
-		Me.NBTaskEdgesMax.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
-		Me.NBTaskEdgesMax.Name = "NBTaskEdgesMax"
-		Me.NBTaskEdgesMax.Size = New System.Drawing.Size(44, 20)
-		Me.NBTaskEdgesMax.TabIndex = 194
-		Me.NBTaskEdgesMax.Value = Global.Tease_AI.My.MySettings.Default.TaskEdgesMax
-		'
-		'NBTaskEdgesMin
-		'
-		Me.NBTaskEdgesMin.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskEdgesMin", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
-		Me.NBTaskEdgesMin.Location = New System.Drawing.Point(117, 65)
-		Me.NBTaskEdgesMin.Maximum = New Decimal(New Integer() {9999, 0, 0, 0})
-		Me.NBTaskEdgesMin.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
-		Me.NBTaskEdgesMin.Name = "NBTaskEdgesMin"
-		Me.NBTaskEdgesMin.Size = New System.Drawing.Size(44, 20)
-		Me.NBTaskEdgesMin.TabIndex = 193
-		Me.NBTaskEdgesMin.Value = Global.Tease_AI.My.MySettings.Default.TaskEdgesMin
-		'
-		'NBTaskStrokingTimeMax
-		'
-		Me.NBTaskStrokingTimeMax.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskStrokingTimeMax", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
-		Me.NBTaskStrokingTimeMax.Location = New System.Drawing.Point(183, 41)
-		Me.NBTaskStrokingTimeMax.Maximum = New Decimal(New Integer() {9999, 0, 0, 0})
-		Me.NBTaskStrokingTimeMax.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
-		Me.NBTaskStrokingTimeMax.Name = "NBTaskStrokingTimeMax"
-		Me.NBTaskStrokingTimeMax.Size = New System.Drawing.Size(44, 20)
-		Me.NBTaskStrokingTimeMax.TabIndex = 189
-		Me.NBTaskStrokingTimeMax.Value = Global.Tease_AI.My.MySettings.Default.TaskStrokingTimeMax
-		'
-		'NBTaskStrokingTimeMin
-		'
-		Me.NBTaskStrokingTimeMin.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskStrokingTimeMin", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
-		Me.NBTaskStrokingTimeMin.Location = New System.Drawing.Point(117, 42)
-		Me.NBTaskStrokingTimeMin.Maximum = New Decimal(New Integer() {9999, 0, 0, 0})
-		Me.NBTaskStrokingTimeMin.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
-		Me.NBTaskStrokingTimeMin.Name = "NBTaskStrokingTimeMin"
-		Me.NBTaskStrokingTimeMin.Size = New System.Drawing.Size(44, 20)
-		Me.NBTaskStrokingTimeMin.TabIndex = 188
-		Me.NBTaskStrokingTimeMin.Value = Global.Tease_AI.My.MySettings.Default.TaskStrokingTimeMin
-		'
-		'NBTaskStrokesMax
-		'
-		Me.NBTaskStrokesMax.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskStrokesMax", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
-		Me.NBTaskStrokesMax.Location = New System.Drawing.Point(183, 18)
-		Me.NBTaskStrokesMax.Maximum = New Decimal(New Integer() {9999, 0, 0, 0})
-		Me.NBTaskStrokesMax.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
-		Me.NBTaskStrokesMax.Name = "NBTaskStrokesMax"
-		Me.NBTaskStrokesMax.Size = New System.Drawing.Size(44, 20)
-		Me.NBTaskStrokesMax.TabIndex = 184
-		Me.NBTaskStrokesMax.Value = Global.Tease_AI.My.MySettings.Default.TaskStrokesMax
-		'
-		'NBTaskStrokesMin
-		'
-		Me.NBTaskStrokesMin.DataBindings.Add(New System.Windows.Forms.Binding("Value", Global.Tease_AI.My.MySettings.Default, "TaskStrokesMin", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged))
-		Me.NBTaskStrokesMin.Location = New System.Drawing.Point(117, 19)
-		Me.NBTaskStrokesMin.Maximum = New Decimal(New Integer() {9999, 0, 0, 0})
-		Me.NBTaskStrokesMin.Minimum = New Decimal(New Integer() {1, 0, 0, 0})
-		Me.NBTaskStrokesMin.Name = "NBTaskStrokesMin"
-		Me.NBTaskStrokesMin.Size = New System.Drawing.Size(44, 20)
-		Me.NBTaskStrokesMin.TabIndex = 183
-		Me.NBTaskStrokesMin.Value = Global.Tease_AI.My.MySettings.Default.TaskStrokesMin
+		Me.TextBox2.BackColor = System.Drawing.Color.LightGray
+		Me.TextBox2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+		Me.TextBox2.Dock = System.Windows.Forms.DockStyle.Fill
+		Me.TextBox2.Location = New System.Drawing.Point(116, 34)
+		Me.TextBox2.Name = "TextBox2"
+		Me.TextBox2.ReadOnly = True
+		Me.TextBox2.Size = New System.Drawing.Size(189, 20)
+		Me.TextBox2.TabIndex = 145
 		'
 		'FrmSettings
 		'
-		Me.AllowDrop = true
-		Me.AutoScaleDimensions = New System.Drawing.SizeF(6!, 13!)
+		Me.AllowDrop = True
+		Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
 		Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
 		Me.ClientSize = New System.Drawing.Size(727, 465)
 		Me.Controls.Add(Me.GroupBox65)
@@ -14297,341 +14409,342 @@ Partial Class FrmSettings
 		Me.Controls.Add(Me.GroupBox12)
 		Me.Controls.Add(Me.GroupBox21)
 		Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Fixed3D
-		Me.MaximizeBox = false
-		Me.MinimizeBox = false
+		Me.MaximizeBox = False
+		Me.MinimizeBox = False
 		Me.Name = "FrmSettings"
-		Me.ShowIcon = false
+		Me.ShowIcon = False
 		Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
 		Me.Text = "Tease AI Settings"
-		Me.SettingsPanel.ResumeLayout(false)
-		Me.SettingsTabs.ResumeLayout(false)
-		Me.TabPage1.ResumeLayout(false)
-		Me.PNLGeneralSettings.ResumeLayout(false)
-		Me.PNLGeneralSettings.PerformLayout
-		Me.GroupBox64.ResumeLayout(false)
-		Me.GroupBox64.PerformLayout
-		Me.GBDommeImages.ResumeLayout(false)
-		Me.GBDommeImages.PerformLayout
-		CType(Me.slideshowNumBox,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GBGeneralTextToSpeech.ResumeLayout(false)
-		Me.GBGeneralTextToSpeech.PerformLayout
-		CType(Me.SliderVRate,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.SliderVVolume,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GBSafeword.ResumeLayout(false)
-		Me.GBSafeword.PerformLayout
-		Me.GBGeneralSystem.ResumeLayout(false)
-		Me.GBGeneralSystem.PerformLayout
-		Me.GBGeneralImages.ResumeLayout(false)
-		Me.GBGeneralImages.PerformLayout
-		CType(Me.PictureBox2,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GBGeneralSettings.ResumeLayout(false)
-		Me.GBGeneralSettings.PerformLayout
-		Me.GBSubFont.ResumeLayout(false)
-		CType(Me.NBFontSize,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GBDommeFont.ResumeLayout(false)
-		CType(Me.NBFontSizeD,System.ComponentModel.ISupportInitialize).EndInit
-		Me.TabPage2.ResumeLayout(false)
-		Me.Panel3.ResumeLayout(false)
-		Me.Panel3.PerformLayout
-		CType(Me.PictureBox4,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GBDomTypingStyle.ResumeLayout(false)
-		Me.GBDomTypingStyle.PerformLayout
-		CType(Me.NBTypoChance,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox63.ResumeLayout(false)
-		Me.GroupBox63.PerformLayout
-		Me.GBDomRanges.ResumeLayout(false)
-		CType(Me.NBDomMoodMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBDomMoodMin,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBSubAgeMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBSubAgeMin,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBSelfAgeMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBSelfAgeMin,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBAvgCockMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBAvgCockMin,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GBDomStats.ResumeLayout(false)
-		Me.GBDomStats.PerformLayout
-		CType(Me.NBEmpathy,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBDomBirthdayDay,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.domageNumBox,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBDomBirthdayMonth,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.domlevelNumBox,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GBDomPersonality.ResumeLayout(false)
-		Me.GBDomPersonality.PerformLayout
-		Me.GBDomOrgasms.ResumeLayout(false)
-		Me.GBDomOrgasms.PerformLayout
-		CType(Me.orgasmsPerNumBox,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GBDomPetNames.ResumeLayout(false)
-		Me.GBDomPetNames.PerformLayout
-		Me.TabPage10.ResumeLayout(false)
-		Me.Panel2.ResumeLayout(false)
-		Me.GroupBox22.ResumeLayout(false)
-		CType(Me.NBWritingTaskMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBWritingTaskMin,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox45.ResumeLayout(false)
-		CType(Me.CBTSlider,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox35.ResumeLayout(false)
-		Me.GroupBox39.ResumeLayout(false)
-		Me.GroupBox39.PerformLayout
-		Me.GroupBox38.ResumeLayout(false)
-		Me.GroupBox38.PerformLayout
-		Me.GroupBox37.ResumeLayout(false)
-		Me.GroupBox37.PerformLayout
-		Me.GroupBox36.ResumeLayout(false)
-		Me.GroupBox36.PerformLayout
-		Me.GroupBox13.ResumeLayout(false)
-		Me.GroupBox7.ResumeLayout(false)
-		Me.GroupBox7.PerformLayout
-		CType(Me.NBExtremeHoldMin,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBExtremeHoldMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBLongHoldMin,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBLongHoldMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBLongEdge,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBHoldTheEdgeMin,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBHoldTheEdgeMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.PictureBox12,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox32.ResumeLayout(false)
-		Me.GroupBox32.PerformLayout
-		CType(Me.NBBirthdayDay,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.subAgeNumBox,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBBirthdayMonth,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.CockSizeNumBox,System.ComponentModel.ISupportInitialize).EndInit
-		Me.TabPage16.ResumeLayout(false)
-		Me.Panel9.ResumeLayout(false)
-		Me.GroupBox31.ResumeLayout(false)
-		Me.TCScripts.ResumeLayout(false)
-		Me.TabPage21.ResumeLayout(false)
-		Me.TabPage17.ResumeLayout(false)
-		Me.TabPage18.ResumeLayout(false)
-		Me.TabPage19.ResumeLayout(false)
-		Me.GroupBox42.ResumeLayout(false)
-		CType(Me.PictureBox1,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox43.ResumeLayout(false)
-		Me.TabPage7.ResumeLayout(false)
-		Me.TabControl4.ResumeLayout(false)
-		Me.TabPage31.ResumeLayout(false)
-		Me.TabPage31.PerformLayout
-		Me.GroupBox66.ResumeLayout(false)
-		CType(Me.PBURLPreview,System.ComponentModel.ISupportInitialize).EndInit
-		Me.TabPage32.ResumeLayout(false)
-		Me.GroupBox16.ResumeLayout(false)
-		Me.GroupBox16.PerformLayout
-		Me.GroupBox14.ResumeLayout(false)
-		Me.GroupBox14.PerformLayout
-		Me.TabPage12.ResumeLayout(false)
-		Me.PNLImageTag.ResumeLayout(false)
-		Me.PNLImageTag.PerformLayout
-		CType(Me.ImageTagPictureBox,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.PictureBox14,System.ComponentModel.ISupportInitialize).EndInit
-		Me.TabPage9.ResumeLayout(false)
-		Me.Panel4.ResumeLayout(false)
-		Me.Panel4.PerformLayout
-		Me.GroupBox55.ResumeLayout(false)
-		Me.GroupBox55.PerformLayout
-		Me.GroupBox53.ResumeLayout(false)
-		Me.GroupBox53.PerformLayout
-		Me.GroupBox49.ResumeLayout(false)
-		Me.GroupBox49.PerformLayout
-		Me.GroupBox46.ResumeLayout(false)
-		Me.GroupBox46.PerformLayout
-		Me.GroupBox54.ResumeLayout(false)
-		Me.GroupBox54.PerformLayout
-		Me.GroupBox51.ResumeLayout(false)
-		Me.GroupBox51.PerformLayout
-		Me.GroupBox50.ResumeLayout(false)
-		Me.GroupBox50.PerformLayout
-		Me.GroupBox48.ResumeLayout(false)
-		Me.GroupBox48.PerformLayout
-		CType(Me.PictureBox7,System.ComponentModel.ISupportInitialize).EndInit
-		Me.TabPage11.ResumeLayout(false)
-		Me.Panel7.ResumeLayout(false)
-		Me.Panel7.PerformLayout
-		CType(Me.PictureBox5,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.WebPictureBox,System.ComponentModel.ISupportInitialize).EndInit
-		Me.TabPage3.ResumeLayout(false)
-		Me.Panel1.ResumeLayout(false)
-		CType(Me.PictureBox6,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox25.ResumeLayout(false)
-		Me.GroupBox25.PerformLayout
-		Me.GroupBox24.ResumeLayout(false)
-		Me.GroupBox24.PerformLayout
-		Me.GroupBox23.ResumeLayout(false)
-		Me.GroupBox23.PerformLayout
-		Me.GroupBox8.ResumeLayout(false)
-		Me.GroupBox4.ResumeLayout(false)
-		Me.GroupBox4.PerformLayout
-		Me.GroupBox3.ResumeLayout(false)
-		Me.GroupBox3.PerformLayout
-		Me.GroupBox2.ResumeLayout(false)
-		Me.GroupBox2.PerformLayout
-		Me.TabPage20.ResumeLayout(false)
-		Me.TabControl1.ResumeLayout(false)
-		Me.TabPage22.ResumeLayout(false)
-		Me.PNLGlitter.ResumeLayout(false)
-		Me.PNLGlitter.PerformLayout
-		Me.GBGlitterD.ResumeLayout(false)
-		Me.GBGlitterD.PerformLayout
-		CType(Me.GlitterSlider,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.GlitterAV,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GBGlitter1.ResumeLayout(false)
-		Me.GBGlitter1.PerformLayout
-		CType(Me.GlitterSlider1,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.GlitterAV1,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GBGlitter3.ResumeLayout(false)
-		Me.GBGlitter3.PerformLayout
-		CType(Me.GlitterSlider3,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.GlitterAV3,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GBGlitter2.ResumeLayout(false)
-		Me.GBGlitter2.PerformLayout
-		CType(Me.GlitterSlider2,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.GlitterAV2,System.ComponentModel.ISupportInitialize).EndInit
-		Me.TabPage23.ResumeLayout(false)
-		Me.TabPage23.PerformLayout
-		Me.GroupBox61.ResumeLayout(false)
-		Me.GroupBox61.PerformLayout
-		CType(Me.GP6,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.GP2,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.GP5,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.GP1,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.GP3,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.GP4,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox60.ResumeLayout(false)
-		CType(Me.CardBack,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox58.ResumeLayout(false)
-		Me.GroupBox58.PerformLayout
-		CType(Me.BP3,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.BP6,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.BP5,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.BP2,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.BP4,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.BP1,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox59.ResumeLayout(false)
-		Me.GroupBox59.PerformLayout
-		CType(Me.SP6,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.SP2,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.SP5,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.SP1,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.SP3,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.SP4,System.ComponentModel.ISupportInitialize).EndInit
-		Me.TabPage6.ResumeLayout(false)
-		Me.Panel10.ResumeLayout(false)
-		Me.Panel10.PerformLayout
-		CType(Me.NBWishlistCost,System.ComponentModel.ISupportInitialize).EndInit
-		Me.PNLWishList.ResumeLayout(false)
-		CType(Me.WishlistCostSilver,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.WishlistCostGold,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.WishlistPreview,System.ComponentModel.ISupportInitialize).EndInit
-		Me.TabPage26.ResumeLayout(false)
-		Me.Panel12.ResumeLayout(false)
-		Me.GroupBox9.ResumeLayout(false)
-		CType(Me.PictureBox10,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox5.ResumeLayout(false)
-		Me.GroupBox5.PerformLayout
-		Me.GroupBox11.ResumeLayout(false)
-		Me.GroupBox1.ResumeLayout(false)
-		CType(Me.PBBackgroundPreview,System.ComponentModel.ISupportInitialize).EndInit
-		Me.TabPage4.ResumeLayout(false)
-		Me.Panel6.ResumeLayout(false)
-		Me.GroupBox68.ResumeLayout(false)
-		CType(Me.NBTasksMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBTasksMin,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox67.ResumeLayout(false)
-		Me.GroupBox10.ResumeLayout(false)
-		CType(Me.NBNextImageChance,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox57.ResumeLayout(false)
-		Me.GroupBox57.PerformLayout
-		CType(Me.NBTauntEdging,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.SliderSTF,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.TauntSlider,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBTauntCycleMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBTauntCycleMin,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBTeaseLengthMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBTeaseLengthMin,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox56.ResumeLayout(false)
-		Me.GroupBox56.PerformLayout
-		CType(Me.NBRuinSometimes,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBRuinRarely,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBRuinOften,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox17.ResumeLayout(false)
-		Me.GroupBox19.ResumeLayout(false)
-		CType(Me.NBGreenLightMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBGreenLightMin,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBRedLightMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBRedLightMin,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox18.ResumeLayout(false)
-		Me.GroupBox18.PerformLayout
-		CType(Me.NBCensorShowMin,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBCensorHideMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBCensorHideMin,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBCensorShowMax,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox52.ResumeLayout(false)
-		Me.GroupBox52.PerformLayout
-		CType(Me.NBAllowSometimes,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBAllowRarely,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBAllowOften,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.PictureBox8,System.ComponentModel.ISupportInitialize).EndInit
-		Me.TabPage13.ResumeLayout(false)
-		Me.TabControl2.ResumeLayout(false)
-		Me.TabPage27.ResumeLayout(false)
-		Me.TabPage27.PerformLayout
-		Me.TabPage14.ResumeLayout(false)
-		Me.TabPage14.PerformLayout
-		Me.TabPage24.ResumeLayout(false)
-		Me.TabPage24.PerformLayout
-		Me.TabPage8.ResumeLayout(false)
-		Me.GroupBox29.ResumeLayout(false)
-		Me.GroupBox28.ResumeLayout(false)
-		Me.GroupBox30.ResumeLayout(false)
-		Me.TabPage15.ResumeLayout(false)
-		Me.TabPage15.PerformLayout
-		Me.GroupBox34.ResumeLayout(false)
-		Me.TabPage25.ResumeLayout(false)
-		Me.Panel11.ResumeLayout(false)
-		Me.GroupBox62.ResumeLayout(false)
-		Me.GroupBox62.PerformLayout
-		Me.GroupBox33.ResumeLayout(false)
-		Me.GroupBox27.ResumeLayout(false)
-		Me.GroupBox27.PerformLayout
-		Me.GroupBox20.ResumeLayout(false)
-		Me.GroupBox20.PerformLayout
-		Me.GroupBox15.ResumeLayout(false)
-		Me.GroupBox15.PerformLayout
-		CType(Me.PictureBox9,System.ComponentModel.ISupportInitialize).EndInit
-		Me.TabPage28.ResumeLayout(false)
-		Me.TabControl3.ResumeLayout(false)
-		Me.TabPage29.ResumeLayout(false)
-		Me.GroupBox26.ResumeLayout(false)
-		Me.GroupBox26.PerformLayout
-		Me.TabPage5.ResumeLayout(false)
-		Me.Panel5.ResumeLayout(false)
-		Me.Panel5.PerformLayout
-		CType(Me.PictureBox3,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox47.ResumeLayout(false)
-		Me.GroupBox41.ResumeLayout(false)
-		Me.GroupBox44.ResumeLayout(false)
-		Me.GroupBox6.ResumeLayout(false)
-		Me.GroupBox6.PerformLayout
-		Me.GroupBox21.ResumeLayout(false)
-		Me.GroupBox12.ResumeLayout(false)
-		Me.GroupBox65.ResumeLayout(false)
-		Me.GroupBox65.PerformLayout
-		CType(Me.TrackBar1,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.TrackBar2,System.ComponentModel.ISupportInitialize).EndInit
-		Me.GroupBox69.ResumeLayout(false)
-		Me.GroupBox69.PerformLayout
-		CType(Me.TypeSpeedSlider,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBTaskCBTTimeMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBTaskCBTTimeMin,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBTaskEdgeHoldTimeMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBTaskEdgeHoldTimeMin,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBTaskEdgesMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBTaskEdgesMin,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBTaskStrokingTimeMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBTaskStrokingTimeMin,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBTaskStrokesMax,System.ComponentModel.ISupportInitialize).EndInit
-		CType(Me.NBTaskStrokesMin,System.ComponentModel.ISupportInitialize).EndInit
-		Me.ResumeLayout(false)
+		Me.SettingsPanel.ResumeLayout(False)
+		Me.SettingsTabs.ResumeLayout(False)
+		Me.TabPage1.ResumeLayout(False)
+		Me.PNLGeneralSettings.ResumeLayout(False)
+		Me.PNLGeneralSettings.PerformLayout()
+		Me.GroupBox64.ResumeLayout(False)
+		Me.GroupBox64.PerformLayout()
+		Me.GBDommeImages.ResumeLayout(False)
+		Me.GBDommeImages.PerformLayout()
+		CType(Me.slideshowNumBox, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GBGeneralTextToSpeech.ResumeLayout(False)
+		Me.GBGeneralTextToSpeech.PerformLayout()
+		CType(Me.SliderVRate, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.SliderVVolume, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GBSafeword.ResumeLayout(False)
+		Me.GBSafeword.PerformLayout()
+		Me.GBGeneralSystem.ResumeLayout(False)
+		Me.GBGeneralSystem.PerformLayout()
+		Me.GBGeneralImages.ResumeLayout(False)
+		Me.GBGeneralImages.PerformLayout()
+		CType(Me.PictureBox2, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GBGeneralSettings.ResumeLayout(False)
+		Me.GBGeneralSettings.PerformLayout()
+		Me.GBSubFont.ResumeLayout(False)
+		CType(Me.NBFontSize, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GBDommeFont.ResumeLayout(False)
+		CType(Me.NBFontSizeD, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.TabPage2.ResumeLayout(False)
+		Me.Panel3.ResumeLayout(False)
+		Me.Panel3.PerformLayout()
+		CType(Me.PictureBox4, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GBDomTypingStyle.ResumeLayout(False)
+		Me.GBDomTypingStyle.PerformLayout()
+		CType(Me.NBTypoChance, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox63.ResumeLayout(False)
+		Me.GroupBox63.PerformLayout()
+		Me.GBDomRanges.ResumeLayout(False)
+		CType(Me.NBDomMoodMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBDomMoodMin, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBSubAgeMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBSubAgeMin, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBSelfAgeMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBSelfAgeMin, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBAvgCockMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBAvgCockMin, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GBDomStats.ResumeLayout(False)
+		Me.GBDomStats.PerformLayout()
+		CType(Me.NBEmpathy, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBDomBirthdayDay, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.domageNumBox, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBDomBirthdayMonth, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.domlevelNumBox, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GBDomPersonality.ResumeLayout(False)
+		Me.GBDomPersonality.PerformLayout()
+		Me.GBDomOrgasms.ResumeLayout(False)
+		Me.GBDomOrgasms.PerformLayout()
+		CType(Me.orgasmsPerNumBox, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GBDomPetNames.ResumeLayout(False)
+		Me.GBDomPetNames.PerformLayout()
+		Me.TabPage10.ResumeLayout(False)
+		Me.Panel2.ResumeLayout(False)
+		Me.GroupBox22.ResumeLayout(False)
+		CType(Me.NBWritingTaskMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBWritingTaskMin, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox45.ResumeLayout(False)
+		CType(Me.CBTSlider, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox35.ResumeLayout(False)
+		Me.GroupBox39.ResumeLayout(False)
+		Me.GroupBox39.PerformLayout()
+		Me.GroupBox38.ResumeLayout(False)
+		Me.GroupBox38.PerformLayout()
+		Me.GroupBox37.ResumeLayout(False)
+		Me.GroupBox37.PerformLayout()
+		Me.GroupBox36.ResumeLayout(False)
+		Me.GroupBox36.PerformLayout()
+		Me.GroupBox13.ResumeLayout(False)
+		Me.GroupBox7.ResumeLayout(False)
+		Me.GroupBox7.PerformLayout()
+		CType(Me.NBExtremeHoldMin, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBExtremeHoldMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBLongHoldMin, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBLongHoldMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBLongEdge, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBHoldTheEdgeMin, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBHoldTheEdgeMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.PictureBox12, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox32.ResumeLayout(False)
+		Me.GroupBox32.PerformLayout()
+		CType(Me.NBBirthdayDay, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.subAgeNumBox, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBBirthdayMonth, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.CockSizeNumBox, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.TabPage16.ResumeLayout(False)
+		Me.Panel9.ResumeLayout(False)
+		Me.GroupBox31.ResumeLayout(False)
+		Me.TCScripts.ResumeLayout(False)
+		Me.TabPage21.ResumeLayout(False)
+		Me.TabPage17.ResumeLayout(False)
+		Me.TabPage18.ResumeLayout(False)
+		Me.TabPage19.ResumeLayout(False)
+		Me.GroupBox42.ResumeLayout(False)
+		CType(Me.PictureBox1, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox43.ResumeLayout(False)
+		Me.TabPage7.ResumeLayout(False)
+		Me.TabControl4.ResumeLayout(False)
+		Me.TabPage31.ResumeLayout(False)
+		Me.TabPage31.PerformLayout()
+		Me.GroupBox66.ResumeLayout(False)
+		CType(Me.PBURLPreview, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.TabPage32.ResumeLayout(False)
+		Me.GrbImageUrlFiles.ResumeLayout(False)
+		Me.TlpImageUrls.ResumeLayout(False)
+		Me.TlpImageUrls.PerformLayout()
+		Me.GroupBox14.ResumeLayout(False)
+		Me.GroupBox14.PerformLayout()
+		Me.TabPage12.ResumeLayout(False)
+		Me.PNLImageTag.ResumeLayout(False)
+		Me.PNLImageTag.PerformLayout()
+		CType(Me.ImageTagPictureBox, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.PictureBox14, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.TabPage9.ResumeLayout(False)
+		Me.Panel4.ResumeLayout(False)
+		Me.Panel4.PerformLayout()
+		Me.GroupBox55.ResumeLayout(False)
+		Me.GroupBox55.PerformLayout()
+		Me.GroupBox53.ResumeLayout(False)
+		Me.GroupBox53.PerformLayout()
+		Me.GroupBox49.ResumeLayout(False)
+		Me.GroupBox49.PerformLayout()
+		Me.GroupBox46.ResumeLayout(False)
+		Me.GroupBox46.PerformLayout()
+		Me.GroupBox54.ResumeLayout(False)
+		Me.GroupBox54.PerformLayout()
+		Me.GroupBox51.ResumeLayout(False)
+		Me.GroupBox51.PerformLayout()
+		Me.GroupBox50.ResumeLayout(False)
+		Me.GroupBox50.PerformLayout()
+		Me.GroupBox48.ResumeLayout(False)
+		Me.GroupBox48.PerformLayout()
+		CType(Me.PictureBox7, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.TabPage11.ResumeLayout(False)
+		Me.Panel7.ResumeLayout(False)
+		Me.Panel7.PerformLayout()
+		CType(Me.PictureBox5, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.WebPictureBox, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.TabPage3.ResumeLayout(False)
+		Me.Panel1.ResumeLayout(False)
+		CType(Me.PictureBox6, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox25.ResumeLayout(False)
+		Me.GroupBox25.PerformLayout()
+		Me.GroupBox24.ResumeLayout(False)
+		Me.GroupBox24.PerformLayout()
+		Me.GroupBox23.ResumeLayout(False)
+		Me.GroupBox23.PerformLayout()
+		Me.GroupBox8.ResumeLayout(False)
+		Me.GroupBox4.ResumeLayout(False)
+		Me.GroupBox4.PerformLayout()
+		Me.GroupBox3.ResumeLayout(False)
+		Me.GroupBox3.PerformLayout()
+		Me.GroupBox2.ResumeLayout(False)
+		Me.GroupBox2.PerformLayout()
+		Me.TabPage20.ResumeLayout(False)
+		Me.TabControl1.ResumeLayout(False)
+		Me.TabPage22.ResumeLayout(False)
+		Me.PNLGlitter.ResumeLayout(False)
+		Me.PNLGlitter.PerformLayout()
+		Me.GBGlitterD.ResumeLayout(False)
+		Me.GBGlitterD.PerformLayout()
+		CType(Me.GlitterSlider, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.GlitterAV, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GBGlitter1.ResumeLayout(False)
+		Me.GBGlitter1.PerformLayout()
+		CType(Me.GlitterSlider1, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.GlitterAV1, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GBGlitter3.ResumeLayout(False)
+		Me.GBGlitter3.PerformLayout()
+		CType(Me.GlitterSlider3, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.GlitterAV3, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GBGlitter2.ResumeLayout(False)
+		Me.GBGlitter2.PerformLayout()
+		CType(Me.GlitterSlider2, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.GlitterAV2, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.TabPage23.ResumeLayout(False)
+		Me.TabPage23.PerformLayout()
+		Me.GroupBox61.ResumeLayout(False)
+		Me.GroupBox61.PerformLayout()
+		CType(Me.GP6, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.GP2, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.GP5, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.GP1, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.GP3, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.GP4, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox60.ResumeLayout(False)
+		CType(Me.CardBack, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox58.ResumeLayout(False)
+		Me.GroupBox58.PerformLayout()
+		CType(Me.BP3, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.BP6, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.BP5, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.BP2, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.BP4, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.BP1, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox59.ResumeLayout(False)
+		Me.GroupBox59.PerformLayout()
+		CType(Me.SP6, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.SP2, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.SP5, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.SP1, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.SP3, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.SP4, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.TabPage6.ResumeLayout(False)
+		Me.Panel10.ResumeLayout(False)
+		Me.Panel10.PerformLayout()
+		CType(Me.NBWishlistCost, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.PNLWishList.ResumeLayout(False)
+		CType(Me.WishlistCostSilver, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.WishlistCostGold, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.WishlistPreview, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.TabPage26.ResumeLayout(False)
+		Me.Panel12.ResumeLayout(False)
+		Me.GroupBox9.ResumeLayout(False)
+		CType(Me.PictureBox10, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox5.ResumeLayout(False)
+		Me.GroupBox5.PerformLayout()
+		Me.GroupBox11.ResumeLayout(False)
+		Me.GroupBox1.ResumeLayout(False)
+		CType(Me.PBBackgroundPreview, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.TabPage4.ResumeLayout(False)
+		Me.Panel6.ResumeLayout(False)
+		Me.GroupBox69.ResumeLayout(False)
+		Me.GroupBox69.PerformLayout()
+		CType(Me.TypeSpeedSlider, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox68.ResumeLayout(False)
+		CType(Me.NBTasksMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBTasksMin, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox67.ResumeLayout(False)
+		CType(Me.NBTaskCBTTimeMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBTaskCBTTimeMin, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBTaskEdgeHoldTimeMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBTaskEdgeHoldTimeMin, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBTaskEdgesMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBTaskEdgesMin, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBTaskStrokingTimeMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBTaskStrokingTimeMin, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBTaskStrokesMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBTaskStrokesMin, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox10.ResumeLayout(False)
+		CType(Me.NBNextImageChance, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox57.ResumeLayout(False)
+		Me.GroupBox57.PerformLayout()
+		CType(Me.NBTauntEdging, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.SliderSTF, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.TauntSlider, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBTauntCycleMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBTauntCycleMin, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBTeaseLengthMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBTeaseLengthMin, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox56.ResumeLayout(False)
+		Me.GroupBox56.PerformLayout()
+		CType(Me.NBRuinSometimes, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBRuinRarely, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBRuinOften, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox17.ResumeLayout(False)
+		Me.GroupBox19.ResumeLayout(False)
+		CType(Me.NBGreenLightMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBGreenLightMin, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBRedLightMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBRedLightMin, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox18.ResumeLayout(False)
+		Me.GroupBox18.PerformLayout()
+		CType(Me.NBCensorShowMin, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBCensorHideMax, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBCensorHideMin, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBCensorShowMax, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox52.ResumeLayout(False)
+		Me.GroupBox52.PerformLayout()
+		CType(Me.NBAllowSometimes, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBAllowRarely, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.NBAllowOften, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.PictureBox8, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.TabPage13.ResumeLayout(False)
+		Me.TabControl2.ResumeLayout(False)
+		Me.TabPage27.ResumeLayout(False)
+		Me.TabPage27.PerformLayout()
+		Me.TabPage14.ResumeLayout(False)
+		Me.TabPage14.PerformLayout()
+		Me.TabPage24.ResumeLayout(False)
+		Me.TabPage24.PerformLayout()
+		Me.TabPage8.ResumeLayout(False)
+		Me.GroupBox29.ResumeLayout(False)
+		Me.GroupBox28.ResumeLayout(False)
+		Me.GroupBox30.ResumeLayout(False)
+		Me.TabPage15.ResumeLayout(False)
+		Me.TabPage15.PerformLayout()
+		Me.GroupBox34.ResumeLayout(False)
+		Me.TabPage25.ResumeLayout(False)
+		Me.Panel11.ResumeLayout(False)
+		Me.GroupBox62.ResumeLayout(False)
+		Me.GroupBox62.PerformLayout()
+		Me.GroupBox33.ResumeLayout(False)
+		Me.GroupBox27.ResumeLayout(False)
+		Me.GroupBox27.PerformLayout()
+		Me.GroupBox20.ResumeLayout(False)
+		Me.GroupBox20.PerformLayout()
+		Me.GroupBox15.ResumeLayout(False)
+		Me.GroupBox15.PerformLayout()
+		CType(Me.PictureBox9, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.TabPage28.ResumeLayout(False)
+		Me.TabControl3.ResumeLayout(False)
+		Me.TabPage29.ResumeLayout(False)
+		Me.GroupBox26.ResumeLayout(False)
+		Me.GroupBox26.PerformLayout()
+		Me.TabPage5.ResumeLayout(False)
+		Me.Panel5.ResumeLayout(False)
+		Me.Panel5.PerformLayout()
+		CType(Me.PictureBox3, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.GroupBox47.ResumeLayout(False)
+		Me.GroupBox41.ResumeLayout(False)
+		Me.GroupBox44.ResumeLayout(False)
+		Me.GroupBox6.ResumeLayout(False)
+		Me.GroupBox6.PerformLayout()
+		Me.GroupBox21.ResumeLayout(False)
+		Me.GroupBox12.ResumeLayout(False)
+		Me.GroupBox65.ResumeLayout(False)
+		Me.GroupBox65.PerformLayout()
+		CType(Me.TrackBar1, System.ComponentModel.ISupportInitialize).EndInit()
+		CType(Me.TrackBar2, System.ComponentModel.ISupportInitialize).EndInit()
+		Me.ResumeLayout(False)
 
-End Sub
+	End Sub
 	Friend WithEvents SettingsPanel As System.Windows.Forms.Panel
 	Friend WithEvents SettingsTabs As System.Windows.Forms.TabControl
 	Friend WithEvents TabPage1 As System.Windows.Forms.TabPage
@@ -14774,15 +14887,13 @@ End Sub
 	Friend WithEvents GroupBox41 As System.Windows.Forms.GroupBox
 	Friend WithEvents CBButtSubDir As System.Windows.Forms.CheckBox
 	Friend WithEvents LBLButtPath As System.Windows.Forms.Label
-	Friend WithEvents LBLButtURL As System.Windows.Forms.Label
 	Friend WithEvents BTNButtPath As System.Windows.Forms.Button
-	Friend WithEvents BTNButtURL As System.Windows.Forms.Button
+	Friend WithEvents BtnImageUrlButt As System.Windows.Forms.Button
 	Friend WithEvents GroupBox40 As System.Windows.Forms.GroupBox
 	Friend WithEvents CBBoobSubDir As System.Windows.Forms.CheckBox
 	Friend WithEvents LBLBoobPath As System.Windows.Forms.Label
-	Friend WithEvents LBLBoobURL As System.Windows.Forms.Label
 	Friend WithEvents BTNBoobPath As System.Windows.Forms.Button
-	Friend WithEvents BTNBoobURL As System.Windows.Forms.Button
+	Friend WithEvents BtnImageUrlBoobs As System.Windows.Forms.Button
 	Friend WithEvents TabPage12 As System.Windows.Forms.TabPage
 	Friend WithEvents PNLImageTag As System.Windows.Forms.Panel
 	Friend WithEvents CBTagSucking As System.Windows.Forms.CheckBox
@@ -15637,45 +15748,34 @@ End Sub
 	Friend WithEvents BTNURLFilesNone As System.Windows.Forms.Button
 	Friend WithEvents BTNURLFilesAll As System.Windows.Forms.Button
 	Friend WithEvents GroupBox14 As System.Windows.Forms.GroupBox
-	Friend WithEvents GroupBox16 As System.Windows.Forms.GroupBox
-	Friend WithEvents CBURLButts As System.Windows.Forms.CheckBox
-	Friend WithEvents CBURLBoobs As System.Windows.Forms.CheckBox
+	Friend WithEvents GrbImageUrlFiles As System.Windows.Forms.GroupBox
+	Friend WithEvents ChbImageUrlButts As System.Windows.Forms.CheckBox
+	Friend WithEvents ChbImageUrlBoobs As System.Windows.Forms.CheckBox
 	Friend WithEvents Label153 As System.Windows.Forms.Label
-	Friend WithEvents LBLURLFemdom As System.Windows.Forms.Label
 	Friend WithEvents Label156 As System.Windows.Forms.Label
-	Friend WithEvents BTNURLGeneral As System.Windows.Forms.Button
+	Friend WithEvents BtnImageUrlGeneral As System.Windows.Forms.Button
 	Friend WithEvents Button34 As System.Windows.Forms.Button
-	Friend WithEvents LBLURLHentai As System.Windows.Forms.Label
-	Friend WithEvents CBURLLesbian As System.Windows.Forms.CheckBox
-	Friend WithEvents BTNURLCaptions As System.Windows.Forms.Button
-	Friend WithEvents CBURLBlowjob As System.Windows.Forms.CheckBox
-	Friend WithEvents BTNURLMaledom As System.Windows.Forms.Button
-	Friend WithEvents CBURLGay As System.Windows.Forms.CheckBox
-	Friend WithEvents BTNURLGay As System.Windows.Forms.Button
-	Friend WithEvents CBURLSoftcore As System.Windows.Forms.CheckBox
-	Friend WithEvents CBURLHentai As System.Windows.Forms.CheckBox
-	Friend WithEvents CBURLLezdom As System.Windows.Forms.CheckBox
-	Friend WithEvents BTNURLHentai As System.Windows.Forms.Button
-	Friend WithEvents LBLURLLezdom As System.Windows.Forms.Label
-	Friend WithEvents BTNURLLezdom As System.Windows.Forms.Button
-	Friend WithEvents CBURLFemdom As System.Windows.Forms.CheckBox
-	Friend WithEvents BTNURLFemdom As System.Windows.Forms.Button
-	Friend WithEvents LBLURLBlowjob As System.Windows.Forms.Label
-	Friend WithEvents BTNURLBlowjob As System.Windows.Forms.Button
-	Friend WithEvents LBLURLLesbian As System.Windows.Forms.Label
-	Friend WithEvents CBURLCaptions As System.Windows.Forms.CheckBox
-	Friend WithEvents BTNURLLesbian As System.Windows.Forms.Button
-	Friend WithEvents LBLURLSoftcore As System.Windows.Forms.Label
-	Friend WithEvents LBLURLGeneral As System.Windows.Forms.Label
-	Friend WithEvents BTNURLSoftcore As System.Windows.Forms.Button
-	Friend WithEvents LBLURLCaptions As System.Windows.Forms.Label
-	Friend WithEvents LBLURLGay As System.Windows.Forms.Label
-	Friend WithEvents CBURLGeneral As System.Windows.Forms.CheckBox
-	Friend WithEvents BTNURLHardcore As System.Windows.Forms.Button
-	Friend WithEvents LBLURLHardcore As System.Windows.Forms.Label
-	Friend WithEvents LBLURLMaledom As System.Windows.Forms.Label
-	Friend WithEvents CBURLHardcore As System.Windows.Forms.CheckBox
-	Friend WithEvents CBURLMaledom As System.Windows.Forms.CheckBox
+	Friend WithEvents ChbImageUrlLesbian As System.Windows.Forms.CheckBox
+	Friend WithEvents BtnImageUrlCaptions As System.Windows.Forms.Button
+	Friend WithEvents ChbImageUrlBlowjob As System.Windows.Forms.CheckBox
+	Friend WithEvents BtnImageUrlMaledom As System.Windows.Forms.Button
+	Friend WithEvents ChbImageUrlGay As System.Windows.Forms.CheckBox
+	Friend WithEvents BtnImageUrlGay As System.Windows.Forms.Button
+	Friend WithEvents ChbImageUrlSoftcore As System.Windows.Forms.CheckBox
+	Friend WithEvents ChbImageUrlHentai As System.Windows.Forms.CheckBox
+	Friend WithEvents ChbImageUrlLezdom As System.Windows.Forms.CheckBox
+	Friend WithEvents BtnImageUrlHentai As System.Windows.Forms.Button
+	Friend WithEvents BtnImageUrlLezdom As System.Windows.Forms.Button
+	Friend WithEvents ChbImageUrlFemdom As System.Windows.Forms.CheckBox
+	Friend WithEvents BtnImageUrlFemdom As System.Windows.Forms.Button
+	Friend WithEvents BtnImageUrlBlowjob As System.Windows.Forms.Button
+	Friend WithEvents ChbImageUrlCaptions As System.Windows.Forms.CheckBox
+	Friend WithEvents BtnImageUrlLesbian As System.Windows.Forms.Button
+	Friend WithEvents BtnImageUrlSoftcore As System.Windows.Forms.Button
+	Friend WithEvents ChbImageUrlGeneral As System.Windows.Forms.CheckBox
+	Friend WithEvents BtnImageUrlHardcore As System.Windows.Forms.Button
+	Friend WithEvents ChbImageUrlHardcore As System.Windows.Forms.CheckBox
+	Friend WithEvents ChbImageUrlMaledom As System.Windows.Forms.CheckBox
 	Friend WithEvents CBIButts As System.Windows.Forms.CheckBox
 	Friend WithEvents CBIBoobs As System.Windows.Forms.CheckBox
 	Friend WithEvents GroupBox66 As System.Windows.Forms.GroupBox
@@ -15717,4 +15817,20 @@ End Sub
 	Friend WithEvents TypeSpeedLabel As System.Windows.Forms.Label
 	Friend WithEvents TimedWriting As System.Windows.Forms.CheckBox
 	Friend WithEvents TypesSpeedVal As System.Windows.Forms.Label
+	Friend WithEvents TlpImageUrls As TableLayoutPanel
+	Friend WithEvents TxbImageUrlLesbian As TextBox
+	Friend WithEvents TxbImageUrlHardcore As TextBox
+	Friend WithEvents TxbImageUrlSoftcore As TextBox
+	Friend WithEvents TxbImageUrlBlowjob As TextBox
+	Friend WithEvents TxbImageUrlFemdom As TextBox
+	Friend WithEvents TxbImageUrlLezdom As TextBox
+	Friend WithEvents TxbImageUrlHentai As TextBox
+	Friend WithEvents TxbImageUrlGay As TextBox
+	Friend WithEvents TxbImageUrlMaledom As TextBox
+	Friend WithEvents TxbImageUrlCaptions As TextBox
+	Friend WithEvents TxbImageUrlGeneral As TextBox
+	Friend WithEvents TxbImageUrlBoobs As TextBox
+	Friend WithEvents TxbImageUrlButts As TextBox
+	Friend WithEvents TxbImgUrlHardcore As TextBox
+	Friend WithEvents TextBox2 As TextBox
 End Class

--- a/Tease AI/Form2.resx
+++ b/Tease AI/Form2.resx
@@ -118,39 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="PictureBox8.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAAJkAAAAPCAYAAAD3Y23kAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAACwwAAAsMAT9AIsgAAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQffAhAMDgicJ1x9
-        AAAAHWlUWHRDb21tZW50AAAAAABDcmVhdGVkIHdpdGggR0lNUGQuZQcAAAYSSURBVGhD7Zp/TJVlFMeN
-        zNEojOaulrasmencylk2LP5IzdBaLLQf2vyRxbAIClmk9ppcQPGKoqZ4hdC4QxTBTdESYU5FEST5lfxK
-        CoVIjQzNtgv33hfn2znvvY97eHre933A3evWOttnD/ec55znPOf9Apc7BoFJgHmAJAB3w3i93Al307w1
-        f97+O0HPePsJao9Sw9VeuanrptIfGv/svUUKGBjvYCOmAnpm5vU0ELCWu6SuPQsMVAwTAD3z1vx9OSPu
-        WXSPUs0V2e7v758kytwPY7ZXd4qLrPaPm4oo+0rPlUKOoch4ucj+8qZTdK8TnpucWtPZ6+DtRbCWu6Su
-        ffp1zoH9Nb/3yrwaWqRk7CmAXEOReWn+vpyRehZdk+0xvuKyy44r8DCDHzCY8T0VviDSWn5ZFhbZmSu9
-        iii5J+qERMbLrbgk94x8YsxaiE8HsPcAYPk335UV8/YjWAswsoSyDsc1Xr4eSdZcEZHR88eejRguOH9f
-        zkg9C1eA26N0okO2T3/z3S004CcJo4NMptV0LG7tttzjHbcLTDLAXPpbryJK9tHbIuPVInBrWg+eLobY
-        MoD+pgj2DwhIOtbu6OLlQBzvyTuDxoz35eXrsSpdFRmvHk388V9viwwtFMC5ahIGD5Cav5b5ckbqWbgC
-        aCa2R6m4zSWXtMsKzX3wIw9iqsgivrTY2PiRNhcWMKfkHDmkBcYROm93ZXs1by/hrYi4TJG6dE2k6ILj
-        RmBQUDLEpgCvz41aHmV6dFQ4fI1DiFmamrWHzUGwFu8MAsYROsfoDoQXQ8M3i9QvvujsIzLbyZYKnK8R
-        sFdXZHTPiDdnRPYBaKbX3ou00j1KB1td8qELskJDi+z95RYbGy9sdYuM9dNg3GgPy9Yi9SeZYV3WtzKr
-        8AD4lwL4633Ft+Vtlck5Jej7BHgaMBc0/HWRzUM/66PBuNEelsJfXDczT5yvEMnFeGFrX5GNnxyyPhQe
-        khaxG7L3euavKzL2LG/OiKwAmgn7pHuU8s875X0/uxQaWmTzv7DY2Hh+i1MVGeunwbjRHpa0w7WqyHgx
-        AhvPa7J3+vn5JYJ/IjD4oWEjVhW0OB15zfar8DoauAdYGDr/o+3YN50LfqE7FLQ47Ly4HjPmRlhF6udD
-        bViJyB4ATDqMw7qe+euKjD7H2zMiK4BmYnuUcpqccu5PLoWGFtm8zy02Nr6r2S0y1k+DcaM9LJaDbpHx
-        YgQ2/kGSdTf4PgZwUIPvDxy68vkZs1ORe4cMifH4hwMJW062VdO54BO5Q3xqUUOZrdHeZQSdG5Vq2ytS
-        f1dTH5HNAfDBaDINHqBn/vhay3w6I7ICaCa2R2lHvUPe2ehUaGiRvQ0iY+OQo4pMBDpvbVFzeVzW4UNa
-        vLooVn1PZgSpZ6263u7xjQWGASM0GAq88eTE4PU7GhxOkg++f9XmweuVB6mLRKbm4Bt/bj2arPqePiLb
-        XHapHudrBOzVFRnpwxczovahmV5+J8JK9yil1zlk6zlohoIWWXicxcbGt9UZXpKYmc7bWtf9d3qtvUuL
-        uOxjRZBj+BEGqTdryYoseL0YeAT9wWEL0qfNj86gmfDSzI0Qw4eIf66vWLan/CjJxxzAyPrcQZSFyVl5
-        kGv4EUb6j31FNn7KjLQQeEhaLFqzc6/A/H05I/UsXN0vB5mwT7pHaWN1j7y5xqHQeET2IDA+7LM1Nja+
-        qapHWGRsrh7L8quFPifDvSmlV5rxa2AUsHjqgthMuMsttubG6m77yLHPrIM9s4EQ/8Cg5LSz9usY8+Qb
-        Wb/uQJi5ZNVOyB3nLqFp8ZuquonI8P1YIMB7L0YYN2VOhFVg/r6ckXoWrgDeYTTbo2T5oUded9ah0Ix5
-        4ZW0xyeFbEDmJdry2bilUlxkbK4esXliIoOelVnRKdmkRyT51LV2Xk3kq5KOc/TeyIyS79GPtdwlda1f
-        d0DWnL5xOSBo2GrIfcxdQtMkS2W3ne7NCLy3wPx9OSN1PnQu26OUWNEtJ53pUfpDYnm3sMgGgKHIeD0N
-        BKzlLqlrbH+iRAL4cYGeeWv+vpwR9yy6x///C+Pu2n/8vzAGJfwDM+QlhBkSjK0AAAAASUVORK5CYII=
-</value>
-  </data>
   <data name="BtnImportSettings.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
@@ -1326,6 +1293,39 @@
         exXq3y+2Gltja2yNrbH9B61Jk/8DRiojGazO+nIAAAAASUVORK5CYII=
 </value>
   </data>
+  <data name="PictureBox8.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAJkAAAAPCAYAAAD3Y23kAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAACwwAAAsMAT9AIsgAAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQffAhAMDgicJ1x9
+        AAAAHWlUWHRDb21tZW50AAAAAABDcmVhdGVkIHdpdGggR0lNUGQuZQcAAAYSSURBVGhD7Zp/TJVlFMeN
+        zNEojOaulrasmencylk2LP5IzdBaLLQf2vyRxbAIClmk9ppcQPGKoqZ4hdC4QxTBTdESYU5FEST5lfxK
+        CoVIjQzNtgv33hfn2znvvY97eHre933A3evWOttnD/ec55znPOf9Apc7BoFJgHmAJAB3w3i93Al307w1
+        f97+O0HPePsJao9Sw9VeuanrptIfGv/svUUKGBjvYCOmAnpm5vU0ELCWu6SuPQsMVAwTAD3z1vx9OSPu
+        WXSPUs0V2e7v758kytwPY7ZXd4qLrPaPm4oo+0rPlUKOoch4ucj+8qZTdK8TnpucWtPZ6+DtRbCWu6Su
+        ffp1zoH9Nb/3yrwaWqRk7CmAXEOReWn+vpyRehZdk+0xvuKyy44r8DCDHzCY8T0VviDSWn5ZFhbZmSu9
+        iii5J+qERMbLrbgk94x8YsxaiE8HsPcAYPk335UV8/YjWAswsoSyDsc1Xr4eSdZcEZHR88eejRguOH9f
+        zkg9C1eA26N0okO2T3/z3S004CcJo4NMptV0LG7tttzjHbcLTDLAXPpbryJK9tHbIuPVInBrWg+eLobY
+        MoD+pgj2DwhIOtbu6OLlQBzvyTuDxoz35eXrsSpdFRmvHk388V9viwwtFMC5ahIGD5Cav5b5ckbqWbgC
+        aCa2R6m4zSWXtMsKzX3wIw9iqsgivrTY2PiRNhcWMKfkHDmkBcYROm93ZXs1by/hrYi4TJG6dE2k6ILj
+        RmBQUDLEpgCvz41aHmV6dFQ4fI1DiFmamrWHzUGwFu8MAsYROsfoDoQXQ8M3i9QvvujsIzLbyZYKnK8R
+        sFdXZHTPiDdnRPYBaKbX3ou00j1KB1td8qELskJDi+z95RYbGy9sdYuM9dNg3GgPy9Yi9SeZYV3WtzKr
+        8AD4lwL4633Ft+Vtlck5Jej7BHgaMBc0/HWRzUM/66PBuNEelsJfXDczT5yvEMnFeGFrX5GNnxyyPhQe
+        khaxG7L3euavKzL2LG/OiKwAmgn7pHuU8s875X0/uxQaWmTzv7DY2Hh+i1MVGeunwbjRHpa0w7WqyHgx
+        AhvPa7J3+vn5JYJ/IjD4oWEjVhW0OB15zfar8DoauAdYGDr/o+3YN50LfqE7FLQ47Ly4HjPmRlhF6udD
+        bViJyB4ATDqMw7qe+euKjD7H2zMiK4BmYnuUcpqccu5PLoWGFtm8zy02Nr6r2S0y1k+DcaM9LJaDbpHx
+        YgQ2/kGSdTf4PgZwUIPvDxy68vkZs1ORe4cMifH4hwMJW062VdO54BO5Q3xqUUOZrdHeZQSdG5Vq2ytS
+        f1dTH5HNAfDBaDINHqBn/vhay3w6I7ICaCa2R2lHvUPe2ehUaGiRvQ0iY+OQo4pMBDpvbVFzeVzW4UNa
+        vLooVn1PZgSpZ6263u7xjQWGASM0GAq88eTE4PU7GhxOkg++f9XmweuVB6mLRKbm4Bt/bj2arPqePiLb
+        XHapHudrBOzVFRnpwxczovahmV5+J8JK9yil1zlk6zlohoIWWXicxcbGt9UZXpKYmc7bWtf9d3qtvUuL
+        uOxjRZBj+BEGqTdryYoseL0YeAT9wWEL0qfNj86gmfDSzI0Qw4eIf66vWLan/CjJxxzAyPrcQZSFyVl5
+        kGv4EUb6j31FNn7KjLQQeEhaLFqzc6/A/H05I/UsXN0vB5mwT7pHaWN1j7y5xqHQeET2IDA+7LM1Nja+
+        qapHWGRsrh7L8quFPifDvSmlV5rxa2AUsHjqgthMuMsttubG6m77yLHPrIM9s4EQ/8Cg5LSz9usY8+Qb
+        Wb/uQJi5ZNVOyB3nLqFp8ZuquonI8P1YIMB7L0YYN2VOhFVg/r6ckXoWrgDeYTTbo2T5oUded9ah0Ix5
+        4ZW0xyeFbEDmJdry2bilUlxkbK4esXliIoOelVnRKdmkRyT51LV2Xk3kq5KOc/TeyIyS79GPtdwlda1f
+        d0DWnL5xOSBo2GrIfcxdQtMkS2W3ne7NCLy3wPx9OSN1PnQu26OUWNEtJ53pUfpDYnm3sMgGgKHIeD0N
+        BKzlLqlrbH+iRAL4cYGeeWv+vpwR9yy6x///C+Pu2n/8vzAGJfwDM+QlhBkSjK0AAAAASUVORK5CYII=
+</value>
+  </data>
   <data name="Label51.Text" xml:space="preserve">
     <value>Select a Video Tease Type and Script, then click the "Load Script" button. This will load all relevant lines from the selected script. Add as many new taunts or comments as you wish, entering a new line for each one just as you would in a word processor. You may also delete any existing lines. Once you are satisfied with your changes, click the "Save Changes" button to overwrite the script file on your computer. To start over without saving, click the "Clear Text" button.  </value>
   </data>
@@ -1609,8 +1609,5 @@ Local Images - Select which genres and paths you would like to use for local ima
   </metadata>
   <metadata name="TTDir.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>1479, 17</value>
-  </metadata>
-  <metadata name="BWURLFiles.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
   </metadata>
 </root>

--- a/Tease AI/Form2.vb
+++ b/Tease AI/Form2.vb
@@ -1,12 +1,5 @@
 ﻿Imports System.IO
-Imports System.Xml
-
-Imports System.Drawing.Font
-Imports System.Drawing.FontFamily
-Imports System.Drawing.FontConverter
 Imports System.Speech.Synthesis
-Imports System.Net
-Imports System.Text
 Imports System.Threading
 Imports Tease_AI.URL_Files
 
@@ -610,7 +603,6 @@ Public Class FrmSettings
 			Debug.Print("Form2 Orgasm Lock Date = " & My.Settings.OrgasmLockDate)
 			If Form1.CompareDates(My.Settings.OrgasmLockDate) <= 0 Then
 				My.Settings.OrgasmsLocked = False
-				My.Settings.Save()
 			Else
 				limitcheckbox.Checked = True
 				limitcheckbox.Enabled = False
@@ -734,33 +726,6 @@ Public Class FrmSettings
 
 		NBTauntEdging.Value = My.Settings.TauntEdging
 
-		LBLURLHardcore.Text = My.Settings.HardcoreURLFile
-		LBLURLSoftcore.Text = My.Settings.SoftcoreURLFile
-		LBLURLLesbian.Text = My.Settings.LesbianURLFile
-		LBLURLBlowjob.Text = My.Settings.BlowjobURLFile
-		LBLURLFemdom.Text = My.Settings.FemdomURLFile
-		LBLURLLezdom.Text = My.Settings.LezdomURLFile
-		LBLURLHentai.Text = My.Settings.HentaiURLFile
-		LBLURLGay.Text = My.Settings.GayURLFile
-		LBLURLMaledom.Text = My.Settings.MaledomURLFile
-		LBLURLCaptions.Text = My.Settings.CaptionsURLFile
-		LBLURLGeneral.Text = My.Settings.GeneralURLFile
-
-		CBURLHardcore.Checked = My.Settings.CBURLHardcore
-		CBURLSoftcore.Checked = My.Settings.CBURLSoftcore
-		CBURLLesbian.Checked = My.Settings.CBURLLesbian
-		CBURLBlowjob.Checked = My.Settings.CBURLBlowjob
-		CBURLFemdom.Checked = My.Settings.CBURLFemdom
-		CBURLLezdom.Checked = My.Settings.CBURLLezdom
-		CBURLHentai.Checked = My.Settings.CBURLHentai
-		CBURLGay.Checked = My.Settings.CBURLGay
-		CBURLMaledom.Checked = My.Settings.CBURLMaledom
-		CBURLCaptions.Checked = My.Settings.CBURLCaptions
-		CBURLGeneral.Checked = My.Settings.CBURLGeneral
-
-		CBURLButts.Checked = My.Settings.CBURLButts
-		CBURLBoobs.Checked = My.Settings.CBURLBoobs
-
 		CBURLPreview.Checked = My.Settings.CBURLPreview
 
 		TypesSpeedVal.Text = TypeSpeedSlider.Value
@@ -882,7 +847,6 @@ Public Class FrmSettings
 
 	Private Sub CockSizeNumBox_LostFocus(sender As System.Object, e As System.EventArgs) Handles CockSizeNumBox.LostFocus
 		My.Settings.SubCockSize = CockSizeNumBox.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub BTNVideoHardCore_Click(sender As System.Object, e As System.EventArgs) Handles BTNVideoHardCore.Click
@@ -891,7 +855,6 @@ Public Class FrmSettings
 			LblVideoHardCore.Text = FolderBrowserDialog1.SelectedPath
 			Form1.HardCoreVideoTotal()
 			My.Settings.VideoHardcore = LblVideoHardCore.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -902,7 +865,6 @@ Public Class FrmSettings
 			LblVideoSoftCore.Text = FolderBrowserDialog1.SelectedPath
 			Form1.SoftcoreVideoTotal()
 			My.Settings.VideoSoftcore = LblVideoSoftCore.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -913,7 +875,6 @@ Public Class FrmSettings
 			LblVideoLesbian.Text = FolderBrowserDialog1.SelectedPath
 			Form1.LesbianVideoTotal()
 			My.Settings.VideoLesbian = LblVideoLesbian.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -924,7 +885,6 @@ Public Class FrmSettings
 			LblVideoBlowjob.Text = FolderBrowserDialog1.SelectedPath
 			Form1.BlowjobVideoTotal()
 			My.Settings.VideoBlowjob = LblVideoBlowjob.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -935,7 +895,6 @@ Public Class FrmSettings
 			LblVideoFemdom.Text = FolderBrowserDialog1.SelectedPath
 			Form1.FemdomVideoTotal()
 			My.Settings.VideoFemdom = LblVideoFemdom.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -946,7 +905,6 @@ Public Class FrmSettings
 			LblVideoFemsub.Text = FolderBrowserDialog1.SelectedPath
 			Form1.FemsubVideoTotal()
 			My.Settings.VideoFemsub = LblVideoFemsub.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -957,7 +915,6 @@ Public Class FrmSettings
 			LblVideoJOI.Text = FolderBrowserDialog1.SelectedPath
 			Form1.JOIVideoTotal()
 			My.Settings.VideoJOI = LblVideoJOI.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -968,7 +925,6 @@ Public Class FrmSettings
 			LblVideoCH.Text = FolderBrowserDialog1.SelectedPath
 			Form1.CHVideoTotal()
 			My.Settings.VideoCH = LblVideoCH.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -979,7 +935,6 @@ Public Class FrmSettings
 			LblVideoGeneral.Text = FolderBrowserDialog1.SelectedPath
 			Form1.GeneralVideoTotal()
 			My.Settings.VideoGeneral = LblVideoGeneral.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -990,7 +945,6 @@ Public Class FrmSettings
 			LblVideoHardCoreD.Text = FolderBrowserDialog1.SelectedPath
 			Form1.HardcoreDVideoTotal()
 			My.Settings.VideoHardcoreD = LblVideoHardCoreD.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -1001,7 +955,6 @@ Public Class FrmSettings
 			LblVideoSoftCoreD.Text = FolderBrowserDialog1.SelectedPath
 			Form1.SoftcoreDVideoTotal()
 			My.Settings.VideoSoftcoreD = LblVideoSoftCoreD.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -1012,7 +965,6 @@ Public Class FrmSettings
 			LblVideoLesbianD.Text = FolderBrowserDialog1.SelectedPath
 			Form1.LesbianDVideoTotal()
 			My.Settings.VideoLesbianD = LblVideoLesbianD.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -1023,7 +975,6 @@ Public Class FrmSettings
 			LblVideoBlowjobD.Text = FolderBrowserDialog1.SelectedPath
 			Form1.BlowjobDVideoTotal()
 			My.Settings.VideoBlowjobD = LblVideoBlowjobD.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -1034,7 +985,6 @@ Public Class FrmSettings
 			LblVideoFemdomD.Text = FolderBrowserDialog1.SelectedPath
 			Form1.FemdomDVideoTotal()
 			My.Settings.VideoFemdomD = LblVideoFemdomD.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -1045,7 +995,6 @@ Public Class FrmSettings
 			LblVideoFemsubD.Text = FolderBrowserDialog1.SelectedPath
 			Form1.FemsubDVideoTotal()
 			My.Settings.VideoFemsubD = LblVideoFemsubD.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -1056,7 +1005,6 @@ Public Class FrmSettings
 			LblVideoJOID.Text = FolderBrowserDialog1.SelectedPath
 			Form1.JOIDVideoTotal()
 			My.Settings.VideoJOID = LblVideoJOID.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -1067,7 +1015,6 @@ Public Class FrmSettings
 			LblVideoCHD.Text = FolderBrowserDialog1.SelectedPath
 			Form1.CHDVideoTotal()
 			My.Settings.VideoCHD = LblVideoCHD.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -1078,7 +1025,6 @@ Public Class FrmSettings
 			LblVideoGeneralD.Text = FolderBrowserDialog1.SelectedPath
 			Form1.GeneralDVideoTotal()
 			My.Settings.VideoGeneralD = LblVideoGeneralD.Text
-			My.Settings.Save()
 		End If
 
 	End Sub
@@ -1090,7 +1036,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBHardcore = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBVideoSoftCore_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBVideoSoftCore.CheckedChanged
@@ -1099,7 +1044,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBSoftcore = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBVideoLesbian_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBVideoLesbian.CheckedChanged
@@ -1108,7 +1052,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBLesbian = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBVideoBlowjob_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBVideoBlowjob.CheckedChanged
@@ -1117,7 +1060,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBBlowjob = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBVideoFemdom_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBVideoFemdom.CheckedChanged
@@ -1126,7 +1068,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBFemdom = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBVideoFemSub_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBVideoFemsub.CheckedChanged
@@ -1135,7 +1076,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBFemsub = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBVideoJOI_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBVideoJOI.CheckedChanged
@@ -1144,7 +1084,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBJOI = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBVideoCH_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBVideoCH.CheckedChanged
@@ -1153,7 +1092,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBCH = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBVideoGeneral_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBVideoGeneral.CheckedChanged
@@ -1162,7 +1100,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBGeneral = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 
@@ -1172,7 +1109,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBHardcoreD = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBVideoSoftcoreD_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBVideoSoftCoreD.CheckedChanged
@@ -1181,7 +1117,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBSoftcoreD = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBVideoLesbianD_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBVideoLesbianD.CheckedChanged
@@ -1190,7 +1125,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBLesbianD = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBVideoBlowjobD_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBVideoBlowjobD.CheckedChanged
@@ -1199,7 +1133,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBBlowjobD = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBVideoFemdomD_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBVideoFemdomD.CheckedChanged
@@ -1208,7 +1141,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBFemdomD = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBVideoFemsubD_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBVideoFemsubD.CheckedChanged
@@ -1217,7 +1149,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBFemsubD = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBVideoJOID_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBVideoJOID.CheckedChanged
@@ -1226,7 +1157,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBJOID = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBVideoCHD_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBVideoCHD.CheckedChanged
@@ -1235,7 +1165,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBCHD = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBVideoGeneralD_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBVideoGeneralD.CheckedChanged
@@ -1244,29 +1173,24 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBGeneralD = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 
 	Private Sub NBCensorShowMin_Leave(sender As System.Object, e As System.EventArgs) Handles NBCensorShowMin.Leave
 		My.Settings.NBCensorShowMin = NBCensorShowMin.Value
-		My.Settings.Save()
 		Debug.Print(My.Settings.NBCensorShowMin & " " & NBCensorShowMin.Value)
 	End Sub
 
 	Private Sub NBCensorShowMax_Leave(sender As System.Object, e As System.EventArgs) Handles NBCensorShowMax.Leave
 		My.Settings.NBCensorShowMax = NBCensorShowMax.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBCensorHideMin_Leave(sender As System.Object, e As System.EventArgs) Handles NBCensorHideMin.Leave
 		My.Settings.NBCensorHideMin = NBCensorHideMin.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBCensorHideMax_Leave(sender As System.Object, e As System.EventArgs) Handles NBCensorHideMax.Leave
 		My.Settings.NBCensorHideMax = NBCensorHideMax.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBCensorConstant_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBCensorConstant.CheckedChanged
@@ -1275,7 +1199,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBCensorConstant = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Public Function Color2Html(ByVal MyColor As Color) As String
@@ -1283,13 +1206,6 @@ Public Class FrmSettings
 	End Function
 
 #Region "Glitter"
-	Private Sub GlitterAV_Click(sender As System.Object, e As System.EventArgs)
-		If OpenFileDialog1.ShowDialog() = DialogResult.OK Then
-			GlitterAV.Image = Image.FromFile(OpenFileDialog1.FileName)
-			My.Settings.GlitterAV = OpenFileDialog1.FileName
-			My.Settings.Save()
-		End If
-	End Sub
 	Private Sub GlitterAV_Click_1(sender As System.Object, e As System.EventArgs) Handles GlitterAV.Click
 		If OpenFileDialog1.ShowDialog() = DialogResult.OK Then
 			Try
@@ -1300,7 +1216,6 @@ Public Class FrmSettings
 			GC.Collect()
 			GlitterAV.Image = Image.FromFile(OpenFileDialog1.FileName)
 			My.Settings.GlitterAV = OpenFileDialog1.FileName
-			My.Settings.Save()
 		End If
 	End Sub
 	Private Sub GlitterAV1_Click(sender As System.Object, e As System.EventArgs) Handles GlitterAV1.Click
@@ -1313,7 +1228,6 @@ Public Class FrmSettings
 			GC.Collect()
 			GlitterAV1.Image = Image.FromFile(OpenFileDialog1.FileName)
 			My.Settings.GlitterAV1 = OpenFileDialog1.FileName
-			My.Settings.Save()
 		End If
 	End Sub
 	Private Sub GlitterAV2_Click(sender As System.Object, e As System.EventArgs) Handles GlitterAV2.Click
@@ -1326,7 +1240,6 @@ Public Class FrmSettings
 			GC.Collect()
 			GlitterAV2.Image = Image.FromFile(OpenFileDialog1.FileName)
 			My.Settings.GlitterAV2 = OpenFileDialog1.FileName
-			My.Settings.Save()
 		End If
 	End Sub
 	Private Sub GlitterAV3_Click(sender As System.Object, e As System.EventArgs) Handles GlitterAV3.Click
@@ -1339,7 +1252,6 @@ Public Class FrmSettings
 			GC.Collect()
 			GlitterAV3.Image = Image.FromFile(OpenFileDialog1.FileName)
 			My.Settings.GlitterAV3 = OpenFileDialog1.FileName
-			My.Settings.Save()
 		End If
 	End Sub
 	Private Sub Button35_Click(sender As System.Object, e As System.EventArgs) Handles BTNGlitterD.Click
@@ -1348,7 +1260,6 @@ Public Class FrmSettings
 			LBLGlitterNCDomme.ForeColor = GetColor.Color
 			Form1.GlitterNCDomme = Color2Html(GetColor.Color)
 			My.Settings.GlitterNCDomme = Form1.GlitterNCDomme
-			My.Settings.Save()
 			Debug.Print("GlitterNCDomme = " & Form1.GlitterNCDomme)
 		End If
 	End Sub
@@ -1358,7 +1269,6 @@ Public Class FrmSettings
 			LBLGlitterNC1.ForeColor = GetColor.Color
 			Form1.GlitterNC1 = Color2Html(GetColor.Color)
 			My.Settings.GlitterNC1 = Form1.GlitterNC1
-			My.Settings.Save()
 			Debug.Print("GlitterNC1 = " & Form1.GlitterNC1)
 		End If
 	End Sub
@@ -1368,7 +1278,6 @@ Public Class FrmSettings
 			LBLGlitterNC2.ForeColor = GetColor.Color
 			Form1.GlitterNC2 = Color2Html(GetColor.Color)
 			My.Settings.GlitterNC2 = Form1.GlitterNC2
-			My.Settings.Save()
 			Debug.Print("GlitterNC2 = " & Form1.GlitterNC2)
 		End If
 	End Sub
@@ -1378,49 +1287,32 @@ Public Class FrmSettings
 			LBLGlitterNC3.ForeColor = GetColor.Color
 			Form1.GlitterNC3 = Color2Html(GetColor.Color)
 			My.Settings.GlitterNC3 = Form1.GlitterNC3
-			My.Settings.Save()
 			Debug.Print("GlitterNC3 = " & Form1.GlitterNC3)
 		End If
 	End Sub
 	Private Sub TBGlitterShortName_TextChanged(sender As System.Object, e As System.EventArgs) Handles TBGlitterShortName.Leave
 		My.Settings.GlitterSN = TBGlitterShortName.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub TBGlitter1_TextChanged(sender As System.Object, e As System.EventArgs) Handles TBGlitter1.Leave
 		My.Settings.Glitter1 = TBGlitter1.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub TBGlitter2_TextChanged(sender As System.Object, e As System.EventArgs) Handles TBGlitter2.Leave
 		My.Settings.Glitter2 = TBGlitter2.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub TBGlitter3_TextChanged(sender As System.Object, e As System.EventArgs) Handles TBGlitter3.Leave
 		My.Settings.Glitter3 = TBGlitter3.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub GlitterSlider_Scroll(sender As System.Object, e As System.EventArgs) Handles GlitterSlider.Scroll
 		My.Settings.GlitterDSlider = GlitterSlider.Value
-		My.Settings.Save()
 	End Sub
 	Private Sub GlitterSlider1_Scroll(sender As System.Object, e As System.EventArgs) Handles GlitterSlider1.Scroll
 		My.Settings.Glitter1Slider = GlitterSlider1.Value
-		My.Settings.Save()
 	End Sub
 	Private Sub GlitterSlider2_Scroll(sender As System.Object, e As System.EventArgs) Handles GlitterSlider2.Scroll
 		My.Settings.Glitter2Slider = GlitterSlider2.Value
-		My.Settings.Save()
 	End Sub
 	Private Sub GlitterSlider3_Scroll(sender As System.Object, e As System.EventArgs) Handles GlitterSlider3.Scroll
 		My.Settings.Glitter3Slider = GlitterSlider3.Value
-		My.Settings.Save()
-	End Sub
-	Private Sub CBGlitterFeed_CheckedChanged(sender As System.Object, e As System.EventArgs)
-		If CBGlitterFeed.Checked = True Then
-			My.Settings.CBGlitterFeed = True
-		Else
-			My.Settings.CBGlitterFeed = False
-		End If
-		My.Settings.Save()
 	End Sub
 	Private Sub CBGlitter1_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBGlitter1.CheckedChanged
 		If CBGlitter1.Checked = True Then
@@ -1428,7 +1320,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBGlitter1 = False
 		End If
-		My.Settings.Save()
 	End Sub
 	Private Sub CBGlitter2_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBGlitter2.CheckedChanged
 		If CBGlitter2.Checked = True Then
@@ -1436,7 +1327,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBGlitter2 = False
 		End If
-		My.Settings.Save()
 	End Sub
 	Private Sub CBGlitter3_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBGlitter3.CheckedChanged
 		If CBGlitter3.Checked = True Then
@@ -1444,7 +1334,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBGlitter3 = False
 		End If
-		My.Settings.Save()
 	End Sub
 	Private Sub CBTease_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBTease.CheckedChanged
 		If CBTease.Checked = True Then
@@ -1452,7 +1341,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBTease = False
 		End If
-		My.Settings.Save()
 	End Sub
 	Private Sub CBEgotist_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBEgotist.CheckedChanged
 		If CBEgotist.Checked = True Then
@@ -1460,7 +1348,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBEgotist = False
 		End If
-		My.Settings.Save()
 	End Sub
 	Private Sub CBTrivia_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBTrivia.CheckedChanged
 		If CBTrivia.Checked = True Then
@@ -1468,7 +1355,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBTrivia = False
 		End If
-		My.Settings.Save()
 	End Sub
 	Private Sub CBDaily_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBDaily.CheckedChanged
 		If CBDaily.Checked = True Then
@@ -1476,7 +1362,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBDaily = False
 		End If
-		My.Settings.Save()
 	End Sub
 	Private Sub CBCustom1_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBCustom1.CheckedChanged
 		If CBCustom1.Checked = True Then
@@ -1484,7 +1369,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBCustom1 = False
 		End If
-		My.Settings.Save()
 	End Sub
 	Private Sub CBCustom2_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBCustom2.CheckedChanged
 		If CBCustom2.Checked = True Then
@@ -1492,7 +1376,6 @@ Public Class FrmSettings
 		Else
 			My.Settings.CBCustom2 = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 
@@ -1616,26 +1499,6 @@ Public Class FrmSettings
 	End Sub
 #End Region
 
-	Private Sub Button21_Click(sender As System.Object, e As System.EventArgs)
-
-		Form1.ScriptTimer.Start()
-
-		' Dim TestString As String
-		'Dim TSStartIndex As Integer
-		'Dim TSEndIndex As Integer
-
-		'TSStartIndex = TextBox3.Text.IndexOf("@Chance") + 7
-		'TSEndIndex = TextBox3.Text.IndexOf("@Chance") + 9
-
-		'TestString = TextBox3.Text
-		'TestString = TestString.Substring(TSStartIndex, TSEndIndex - TSStartIndex).Trim
-
-		'        Dim TestVal As Integer
-
-		' TestVal = Val(TestString)
-
-		'Debug.Print("Check Substring " & TestString & " , " & TestVal)
-	End Sub
 
 
 
@@ -1649,40 +1512,32 @@ Public Class FrmSettings
 
 	Private Sub NBTeaseLengthMin_LostFocus(sender As Object, e As System.EventArgs) Handles NBTeaseLengthMin.LostFocus
 		My.Settings.TeaseLengthMin = NBTeaseLengthMin.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBTeaseLengthMax_LostFocus(sender As Object, e As System.EventArgs) Handles NBTeaseLengthMax.LostFocus
 		My.Settings.TeaseLengthMax = NBTeaseLengthMax.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBTauntCycleMin_LostFocus(sender As Object, e As System.EventArgs) Handles NBTauntCycleMin.LostFocus
 		My.Settings.TauntCycleMin = NBTauntCycleMin.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBTauntCycleMax_LostFocus(sender As Object, e As System.EventArgs) Handles NBTauntCycleMax.LostFocus
 		My.Settings.TauntCycleMax = NBTauntCycleMax.Value
-		My.Settings.Save()
 	End Sub
 	Private Sub NBRedLightMin_LostFocus(sender As Object, e As System.EventArgs) Handles NBRedLightMin.LostFocus
 		My.Settings.RedLightMin = NBRedLightMin.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBRedLightMax_LostFocus(sender As Object, e As System.EventArgs) Handles NBRedLightMax.LostFocus
 		My.Settings.RedLightMax = NBRedLightMax.Value
-		My.Settings.Save()
 	End Sub
 	Private Sub NBGreenLightMin_LostFocus(sender As Object, e As System.EventArgs) Handles NBGreenLightMin.LostFocus
 		My.Settings.GreenLightMin = NBGreenLightMin.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBGreenLightMax_LostFocus(sender As Object, e As System.EventArgs) Handles NBGreenLightMax.LostFocus
 		My.Settings.GreenLightMax = NBGreenLightMax.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBTeaseLengthMin_ValueChanged(sender As System.Object, e As System.EventArgs) Handles NBTeaseLengthMin.ValueChanged
@@ -1911,7 +1766,6 @@ Public Class FrmSettings
 		My.Settings.pnSetting7 = petnameBox7.Text
 		My.Settings.pnSetting8 = petnameBox8.Text
 
-		My.Settings.Save()
 
 	End Sub
 
@@ -2632,11 +2486,6 @@ trypreviousimage:
 		WebPictureBox.Focus()
 	End Sub
 
-	Private Sub Button32_Click_1(sender As System.Object, e As System.EventArgs)
-		Form1.GetBlogImage()
-
-	End Sub
-
 	Private Sub SliderSTF_Scroll(sender As System.Object, e As System.EventArgs) Handles SliderSTF.Scroll
 		If SliderSTF.Value = 1 Then LBLStf.Text = "Preoccupied"
 		If SliderSTF.Value = 2 Then LBLStf.Text = "Distracted"
@@ -2659,13 +2508,11 @@ trypreviousimage:
 
 	Private Sub TauntSlider_LostFocus(sender As System.Object, e As System.EventArgs) Handles TauntSlider.LostFocus
 		My.Settings.TimerVTF = TauntSlider.Value
-		My.Settings.Save()
 
 	End Sub
 
 	Private Sub SliderSTF_LostFocus(sender As System.Object, e As System.EventArgs) Handles SliderSTF.LostFocus
 		My.Settings.TimerSTF = SliderSTF.Value
-		My.Settings.Save()
 
 	End Sub
 
@@ -2676,7 +2523,6 @@ trypreviousimage:
 			LBLDomColor.ForeColor = GetColor.Color
 			Form1.DomColor = Color2Html(GetColor.Color)
 			My.Settings.DomColor = Form1.DomColor
-			My.Settings.Save()
 		End If
 
 
@@ -2689,23 +2535,10 @@ trypreviousimage:
 			LBLSubColor.ForeColor = GetColor.Color
 			Form1.SubColor = Color2Html(GetColor.Color)
 			My.Settings.SubColor = Form1.SubColor
-			My.Settings.Save()
 		End If
 
 	End Sub
 
-	Private Sub Button39_Click(sender As System.Object, e As System.EventArgs)
-		Form1.StrokePaceInt = 1
-		Form1.StrokePaceRight = True
-
-		If Form1.StrokePaceTimer.Enabled = True Then
-			Form1.StopMetronome = True
-			Form1.StrokePaceTimer.Stop()
-		Else
-			Form1.StopMetronome = False
-			Form1.StrokePaceTimer.Start()
-		End If
-	End Sub
 
 
 
@@ -2718,7 +2551,6 @@ trypreviousimage:
 		Else
 			My.Settings.CBTimeStamps = False
 		End If
-		My.Settings.Save()
 
 
 
@@ -2732,7 +2564,6 @@ trypreviousimage:
 		Else
 			My.Settings.CBShowNames = False
 		End If
-		My.Settings.Save()
 
 	End Sub
 
@@ -2743,7 +2574,6 @@ trypreviousimage:
 		Else
 			My.Settings.CBInstantType = False
 		End If
-		My.Settings.Save()
 
 
 	End Sub
@@ -2755,7 +2585,6 @@ trypreviousimage:
 		Else
 			My.Settings.CBWebtease = False
 		End If
-		My.Settings.Save()
 
 
 	End Sub
@@ -2766,7 +2595,6 @@ trypreviousimage:
 		Else
 			My.Settings.CBBlogImageMain = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub landscapeCheckBox_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles landscapeCheckBox.MouseClick
@@ -2775,7 +2603,6 @@ trypreviousimage:
 		Else
 			My.Settings.CBStretchLandscape = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBSettingsPause_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBSettingsPause.MouseClick
@@ -2784,7 +2611,6 @@ trypreviousimage:
 		Else
 			My.Settings.CBSettingsPause = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub timestampCheckBox_CheckedChanged_1(sender As System.Object, e As System.EventArgs) Handles timestampCheckBox.MouseHover
@@ -2972,7 +2798,6 @@ trypreviousimage:
 		If teaseRadio.Checked = True Then My.Settings.SlideshowMode = "Tease"
 		If timedRadio.Checked = True Then My.Settings.SlideshowMode = "Timed"
 		If offRadio.Checked = True Then My.Settings.SlideshowMode = "Manual"
-		My.Settings.Save()
 	End Sub
 
 	Private Sub teaseRadio_MouseHover(sender As System.Object, e As System.EventArgs) Handles teaseRadio.MouseHover
@@ -2996,11 +2821,6 @@ trypreviousimage:
 	End Sub
 
 
-	' Private Sub CBMetronome_CheckedChanged_1(sender As System.Object, e As System.EventArgs)
-	' LBLGeneralSettingsDescription.Text = "When this is selected, the silent metronome located above the sub avatar will activate any time you are instructed to stroke."
-
-	' If RBGerman.Checked = True Then LBLGeneralSettingsDescription.Text = ""
-	' End Sub
 
 	Private Sub CBSettingsPause_CheckedChanged_1(sender As System.Object, e As System.EventArgs) Handles CBSettingsPause.MouseHover
 
@@ -3100,7 +2920,6 @@ trypreviousimage:
 
 	Private Sub domlevelNumBox_LostFocus(sender As System.Object, e As System.EventArgs) Handles domlevelNumBox.LostFocus
 		My.Settings.DomLevel = domlevelNumBox.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub alloworgasmComboBox_SelectedIndexChanged(sender As System.Object, e As System.EventArgs) Handles alloworgasmComboBox.LostFocus
@@ -3108,7 +2927,6 @@ trypreviousimage:
 
 
 		My.Settings.OrgasmAllow = alloworgasmComboBox.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub ruinorgasmComboBox_SelectedIndexChanged(sender As System.Object, e As System.EventArgs) Handles ruinorgasmComboBox.LostFocus
@@ -3116,7 +2934,6 @@ trypreviousimage:
 
 
 		My.Settings.OrgasmRuin = ruinorgasmComboBox.Text
-		My.Settings.Save()
 
 
 
@@ -3129,7 +2946,6 @@ trypreviousimage:
 		Else
 			My.Settings.CBAutosaveChatlog = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBSaveChatlogExit_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBSaveChatlogExit.MouseClick
@@ -3138,7 +2954,6 @@ trypreviousimage:
 		Else
 			My.Settings.CBExitSaveChatlog = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBJackInTheBox_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBAuditStartup.MouseClick
@@ -3147,12 +2962,10 @@ trypreviousimage:
 		Else
 			My.Settings.AuditStartup = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBWritingTaskMin_LostFocus(sender As Object, e As System.EventArgs) Handles NBWritingTaskMin.LostFocus
 		My.Settings.NBWritingTaskMin = NBWritingTaskMin.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBWritingTaskMin_ValueChanged(sender As System.Object, e As System.EventArgs) Handles NBWritingTaskMin.ValueChanged
@@ -3161,22 +2974,10 @@ trypreviousimage:
 
 	Private Sub NBWritingTaskMax_LostFocus(sender As Object, e As System.EventArgs) Handles NBWritingTaskMax.LostFocus
 		My.Settings.NBWritingTaskMax = NBWritingTaskMax.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBWritingTaskMax_ValueChanged(sender As System.Object, e As System.EventArgs) Handles NBWritingTaskMax.ValueChanged
 		If NBWritingTaskMax.Value < NBWritingTaskMin.Value Then NBWritingTaskMax.Value = NBWritingTaskMin.Value
-	End Sub
-
-	Private Sub Button43_Click(sender As System.Object, e As System.EventArgs)
-		'My.Computer.Network.DownloadFile("http://41.media.tumblr.com/71a41fe5e4b0fee012b516e2666465dd/tumblr_njunkf9uGX1rsx7u3o1_1280.jpg", "G:\Anime\Images\Tumblr\Tease AI\Scrape\file.jpg")
-
-		If Form1.TnASlides.Enabled = True Then
-			Form1.TnASlides.Stop()
-			Return
-		End If
-		Form1.TnASlides.Start()
-
 	End Sub
 
 
@@ -3187,15 +2988,6 @@ trypreviousimage:
 		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
 			LBLBoobPath.Text = FolderBrowserDialog1.SelectedPath
 			My.Settings.LBLBoobPath = LBLBoobPath.Text
-			My.Settings.Save()
-		End If
-	End Sub
-
-	Private Sub BTNBoobURL_Click(sender As System.Object, e As System.EventArgs) Handles BTNBoobURL.Click
-		If (WebImageFileDialog.ShowDialog = Windows.Forms.DialogResult.OK) Then
-			LBLBoobURL.Text = WebImageFileDialog.FileName
-			My.Settings.LBLBoobURL = LBLBoobURL.Text
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -3203,38 +2995,22 @@ trypreviousimage:
 		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
 			LBLButtPath.Text = FolderBrowserDialog1.SelectedPath
 			My.Settings.LBLButtPath = LBLButtPath.Text
-			My.Settings.Save()
-		End If
-	End Sub
-
-	Private Sub BTNButtURL_Click(sender As System.Object, e As System.EventArgs) Handles BTNButtURL.Click
-		If (WebImageFileDialog.ShowDialog = Windows.Forms.DialogResult.OK) Then
-			LBLButtURL.Text = WebImageFileDialog.FileName
-			My.Settings.LBLButtURL = LBLButtURL.Text
-			My.Settings.Save()
 		End If
 	End Sub
 
 	Private Sub CBBoobSubDir_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBBoobSubDir.CheckedChanged
 		If CBBoobSubDir.Checked = True Then
 			My.Settings.CBBoobSubDir = True
-			My.Settings.Save()
 		End If
 	End Sub
 
 	Private Sub CBButtSubDir_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBButtSubDir.CheckedChanged
 		If CBButtSubDir.Checked = True Then
 			My.Settings.CBButtSubDir = True
-			My.Settings.Save()
 		End If
 	End Sub
 
 
-
-	Private Sub Button45_Click(sender As System.Object, e As System.EventArgs)
-		Form1.GetBlogImage()
-
-	End Sub
 
 	Private Sub CheckBox6_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBTagBoobs.CheckedChanged
 
@@ -4298,7 +4074,6 @@ trypreviousimage:
 		Else
 			My.Settings.CBSlideshowSubDir = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBSlideshowSubDir_MouseHover(sender As System.Object, e As System.EventArgs) Handles CBSlideshowSubDir.MouseHover
@@ -4327,7 +4102,6 @@ trypreviousimage:
 		Else
 			My.Settings.CBSlideshowRandom = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBSlideshowRandom_MouseHover(sender As System.Object, e As System.EventArgs) Handles CBSlideshowRandom.MouseHover
@@ -4448,7 +4222,6 @@ trypreviousimage:
 
 	Private Sub domageNumBox_LostFocus(sender As System.Object, e As System.EventArgs) Handles domageNumBox.LostFocus
 		My.Settings.DomAge = domageNumBox.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub domageNumBox_MouseHover(sender As Object, e As System.EventArgs) Handles domageNumBox.MouseHover
@@ -4495,7 +4268,6 @@ trypreviousimage:
 
 	Private Sub TBDomHairColor_LostFocus(sender As System.Object, e As System.EventArgs) Handles TBDomHairColor.LostFocus
 		My.Settings.DomHair = TBDomHairColor.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub domhairComboBox_MouseHover(sender As System.Object, e As System.EventArgs) Handles TBDomHairColor.MouseHover
@@ -4508,7 +4280,6 @@ trypreviousimage:
 
 	Private Sub domhairlengthComboBox_LostFocus(sender As System.Object, e As System.EventArgs) Handles domhairlengthComboBox.LostFocus
 		My.Settings.DomHairLength = domhairlengthComboBox.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub domhairlengthComboBox_MouseHover(sender As System.Object, e As System.EventArgs) Handles domhairlengthComboBox.MouseHover
@@ -4521,7 +4292,6 @@ trypreviousimage:
 
 	Private Sub TBDomEyeColor_LostFocus(sender As System.Object, e As System.EventArgs) Handles TBDomEyeColor.LostFocus
 		My.Settings.DomEyes = TBDomEyeColor.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub domeyesComboBox_MouseHover(sender As System.Object, e As System.EventArgs) Handles TBDomEyeColor.MouseHover
@@ -4534,7 +4304,6 @@ trypreviousimage:
 
 	Private Sub boobComboBox_LostFocus(sender As System.Object, e As System.EventArgs) Handles boobComboBox.LostFocus
 		My.Settings.DomCup = boobComboBox.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub boobComboBox_MouseHover(sender As System.Object, e As System.EventArgs) Handles boobComboBox.MouseHover
@@ -4547,7 +4316,6 @@ trypreviousimage:
 
 	Private Sub dompubichairComboBox_LostFocus(sender As System.Object, e As System.EventArgs) Handles dompubichairComboBox.LostFocus
 		My.Settings.DomPubicHair = dompubichairComboBox.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub dompubichairComboBox_MouseHover(sender As System.Object, e As System.EventArgs) Handles dompubichairComboBox.MouseHover
@@ -4558,10 +4326,6 @@ trypreviousimage:
 		'  "of the slideshow model's pubic hair to enhance immersion."
 	End Sub
 
-	' Private Sub dompersonalityComboBox_MouseHover(sender As System.Object, e As System.EventArgs)
-	' LblDommeSettingsDescription.Text = "Sets the Domme's personality to a type you have created or downloaded." & Environment.NewLine & Environment.NewLine & "Different personalities allow for varied experiences while using " & _
-	'     "this program. For best results, this value should only be changed before greeting the domme."
-	' End Sub
 
 	Private Sub crazyCheckBox_LostFocus(sender As System.Object, e As System.EventArgs) Handles crazyCheckBox.LostFocus
 		If crazyCheckBox.Checked = True Then
@@ -4569,7 +4333,6 @@ trypreviousimage:
 		Else
 			My.Settings.DomCrazy = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub crazyCheckBox_MouseHover(sender As System.Object, e As System.EventArgs) Handles crazyCheckBox.MouseHover
@@ -4587,7 +4350,6 @@ trypreviousimage:
 		Else
 			My.Settings.DomTattoos = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBDomTattoos_MouseHover(sender As System.Object, e As System.EventArgs) Handles CBDomTattoos.MouseHover
@@ -4605,7 +4367,6 @@ trypreviousimage:
 		Else
 			My.Settings.DomFreckles = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBDomFreckles_MouseHover(sender As System.Object, e As System.EventArgs) Handles CBDomFreckles.MouseHover
@@ -4622,7 +4383,6 @@ trypreviousimage:
 		Else
 			My.Settings.DomVulgar = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub vulgarCheckBox_MouseHover(sender As System.Object, e As System.EventArgs) Handles vulgarCheckBox.MouseHover
@@ -4640,7 +4400,6 @@ trypreviousimage:
 		Else
 			My.Settings.DomSupremacist = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub supremacistCheckBox_MouseHover(sender As System.Object, e As System.EventArgs) Handles supremacistCheckBox.MouseHover
@@ -4659,7 +4418,6 @@ trypreviousimage:
 		Else
 			My.Settings.DomLowercase = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub alloworgasmComboBox_MouseHover(sender As Object, e As System.EventArgs) Handles alloworgasmComboBox.MouseHover
@@ -4694,7 +4452,6 @@ trypreviousimage:
 		Else
 			My.Settings.DomNoApostrophes = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub apostropheCheckBox_MouseHover(sender As System.Object, e As System.EventArgs) Handles apostropheCheckBox.MouseHover
@@ -4710,7 +4467,6 @@ trypreviousimage:
 		Else
 			My.Settings.DomNoCommas = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub commaCheckBox_MouseHover(sender As System.Object, e As System.EventArgs) Handles commaCheckBox.MouseHover
@@ -4726,7 +4482,6 @@ trypreviousimage:
 		Else
 			My.Settings.DomNoPeriods = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub periodCheckBox_MouseHover(sender As System.Object, e As System.EventArgs) Handles periodCheckBox.MouseHover
@@ -4742,7 +4497,6 @@ trypreviousimage:
 		Else
 			My.Settings.DomMeMyMine = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBMeMyMine_MouseHover(sender As System.Object, e As System.EventArgs) Handles CBMeMyMine.MouseHover
@@ -4752,12 +4506,10 @@ trypreviousimage:
 
 	Private Sub TBEmote_LostFocus(sender As System.Object, e As System.EventArgs) Handles TBEmote.LostFocus
 		My.Settings.TBEmote = TBEmote.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub TBEmoteEnd_LostFocus(sender As System.Object, e As System.EventArgs) Handles TBEmoteEnd.LostFocus
 		My.Settings.TBEmoteEnd = TBEmoteEnd.Text
-		My.Settings.Save()
 	End Sub
 
 
@@ -4776,7 +4528,6 @@ trypreviousimage:
 		Else
 			My.Settings.DomDenialEnd = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBDomDenialEnds_MouseHover(sender As System.Object, e As System.EventArgs) Handles CBDomDenialEnds.MouseHover
@@ -4791,7 +4542,6 @@ trypreviousimage:
 		Else
 			My.Settings.DomOrgasmEnd = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBDomOrgasmEnds_MouseHover(sender As System.Object, e As System.EventArgs) Handles CBDomOrgasmEnds.MouseHover
@@ -4842,7 +4592,6 @@ trypreviousimage:
 
 	Private Sub NBDomMoodMin_LostFocus(sender As System.Object, e As System.EventArgs) Handles NBDomMoodMin.LostFocus
 		My.Settings.DomMoodMin = NBDomMoodMin.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBDomMoodMin_MouseHover(sender As System.Object, e As System.EventArgs) Handles NBDomMoodMin.MouseHover
@@ -4860,7 +4609,6 @@ trypreviousimage:
 
 	Private Sub NBDomMoodMax_LostFocus(sender As System.Object, e As System.EventArgs) Handles NBDomMoodMax.LostFocus
 		My.Settings.DomMoodMax = NBDomMoodMax.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBDomMoodMax_MouseHover(sender As System.Object, e As System.EventArgs) Handles NBDomMoodMax.MouseHover
@@ -4886,7 +4634,6 @@ trypreviousimage:
 
 	Private Sub NBAvgCockMin_LostFocus(sender As System.Object, e As System.EventArgs) Handles NBAvgCockMin.LostFocus
 		My.Settings.AvgCockMin = NBAvgCockMin.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBAvgCockMin_MouseHover(sender As System.Object, e As System.EventArgs) Handles NBAvgCockMin.MouseHover
@@ -4896,7 +4643,6 @@ trypreviousimage:
 
 	Private Sub NBAvgCockMax_LostFocus(sender As System.Object, e As System.EventArgs) Handles NBAvgCockMax.LostFocus
 		My.Settings.AvgCockMax = NBAvgCockMax.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBAvgCockMax_MouseHover(sender As System.Object, e As System.EventArgs) Handles NBAvgCockMax.MouseHover
@@ -4914,7 +4660,6 @@ trypreviousimage:
 
 	Private Sub NBSelfAgeMin_LostFocus(sender As System.Object, e As System.EventArgs) Handles NBSelfAgeMin.LostFocus
 		My.Settings.SelfAgeMin = NBSelfAgeMin.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBSelfAgeMin_Enter(sender As Object, e As System.EventArgs) Handles NBSelfAgeMin.MouseHover
@@ -4926,7 +4671,6 @@ trypreviousimage:
 
 	Private Sub NBSelfAgeMax_LostFocus(sender As System.Object, e As System.EventArgs) Handles NBSelfAgeMax.LostFocus
 		My.Settings.SelfAgeMax = NBSelfAgeMax.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBSelfAgeMax_Enter(sender As Object, e As System.EventArgs) Handles NBSelfAgeMax.MouseHover
@@ -4946,7 +4690,6 @@ trypreviousimage:
 
 	Private Sub NBSubAgeMin_LostFocus(sender As System.Object, e As System.EventArgs) Handles NBSubAgeMin.LostFocus
 		My.Settings.SubAgeMin = NBSubAgeMin.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBSubAgeMin_Enter(sender As Object, e As System.EventArgs) Handles NBSubAgeMin.MouseHover
@@ -4957,7 +4700,6 @@ trypreviousimage:
 
 	Private Sub NBSubAgeMax_LostFocus(sender As System.Object, e As System.EventArgs) Handles NBSubAgeMax.LostFocus
 		My.Settings.SubAgeMax = NBSubAgeMax.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBSubAgeMax_Enter(sender As Object, e As System.EventArgs) Handles NBSubAgeMax.MouseHover
@@ -5034,7 +4776,6 @@ trypreviousimage:
 		Else
 			My.Settings.CBInputIcon = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 
@@ -5233,23 +4974,19 @@ trypreviousimage:
 
 	Private Sub TBGreeting_LostFocus(sender As System.Object, e As System.EventArgs) Handles TBGreeting.LostFocus
 		My.Settings.SubGreeting = TBGreeting.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub TBYes_LostFocus(sender As System.Object, e As System.EventArgs) Handles TBYes.LostFocus
 		My.Settings.SubYes = TBYes.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub TBNo_LostFocus(sender As System.Object, e As System.EventArgs) Handles TBNo.LostFocus
 		My.Settings.SubNo = TBNo.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub TBHonorific_LostFocus(sender As System.Object, e As System.EventArgs) Handles TBHonorific.LostFocus
 		If TBHonorific.Text = "" Or TBHonorific.Text Is Nothing Then TBHonorific.Text = "Mistress"
 		My.Settings.SubHonorific = TBHonorific.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBHonorificInclude_LostFocus(sender As System.Object, e As System.EventArgs) Handles CBHonorificInclude.LostFocus
@@ -5258,7 +4995,6 @@ trypreviousimage:
 		Else
 			My.Settings.CBUseHonor = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBHonorificCapitalized_LostFocus(sender As System.Object, e As System.EventArgs) Handles CBHonorificCapitalized.LostFocus
@@ -5267,43 +5003,35 @@ trypreviousimage:
 		Else
 			My.Settings.CBCapHonor = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub subAgeNumBox_LostFocus(sender As System.Object, e As System.EventArgs) Handles subAgeNumBox.LostFocus
 		My.Settings.SubAge = subAgeNumBox.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBDomBirthdayMonth_LostFocus(sender As System.Object, e As System.EventArgs) Handles NBDomBirthdayMonth.LostFocus
 		My.Settings.DomBirthMonth = NBDomBirthdayMonth.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBDomBirthdayDay_LostFocus(sender As System.Object, e As System.EventArgs) Handles NBDomBirthdayDay.LostFocus
 		My.Settings.DomBirthDay = NBDomBirthdayDay.Value
-		My.Settings.Save()
 	End Sub
 
 
 	Private Sub NBBirthdayMonth_LostFocus(sender As System.Object, e As System.EventArgs) Handles NBBirthdayMonth.LostFocus
 		My.Settings.SubBirthMonth = NBBirthdayMonth.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBBirthdayDay_LostFocus(sender As System.Object, e As System.EventArgs) Handles NBBirthdayDay.LostFocus
 		My.Settings.SubBirthDay = NBBirthdayDay.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub TBSubHairColor_LostFocus(sender As System.Object, e As System.EventArgs) Handles TBSubHairColor.LostFocus
 		My.Settings.SubHair = TBSubHairColor.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub TBSubEyeColor_LostFocus(sender As System.Object, e As System.EventArgs) Handles TBSubEyeColor.LostFocus
 		My.Settings.SubEyes = TBSubEyeColor.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub Button37_Click_1(sender As System.Object, e As System.EventArgs) Handles Button37.Click
@@ -5354,22 +5082,6 @@ trypreviousimage:
 
 	End Sub
 
-	Private Sub ButtonOpenScript_Click(sender As System.Object, e As System.EventArgs)
-
-		If OpenScriptDialog.ShowDialog() = DialogResult.OK Then
-
-			Form1.StrokeTauntVal = -1
-
-			Form1.FileText = OpenScriptDialog.FileName
-			Form1.ScriptTick = 1
-			Form1.ScriptTimer.Start()
-
-
-		End If
-
-
-	End Sub
-
 
 
 	Private Sub timedRadio_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles timedRadio.CheckedChanged
@@ -5393,55 +5105,20 @@ trypreviousimage:
 
 	Private Sub FontComboBoxD_LostFocus(sender As System.Object, e As System.EventArgs) Handles FontComboBoxD.LostFocus
 		My.Settings.DomFont = FontComboBoxD.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub FontComboBox_LostFocus(sender As System.Object, e As System.EventArgs) Handles FontComboBox.LostFocus
 		My.Settings.SubFont = FontComboBox.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBFontSizeD_LostFocus(sender As System.Object, e As System.EventArgs) Handles NBFontSizeD.LostFocus
 		My.Settings.DomFontSize = NBFontSizeD.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBFontSize_LostFocus(sender As System.Object, e As System.EventArgs) Handles NBFontSize.LostFocus
 		My.Settings.SubFontSize = NBFontSize.Value
-		My.Settings.Save()
 	End Sub
 
-
-	' Private Sub Button2_Click(sender As System.Object, e As System.EventArgs)
-	'Dim Str As System.IO.Stream
-	'Dim srRead As System.IO.StreamReader
-	'   Try
-	' make a Web request
-	'Dim req As System.Net.WebRequest = System.Net.WebRequest.Create(TextBox3.Text)
-	'Dim resp As System.Net.WebResponse = req.GetResponse
-	'       Str = resp.GetResponseStream
-	'      srRead = New System.IO.StreamReader(Str)
-	' read all the text
-	'Dim strlist As New List(Of String)
-	'       While srRead.Peek <> -1
-	'          strlist.Add(srRead.ReadLine())
-	'     End While
-
-	'        For i As Integer = 0 To strlist.Count - 1
-	'           If strlist(i).Contains(TextBox4.Text) Then
-	'              MsgBox(TextBox4.Text & " found at line " & i + 1 & Environment.NewLine & Environment.NewLine & strlist(i))
-	'         End If
-	'    Next
-
-	'        TextBox4.Text = "Finished"
-	'   Catch ex As Exception
-	'      TextBox4.Text = "Unable to download content"
-	' Finally
-	' Close Stream and StreamReader when done
-	'    srRead.Close()
-	'   Str.Close()
-	'End Try
-	'End Sub
 
 
 
@@ -5455,73 +5132,8 @@ trypreviousimage:
 			'Form1.LBLImageInfo.Text = ""
 			My.Settings.CBImageInfo = False
 		End If
-		My.Settings.Save()
 	End Sub
 
-	Private Sub Button3_Click(sender As System.Object, e As System.EventArgs)
-
-		Dim KeywordCount As Integer = 0
-
-		Dim Str As System.IO.Stream
-		Dim srRead As System.IO.StreamReader
-		Try
-			' make a Web request
-			Dim req As System.Net.WebRequest = System.Net.WebRequest.Create(TBKeywordPreview.Text)
-			Dim resp As System.Net.WebResponse = req.GetResponse
-			Str = resp.GetResponseStream
-			srRead = New System.IO.StreamReader(Str)
-			' read all the text
-			Dim strlist As New List(Of String)
-			While srRead.Peek <> -1
-				strlist.Add(srRead.ReadLine())
-			End While
-
-			For i As Integer = 0 To strlist.Count - 1
-				If strlist(i).Contains("Keyword]") Then
-					KeywordCount = InstrCount(strlist(i), "[Keyword]")
-					strlist(i) = strlist(i).Replace("<br />", ",")
-					strlist(i) = strlist(i).Replace("<br/>", ",")
-					strlist(i) = strlist(i).Replace("</br>", ",")
-					strlist(i) = strlist(i).Replace("</ br>", ",")
-
-
-					For j As Integer = 1 To KeywordCount
-
-
-
-
-
-
-
-
-					Next
-				End If
-			Next
-
-			If KeywordCount > 0 Then
-				'Form1.ImportKeyword = True
-				If KeywordCount > 1 Then
-					'  Button3.Text = "Next"
-				Else
-					'  Button3.Enabled = False
-				End If
-			End If
-
-			MsgBox("[Keyword] was found " & KeywordCount & " times!")
-
-		Catch ex As Exception
-			' TextBox4.Text = "Unable to download content"
-		Finally
-
-
-
-			' Close Stream and StreamReader when done
-			srRead.Close()
-			Str.Close()
-		End Try
-
-
-	End Sub
 
 	Function InstrCount(StringToSearch As String,
 		   StringToFind As String) As Long
@@ -6026,7 +5638,6 @@ GeneralGood:
 		PBMaintenance.Value = PBMaintenance.Maximum
 
 
-		My.Settings.Save()
 
 
 		MessageBox.Show(Me, "All Local Image paths have been validated.", "Information", MessageBoxButtons.OK, MessageBoxIcon.Information)
@@ -6159,7 +5770,6 @@ WhyUMakeMeDoDis:
 		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
 			LBLIHardcore.Text = FolderBrowserDialog1.SelectedPath
 			My.Settings.IHardcore = LBLIHardcore.Text
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6168,7 +5778,6 @@ WhyUMakeMeDoDis:
 		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
 			LBLISoftcore.Text = FolderBrowserDialog1.SelectedPath
 			My.Settings.ISoftcore = LBLISoftcore.Text
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6176,7 +5785,6 @@ WhyUMakeMeDoDis:
 		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
 			LBLILesbian.Text = FolderBrowserDialog1.SelectedPath
 			My.Settings.ILesbian = LBLILesbian.Text
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6184,7 +5792,6 @@ WhyUMakeMeDoDis:
 		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
 			LBLIBlowjob.Text = FolderBrowserDialog1.SelectedPath
 			My.Settings.IBlowjob = LBLIBlowjob.Text
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6192,7 +5799,6 @@ WhyUMakeMeDoDis:
 		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
 			LBLIFemdom.Text = FolderBrowserDialog1.SelectedPath
 			My.Settings.IFemdom = LBLIFemdom.Text
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6200,7 +5806,6 @@ WhyUMakeMeDoDis:
 		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
 			LBLILezdom.Text = FolderBrowserDialog1.SelectedPath
 			My.Settings.ILezdom = LBLILezdom.Text
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6208,7 +5813,6 @@ WhyUMakeMeDoDis:
 		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
 			LBLIHentai.Text = FolderBrowserDialog1.SelectedPath
 			My.Settings.IHentai = LBLIHentai.Text
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6216,7 +5820,6 @@ WhyUMakeMeDoDis:
 		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
 			LBLIGay.Text = FolderBrowserDialog1.SelectedPath
 			My.Settings.IGay = LBLIGay.Text
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6224,7 +5827,6 @@ WhyUMakeMeDoDis:
 		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
 			LBLIMaledom.Text = FolderBrowserDialog1.SelectedPath
 			My.Settings.IMaledom = LBLIMaledom.Text
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6232,7 +5834,6 @@ WhyUMakeMeDoDis:
 		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
 			LBLIGeneral.Text = FolderBrowserDialog1.SelectedPath
 			My.Settings.IGeneral = LBLIGeneral.Text
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6244,7 +5845,6 @@ WhyUMakeMeDoDis:
 			My.Settings.IHardcoreSD = False
 		End If
 		Debug.Print("My.Settings.IHardcoreSD = " & My.Settings.IHardcoreSD)
-		My.Settings.Save()
 
 	End Sub
 
@@ -6255,7 +5855,6 @@ WhyUMakeMeDoDis:
 		Else
 			My.Settings.ISoftcoreSD = False
 		End If
-		My.Settings.Save()
 
 	End Sub
 
@@ -6266,7 +5865,6 @@ WhyUMakeMeDoDis:
 		Else
 			My.Settings.ILesbianSD = False
 		End If
-		My.Settings.Save()
 
 	End Sub
 
@@ -6277,7 +5875,6 @@ WhyUMakeMeDoDis:
 		Else
 			My.Settings.IBlowjobSD = False
 		End If
-		My.Settings.Save()
 
 	End Sub
 
@@ -6288,7 +5885,7 @@ WhyUMakeMeDoDis:
 		Else
 			My.Settings.IFemdomSD = False
 		End If
-		My.Settings.Save()
+
 
 	End Sub
 
@@ -6299,7 +5896,6 @@ WhyUMakeMeDoDis:
 		Else
 			My.Settings.ILezdomSD = False
 		End If
-		My.Settings.Save()
 
 	End Sub
 
@@ -6310,7 +5906,6 @@ WhyUMakeMeDoDis:
 		Else
 			My.Settings.IHentaiSD = False
 		End If
-		My.Settings.Save()
 
 	End Sub
 
@@ -6321,7 +5916,6 @@ WhyUMakeMeDoDis:
 		Else
 			My.Settings.IGaySD = False
 		End If
-		My.Settings.Save()
 
 	End Sub
 
@@ -6332,7 +5926,6 @@ WhyUMakeMeDoDis:
 		Else
 			My.Settings.IMaledomSD = False
 		End If
-		My.Settings.Save()
 
 	End Sub
 
@@ -6343,7 +5936,6 @@ WhyUMakeMeDoDis:
 		Else
 			My.Settings.IGeneralSD = False
 		End If
-		My.Settings.Save()
 
 	End Sub
 
@@ -6354,7 +5946,6 @@ WhyUMakeMeDoDis:
 		Else
 			My.Settings.ICaptionsSD = False
 		End If
-		My.Settings.Save()
 
 	End Sub
 
@@ -6372,7 +5963,6 @@ WhyUMakeMeDoDis:
 				My.Settings.CBIHardcore = False
 			End If
 			Debug.Print("My.Settings.CBIHardcore = " & My.Settings.CBIHardcore)
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6383,7 +5973,6 @@ WhyUMakeMeDoDis:
 			Else
 				My.Settings.CBISoftcore = False
 			End If
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6394,7 +5983,6 @@ WhyUMakeMeDoDis:
 			Else
 				My.Settings.CBILesbian = False
 			End If
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6405,7 +5993,6 @@ WhyUMakeMeDoDis:
 			Else
 				My.Settings.CBIBlowjob = False
 			End If
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6416,7 +6003,6 @@ WhyUMakeMeDoDis:
 			Else
 				My.Settings.CBIFemdom = False
 			End If
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6427,7 +6013,6 @@ WhyUMakeMeDoDis:
 			Else
 				My.Settings.CBILezdom = False
 			End If
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6438,7 +6023,6 @@ WhyUMakeMeDoDis:
 			Else
 				My.Settings.CBIHentai = False
 			End If
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6449,7 +6033,6 @@ WhyUMakeMeDoDis:
 			Else
 				My.Settings.CBIGay = False
 			End If
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6460,7 +6043,6 @@ WhyUMakeMeDoDis:
 			Else
 				My.Settings.CBIMaledom = False
 			End If
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6471,7 +6053,6 @@ WhyUMakeMeDoDis:
 			Else
 				My.Settings.CBICaptions = False
 			End If
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6482,7 +6063,6 @@ WhyUMakeMeDoDis:
 			Else
 				My.Settings.CBIGeneral = False
 			End If
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6490,7 +6070,6 @@ WhyUMakeMeDoDis:
 		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
 			LBLICaptions.Text = FolderBrowserDialog1.SelectedPath
 			My.Settings.ICaptions = LBLICaptions.Text
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -6498,7 +6077,6 @@ WhyUMakeMeDoDis:
 		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
 			LBLDomImageDir.Text = FolderBrowserDialog1.SelectedPath
 			My.Settings.DomImageDir = LBLDomImageDir.Text
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -7187,6 +6765,7 @@ WhyUMakeMeDoDis:
 	End Sub
 
 	Public Sub GetScriptStatus()
+		'BUG: This Function is not checking all Commands and their contditions
 		ScriptStatusUnlock(True)
 		Dim ScriptReader As New StreamReader(ScriptFile)
 		ScriptList.Clear()
@@ -7335,13 +6914,13 @@ WhyUMakeMeDoDis:
 			If ScriptList(i).Contains("@ShowButtImage") Then
 				If Not RTBScriptReq.Text.Contains("* BnB Butt path must be set to a valid directory or URL File *") Then RTBScriptReq.Text = RTBScriptReq.Text & "* BnB Butt path must be set to a valid directory or URL File *" & Environment.NewLine
 				If CBIButts.Checked = True And Not Directory.Exists(LBLButtPath.Text) Then ScriptReqFailed = True
-				If CBURLButts.Checked = True And Not File.Exists(LBLButtURL.Text) Then ScriptReqFailed = True
+				If ChbImageUrlButts.Checked = True And Not File.Exists(My.Settings.UrlFileButt) Then ScriptReqFailed = True
 			End If
 
 			If ScriptList(i).Contains("@ShowBoobsImage") Then
 				If Not RTBScriptReq.Text.Contains("* BnB Boobs path must be set to a valid directory or URL File *") Then RTBScriptReq.Text = RTBScriptReq.Text & "* BnB Boobs path must be set to a valid directory or URL File *" & Environment.NewLine
 				If CBIBoobs.Checked = True And Not Directory.Exists(LBLBoobPath.Text) Then ScriptReqFailed = True
-				If CBURLBoobs.Checked = True And Not File.Exists(LBLBoobURL.Text) Then ScriptReqFailed = True
+				If ChbImageUrlBoobs.Checked = True And Not File.Exists(My.Settings.UrlFileBoobs) Then ScriptReqFailed = True
 			End If
 
 			If ScriptList(i).Contains("@ShowHardcoreImage") Then
@@ -7495,9 +7074,6 @@ WhyUMakeMeDoDis:
 	End Sub
 
 
-	Private Sub Button4_Click(sender As System.Object, e As System.EventArgs)
-		CLBStartList.SetItemChecked(2, False)
-	End Sub
 
 	Private Sub Button4_Click_1(sender As System.Object, e As System.EventArgs) Handles BTNScriptOpen.Click
 		If CLBStartList.Visible = True Then
@@ -7768,6 +7344,7 @@ WhyUMakeMeDoDis:
 	End Sub
 
 	Public Sub GetAvailFail()
+		'BUG: This Function is not checking all Commands and their contditions
 
 		For j As Integer = 0 To AvailList.Count - 1
 			If AvailList(j).Contains("@ShowBlogImage") Then
@@ -7886,12 +7463,12 @@ WhyUMakeMeDoDis:
 
 			If AvailList(j).Contains("@ShowButtImage") Then
 				If CBIButts.Checked = True And Not Directory.Exists(LBLButtPath.Text) Then AvailFail = True
-				If CBURLButts.Checked = True And Not File.Exists(LBLButtURL.Text) Then AvailFail = True
+				If ChbImageUrlButts.Checked = True And Not File.Exists(My.Settings.UrlFileButt) Then AvailFail = True
 			End If
 
 			If AvailList(j).Contains("@ShowBoobsImage") Then
 				If CBIBoobs.Checked = True And Not Directory.Exists(LBLBoobPath.Text) Then AvailFail = True
-				If CBURLBoobs.Checked = True And Not File.Exists(LBLBoobURL.Text) Then AvailFail = True
+				If ChbImageUrlBoobs.Checked = True And Not File.Exists(My.Settings.UrlFileBoobs) Then AvailFail = True
 			End If
 
 			If AvailList(j).Contains("@ShowHardcoreImage") Then
@@ -8015,19 +7592,12 @@ WhyUMakeMeDoDis:
 
 	End Sub
 
-	Private Sub Button4_Click_2(sender As System.Object, e As System.EventArgs)
-		For i As Integer = 0 To CLBStartList.Items.Count - 1
-			' Debug.Print("CLBStartList.GetItemChecked(i) = " & CLBStartList.GetItemChecked(i))
-		Next
-	End Sub
-
 	Private Sub CBCBTCock_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBCBTCock.LostFocus
 		If CBCBTCock.Checked = True Then
 			My.Settings.CBTCock = True
 		Else
 			My.Settings.CBTCock = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBCBTBalls_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBCBTBalls.LostFocus
@@ -8036,7 +7606,6 @@ WhyUMakeMeDoDis:
 		Else
 			My.Settings.CBTBalls = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub TabPage9_Click(sender As System.Object, e As System.EventArgs) Handles TabPage9.Click
@@ -8843,46 +8412,20 @@ WhyUMakeMeDoDis:
 
 	End Sub
 
-	Private Sub Button4_Click_4(sender As System.Object, e As System.EventArgs)
-		'If (SaveSettingsDialog.ShowDialog = Windows.Forms.DialogResult.OK) Then
-		'My.Settings.Save(SaveSettingsDialog.FileName)
-
-		' Dim SettingsSave As String = Configuration.ConfigurationSettings.AppSettings(My.Settings(0))
-
-		'Dim SettingsSave As String = Configuration.ConfigurationSettings.AppSettings(My.Settings(6))
-
-
-		'End If
-
-	End Sub
-
-	Private Sub Button5_Click_1(sender As System.Object, e As System.EventArgs)
-
-
-		' For Each MySet As My.MySettings In Configuration.ConfigurationSettings.AppSettings
-		'Debug.Print(MySet.ToString)
-
-		'Next
-
-
-	End Sub
 
 	Private Sub NBLongEdge_ValueChanged(sender As System.Object, e As System.EventArgs) Handles NBLongEdge.LostFocus
 		My.Settings.LongEdge = NBLongEdge.Value
-		My.Settings.Save()
 	End Sub
 
 
 	Private Sub NBHoldTheEdgeMax_LostFocus(sender As Object, e As System.EventArgs) Handles NBHoldTheEdgeMax.LostFocus
 		My.Settings.HoldTheEdgeMax = NBHoldTheEdgeMax.Value
 		My.Settings.HoldTheEdgeMaxAmount = LBLMaxHold.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBHoldTheEdgeMin_LostFocus(sender As Object, e As System.EventArgs) Handles NBHoldTheEdgeMin.LostFocus
 		My.Settings.HoldTheEdgeMin = NBHoldTheEdgeMin.Value
 		My.Settings.HoldTheEdgeMinAmount = LBLMinHold.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBHoldTheEdgeMax_ValueChanged(sender As System.Object, e As System.EventArgs) Handles NBHoldTheEdgeMax.ValueChanged
@@ -8921,12 +8464,10 @@ WhyUMakeMeDoDis:
 
 	Private Sub NBLongHoldMax_LostFocus(sender As Object, e As System.EventArgs) Handles NBLongHoldMax.LostFocus
 		My.Settings.LongHoldMax = NBLongHoldMax.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBLongHoldMin_LostFocus(sender As Object, e As System.EventArgs) Handles NBLongHoldMin.LostFocus
 		My.Settings.LongHoldMin = NBLongHoldMin.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBLongHoldMax_ValueChanged(sender As System.Object, e As System.EventArgs) Handles NBLongHoldMax.ValueChanged
@@ -8952,12 +8493,10 @@ WhyUMakeMeDoDis:
 
 	Private Sub NBExtremeHoldMax_LostFocus(sender As Object, e As System.EventArgs) Handles NBExtremeHoldMax.LostFocus
 		My.Settings.ExtremeHoldMax = NBExtremeHoldMax.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBExtremeHoldMin_LostFocus(sender As Object, e As System.EventArgs) Handles NBExtremeHoldMin.LostFocus
 		My.Settings.ExtremeHoldMin = NBExtremeHoldMin.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBExtremeHoldMax_ValueChanged(sender As System.Object, e As System.EventArgs) Handles NBExtremeHoldMax.ValueChanged
@@ -8980,25 +8519,10 @@ WhyUMakeMeDoDis:
 		End If
 	End Sub
 
-	Private Sub Button11_Click(sender As System.Object, e As System.EventArgs)
-		Dim testreader As New StreamReader(Application.StartupPath & "\Scripts\" & Form1.dompersonalitycombobox.Text & "\Stroke\StrokeTaunts_1.txt")
-		Dim TestingList As New List(Of String)
-		While testreader.Peek <> -1
-			TestingList.Add(testreader.ReadLine())
-		End While
-
-		testreader.Close()
-		testreader.Dispose()
-
-
-
-
-	End Sub
 
 	Private Sub CBTSlider_Scroll(sender As System.Object, e As System.EventArgs) Handles CBTSlider.Scroll
 		If FrmSettingsLoading = False Then
 			My.Settings.CBTSlider = CBTSlider.Value
-			My.Settings.Save()
 			If CBTSlider.Value = 1 Then LBLCBTSlider.Text = "CBT Level: 1"
 			If CBTSlider.Value = 2 Then LBLCBTSlider.Text = "CBT Level: 2"
 			If CBTSlider.Value = 3 Then LBLCBTSlider.Text = "CBT Level: 3"
@@ -9014,7 +8538,6 @@ WhyUMakeMeDoDis:
 			Else
 				My.Settings.SubCircumcised = False
 			End If
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -9025,7 +8548,6 @@ WhyUMakeMeDoDis:
 			Else
 				My.Settings.SubPierced = False
 			End If
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -9037,7 +8559,6 @@ WhyUMakeMeDoDis:
 		If NBEmpathy.Value = 4 Then My.Settings.DomEmpathy = 4
 		If NBEmpathy.Value = 5 Then My.Settings.DomEmpathy = 5
 
-		My.Settings.Save()
 
 		Debug.Print(My.Settings.DomEmpathy)
 
@@ -9286,7 +8807,6 @@ WhyUMakeMeDoDis:
 		My.Settings.SubAgeMin = NBSubAgeMin.Value
 		My.Settings.SubAgeMax = NBSubAgeMax.Value
 
-		My.Settings.Save()
 
 
 	End Sub
@@ -9453,9 +8973,6 @@ WhyUMakeMeDoDis:
 	End Sub
 
 
-	Private Sub Button6_Click_1(sender As System.Object, e As System.EventArgs)
-		Form1.CreateTaskLetter()
-	End Sub
 
 	Private Sub CBSaveChatlogExit_CheckedChanged(sender As System.Object, e As System.Windows.Forms.MouseEventArgs) Handles CBSaveChatlogExit.MouseClick
 
@@ -9487,122 +9004,95 @@ WhyUMakeMeDoDis:
 
 	Private Sub CBRangeOrgasm_LostFocus(sender As Object, e As System.EventArgs) Handles CBRangeOrgasm.LostFocus
 		My.Settings.RangeOrgasm = CBRangeOrgasm.Checked
-		My.Settings.Save()
 	End Sub
 	Private Sub CBRangeRuin_LostFocus(sender As Object, e As System.EventArgs) Handles CBRangeRuin.LostFocus
 		My.Settings.RangeRuin = CBRangeRuin.Checked
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBAllowOften_ValueChanged(sender As System.Object, e As System.EventArgs) Handles NBAllowOften.LostFocus
 		My.Settings.AllowOften = NBAllowOften.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBAllowSometimes_ValueChanged(sender As System.Object, e As System.EventArgs) Handles NBAllowSometimes.LostFocus
 		My.Settings.AllowSometimes = NBAllowSometimes.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBAllowRarely_ValueChanged(sender As System.Object, e As System.EventArgs) Handles NBAllowRarely.LostFocus
 		My.Settings.AllowRarely = NBAllowRarely.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBRuinOften_ValueChanged(sender As System.Object, e As System.EventArgs) Handles NBRuinOften.LostFocus
 		My.Settings.RuinOften = NBRuinOften.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBRuinSometimes_ValueChanged(sender As System.Object, e As System.EventArgs) Handles NBRuinSometimes.LostFocus
 		My.Settings.RuinSometimes = NBRuinSometimes.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBRuinRarely_ValueChanged(sender As System.Object, e As System.EventArgs) Handles NBRuinRarely.LostFocus
 		My.Settings.RuinRarely = NBRuinRarely.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub TBSafeword_LostFocus(sender As Object, e As System.EventArgs) Handles TBSafeword.LostFocus
 		My.Settings.Safeword = TBSafeword.Text
-		My.Settings.Save()
 	End Sub
 
 
 	Private Sub BN1_LostFocus(sender As Object, e As System.EventArgs) Handles BN1.LostFocus
 		My.Settings.BN1 = BN1.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub BN2_LostFocus(sender As Object, e As System.EventArgs) Handles BN2.LostFocus
 		My.Settings.BN2 = BN2.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub BN3_LostFocus(sender As Object, e As System.EventArgs) Handles BN3.LostFocus
 		My.Settings.BN3 = BN3.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub BN4_LostFocus(sender As Object, e As System.EventArgs) Handles BN4.LostFocus
 		My.Settings.BN4 = BN4.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub BN5_LostFocus(sender As Object, e As System.EventArgs) Handles BN5.LostFocus
 		My.Settings.BN5 = BN5.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub BN6_LostFocus(sender As Object, e As System.EventArgs) Handles BN6.LostFocus
 		My.Settings.BN6 = BN6.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub SN1_LostFocus(sender As Object, e As System.EventArgs) Handles SN1.LostFocus
 		My.Settings.SN1 = SN1.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub SN2_LostFocus(sender As Object, e As System.EventArgs) Handles SN2.LostFocus
 		My.Settings.SN2 = SN2.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub SN3_LostFocus(sender As Object, e As System.EventArgs) Handles SN3.LostFocus
 		My.Settings.SN3 = SN3.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub SN4_LostFocus(sender As Object, e As System.EventArgs) Handles SN4.LostFocus
 		My.Settings.SN4 = SN4.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub SN5_LostFocus(sender As Object, e As System.EventArgs) Handles SN5.LostFocus
 		My.Settings.SN5 = SN5.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub SN6_LostFocus(sender As Object, e As System.EventArgs) Handles SN6.LostFocus
 		My.Settings.SN6 = SN6.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub GN1_LostFocus(sender As Object, e As System.EventArgs) Handles GN1.LostFocus
 		My.Settings.GN1 = GN1.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub GN2_LostFocus(sender As Object, e As System.EventArgs) Handles GN2.LostFocus
 		My.Settings.GN2 = GN2.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub GN3_LostFocus(sender As Object, e As System.EventArgs) Handles GN3.LostFocus
 		My.Settings.GN3 = GN3.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub GN4_LostFocus(sender As Object, e As System.EventArgs) Handles GN4.LostFocus
 		My.Settings.GN4 = GN4.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub GN5_LostFocus(sender As Object, e As System.EventArgs) Handles GN5.LostFocus
 		My.Settings.GN5 = GN5.Text
-		My.Settings.Save()
 	End Sub
 	Private Sub GN6_LostFocus(sender As Object, e As System.EventArgs) Handles GN6.LostFocus
 		My.Settings.GN6 = GN6.Text
-		My.Settings.Save()
 	End Sub
 
 	Private Sub BP1_DragEnter(ByVal sender As Object, ByVal e As System.Windows.Forms.DragEventArgs) Handles BP1.DragEnter, BP2.DragEnter, BP3.DragEnter, BP4.DragEnter, BP5.DragEnter, BP6.DragEnter
@@ -9695,7 +9185,6 @@ WhyUMakeMeDoDis:
 		Try
 			BP1.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardBP1.bmp")
 			My.Settings.BP1 = Application.StartupPath & "\Images\Cards\CardBP1.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -9728,7 +9217,6 @@ WhyUMakeMeDoDis:
 			Try
 				BP1.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardBP1.bmp")
 				My.Settings.BP1 = Application.StartupPath & "\Images\Cards\CardBP1.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -9756,7 +9244,6 @@ WhyUMakeMeDoDis:
 		Try
 			BP2.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardBP2.bmp")
 			My.Settings.BP2 = Application.StartupPath & "\Images\Cards\CardBP2.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -9788,7 +9275,6 @@ WhyUMakeMeDoDis:
 			Try
 				BP2.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardBP2.bmp")
 				My.Settings.BP2 = Application.StartupPath & "\Images\Cards\CardBP2.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -9815,7 +9301,6 @@ WhyUMakeMeDoDis:
 		Try
 			BP3.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardBP3.bmp")
 			My.Settings.BP3 = Application.StartupPath & "\Images\Cards\CardBP3.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -9846,7 +9331,6 @@ WhyUMakeMeDoDis:
 			Try
 				BP3.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardBP3.bmp")
 				My.Settings.BP3 = Application.StartupPath & "\Images\Cards\CardBP3.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -9873,7 +9357,6 @@ WhyUMakeMeDoDis:
 		Try
 			BP4.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardBP4.bmp")
 			My.Settings.BP4 = Application.StartupPath & "\Images\Cards\CardBP4.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -9904,7 +9387,6 @@ WhyUMakeMeDoDis:
 			Try
 				BP4.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardBP4.bmp")
 				My.Settings.BP4 = Application.StartupPath & "\Images\Cards\CardBP4.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -9931,7 +9413,6 @@ WhyUMakeMeDoDis:
 		Try
 			BP5.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardBP5.bmp")
 			My.Settings.BP5 = Application.StartupPath & "\Images\Cards\CardBP5.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -9962,7 +9443,6 @@ WhyUMakeMeDoDis:
 			Try
 				BP5.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardBP5.bmp")
 				My.Settings.BP5 = Application.StartupPath & "\Images\Cards\CardBP5.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -9989,7 +9469,6 @@ WhyUMakeMeDoDis:
 		Try
 			BP6.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardBP6.bmp")
 			My.Settings.BP6 = Application.StartupPath & "\Images\Cards\CardBP6.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -10020,7 +9499,6 @@ WhyUMakeMeDoDis:
 			Try
 				BP6.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardBP6.bmp")
 				My.Settings.BP6 = Application.StartupPath & "\Images\Cards\CardBP6.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -10053,7 +9531,6 @@ WhyUMakeMeDoDis:
 		Try
 			SP1.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardSP1.bmp")
 			My.Settings.SP1 = Application.StartupPath & "\Images\Cards\CardSP1.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -10084,7 +9561,6 @@ WhyUMakeMeDoDis:
 			Try
 				SP1.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardSP1.bmp")
 				My.Settings.SP1 = Application.StartupPath & "\Images\Cards\CardSP1.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -10111,7 +9587,6 @@ WhyUMakeMeDoDis:
 		Try
 			SP2.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardSP2.bmp")
 			My.Settings.SP2 = Application.StartupPath & "\Images\Cards\CardSP2.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -10141,7 +9616,6 @@ WhyUMakeMeDoDis:
 			Try
 				SP2.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardSP2.bmp")
 				My.Settings.SP2 = Application.StartupPath & "\Images\Cards\CardSP2.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -10168,7 +9642,6 @@ WhyUMakeMeDoDis:
 		Try
 			SP3.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardSP3.bmp")
 			My.Settings.SP3 = Application.StartupPath & "\Images\Cards\CardSP3.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -10199,7 +9672,6 @@ WhyUMakeMeDoDis:
 			Try
 				SP3.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardSP3.bmp")
 				My.Settings.SP3 = Application.StartupPath & "\Images\Cards\CardSP3.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -10226,7 +9698,6 @@ WhyUMakeMeDoDis:
 		Try
 			SP4.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardSP4.bmp")
 			My.Settings.SP4 = Application.StartupPath & "\Images\Cards\CardSP4.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -10257,7 +9728,6 @@ WhyUMakeMeDoDis:
 			Try
 				SP4.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardSP4.bmp")
 				My.Settings.SP4 = Application.StartupPath & "\Images\Cards\CardSP4.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -10284,7 +9754,6 @@ WhyUMakeMeDoDis:
 		Try
 			SP5.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardSP5.bmp")
 			My.Settings.SP5 = Application.StartupPath & "\Images\Cards\CardSP5.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -10315,7 +9784,6 @@ WhyUMakeMeDoDis:
 			Try
 				SP5.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardSP5.bmp")
 				My.Settings.SP5 = Application.StartupPath & "\Images\Cards\CardSP5.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -10342,7 +9810,6 @@ WhyUMakeMeDoDis:
 		Try
 			SP6.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardSP6.bmp")
 			My.Settings.SP6 = Application.StartupPath & "\Images\Cards\CardSP6.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -10373,7 +9840,6 @@ WhyUMakeMeDoDis:
 			Try
 				SP6.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardSP6.bmp")
 				My.Settings.SP6 = Application.StartupPath & "\Images\Cards\CardSP6.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -10400,7 +9866,6 @@ WhyUMakeMeDoDis:
 		Try
 			GP1.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardGP1.bmp")
 			My.Settings.GP1 = Application.StartupPath & "\Images\Cards\CardGP1.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -10431,7 +9896,6 @@ WhyUMakeMeDoDis:
 			Try
 				GP1.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardGP1.bmp")
 				My.Settings.GP1 = Application.StartupPath & "\Images\Cards\CardGP1.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -10464,7 +9928,6 @@ WhyUMakeMeDoDis:
 		Try
 			GP2.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardGP2.bmp")
 			My.Settings.GP2 = Application.StartupPath & "\Images\Cards\CardGP2.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -10495,7 +9958,6 @@ WhyUMakeMeDoDis:
 			Try
 				GP2.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardGP2.bmp")
 				My.Settings.GP2 = Application.StartupPath & "\Images\Cards\CardGP2.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -10522,7 +9984,6 @@ WhyUMakeMeDoDis:
 		Try
 			GP3.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardGP3.bmp")
 			My.Settings.GP3 = Application.StartupPath & "\Images\Cards\CardGP3.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -10552,7 +10013,6 @@ WhyUMakeMeDoDis:
 			Try
 				GP3.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardGP3.bmp")
 				My.Settings.GP3 = Application.StartupPath & "\Images\Cards\CardGP3.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -10579,7 +10039,6 @@ WhyUMakeMeDoDis:
 		Try
 			GP4.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardGP4.bmp")
 			My.Settings.GP4 = Application.StartupPath & "\Images\Cards\CardGP4.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -10610,7 +10069,6 @@ WhyUMakeMeDoDis:
 			Try
 				GP4.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardGP4.bmp")
 				My.Settings.GP4 = Application.StartupPath & "\Images\Cards\CardGP4.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -10637,7 +10095,6 @@ WhyUMakeMeDoDis:
 		Try
 			GP5.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardGP5.bmp")
 			My.Settings.GP5 = Application.StartupPath & "\Images\Cards\CardGP5.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -10668,7 +10125,6 @@ WhyUMakeMeDoDis:
 			Try
 				GP5.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardGP5.bmp")
 				My.Settings.GP5 = Application.StartupPath & "\Images\Cards\CardGP5.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -10695,7 +10151,6 @@ WhyUMakeMeDoDis:
 		Try
 			GP6.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardGP6.bmp")
 			My.Settings.GP6 = Application.StartupPath & "\Images\Cards\CardGP6.bmp"
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -10726,7 +10181,6 @@ WhyUMakeMeDoDis:
 			Try
 				GP6.Image = Image.FromFile(Application.StartupPath & "\Images\Cards\CardGP6.bmp")
 				My.Settings.GP6 = Application.StartupPath & "\Images\Cards\CardGP6.bmp"
-				My.Settings.Save()
 			Catch ex As Exception
 				MessageBox.Show("An error occurred - Card did not save correctly")
 			End Try
@@ -10747,7 +10201,6 @@ WhyUMakeMeDoDis:
 		Try
 			CardBack.Image = Image.FromFile(CType(e.Data.GetData(DataFormats.FileDrop), Array).GetValue(0).ToString)
 			My.Settings.CardBack = CType(e.Data.GetData(DataFormats.FileDrop), Array).GetValue(0).ToString
-			My.Settings.Save()
 		Catch ex As Exception
 			MessageBox.Show("Error Doing Drag/Drop")
 		End Try
@@ -10763,7 +10216,6 @@ WhyUMakeMeDoDis:
 			GC.Collect()
 			CardBack.Load(OpenFileDialog1.FileName)
 			My.Settings.CardBack = OpenFileDialog1.FileName
-			My.Settings.Save()
 		End If
 	End Sub
 
@@ -10949,19 +10401,6 @@ WhyUMakeMeDoDis:
 
 	End Sub
 
-	Private Sub Button10_Click(sender As System.Object, e As System.EventArgs)
-
-		For i As Integer = 0 To RTBResponses.Lines.Count - 1
-			' If RTBResponses.Lines(i).Substring(0, 1) = "[" Then
-			RTBResponses.SelectionStart = RTBResponses.Text.IndexOf(RTBResponses.Lines(i))
-			RTBResponses.SelectionLength = RTBResponses.Lines(i).Length
-			RTBResponses.SelectionFont = New Font(RTBResponses.SelectionFont, FontStyle.Bold)
-			'End If
-		Next
-
-	End Sub
-
-
 
 	Private Sub subAgeNumBox_MouseHover(sender As Object, e As System.EventArgs) Handles subAgeNumBox.MouseEnter
 		TTDir.SetToolTip(subAgeNumBox, "Set your age.")
@@ -11113,7 +10552,6 @@ WhyUMakeMeDoDis:
 
 	Private Sub CBEdgeUseAvg_LostFocus(sender As Object, e As System.EventArgs) Handles CBEdgeUseAvg.LostFocus
 		My.Settings.CBEdgeUseAvg = CBEdgeUseAvg.Checked
-		My.Settings.Save()
 	End Sub
 	Private Sub CBEdgeUseAvg_MouseHover(sender As Object, e As System.EventArgs) Handles CBEdgeUseAvg.MouseEnter
 		LBLSubSettingsDescription.Text = "When this is checked, the domme will use the average amount of time it has historically taken you to reach the edge to decide when you have been trying to edge for too long."
@@ -11121,7 +10559,6 @@ WhyUMakeMeDoDis:
 
 	Private Sub CBLongEdgeTaunts_LostFocus(sender As Object, e As System.EventArgs) Handles CBLongEdgeTaunts.LostFocus
 		My.Settings.CBLongEdgeTaunts = CBLongEdgeTaunts.Checked
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBLongEdgeTaunts_MouseHover(sender As Object, e As System.EventArgs) Handles CBLongEdgeTaunts.MouseEnter
@@ -11131,7 +10568,6 @@ WhyUMakeMeDoDis:
 
 	Private Sub CBLongEdgeInterrupts_LostFocus(sender As Object, e As System.EventArgs) Handles CBLongEdgeInterrupts.LostFocus
 		My.Settings.CBLongEdgeInterrupts = CBLongEdgeInterrupts.Checked
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBLongEdgeInterrupts_MouseHover(sender As Object, e As System.EventArgs) Handles CBLongEdgeInterrupts.MouseEnter
@@ -11157,7 +10593,6 @@ WhyUMakeMeDoDis:
 
 	Private Sub NBNextImageChance_LostFocus(sender As Object, e As System.EventArgs) Handles NBNextImageChance.LostFocus
 		My.Settings.NextImageChance = NBNextImageChance.Value
-		My.Settings.Save()
 	End Sub
 
 
@@ -11229,7 +10664,6 @@ WhyUMakeMeDoDis:
 			orgasmlockrandombutton.Enabled = False
 
 
-			My.Settings.Save()
 
 
 
@@ -11347,7 +10781,6 @@ WhyUMakeMeDoDis:
 			orgasmsperlockButton.Enabled = False
 			orgasmlockrandombutton.Enabled = False
 
-			My.Settings.Save()
 
 		End If
 
@@ -11383,11 +10816,6 @@ WhyUMakeMeDoDis:
 	End Sub
 
 
-	Private Sub Button2_Click(sender As System.Object, e As System.EventArgs)
-		Form1.UpdatesTick = 3
-	End Sub
-
-
 
 	Private Sub NBTeaseLengthMin_MouseHover(sender As Object, e As System.EventArgs) Handles NBTeaseLengthMin.MouseEnter
 		LBLRangeSettingsDescription.Text = "Set the minimum amount of time the program will run before the domme decides if you can have an orgasm." & Environment.NewLine & Environment.NewLine &
@@ -11404,12 +10832,10 @@ WhyUMakeMeDoDis:
 
 	Private Sub CBTeaseLengthDD_LostFocus(sender As Object, e As System.EventArgs) Handles CBTeaseLengthDD.LostFocus
 		My.Settings.CBTeaseLengthDD = CBTeaseLengthDD.Checked
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBTauntCycleDD_LostFocus(sender As Object, e As System.EventArgs) Handles CBTauntCycleDD.LostFocus
 		My.Settings.CBTauntCycleDD = CBTauntCycleDD.Checked
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBTeaseLengthDD_MouseHover(sender As Object, e As System.EventArgs) Handles CBTeaseLengthDD.MouseEnter
@@ -11622,22 +11048,18 @@ WhyUMakeMeDoDis:
 
 	Private Sub CBOwnChastity_LostFocus(sender As Object, e As System.EventArgs) Handles CBOwnChastity.LostFocus
 		My.Settings.CBOwnChastity = CBOwnChastity.Checked
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBChastityPA_LostFocus(sender As Object, e As System.EventArgs) Handles CBChastityPA.LostFocus
 		My.Settings.ChastityPA = CBChastityPA.Checked
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBChastitySpikes_LostFocus(sender As Object, e As System.EventArgs) Handles CBChastitySpikes.LostFocus
 		My.Settings.ChastitySpikes = CBChastitySpikes.Checked
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBIncludeGifs_LostFocus(sender As Object, e As System.EventArgs) Handles CBIncludeGifs.LostFocus
 		My.Settings.CBIncludeGifs = CBIncludeGifs.Checked
-		My.Settings.Save()
 
 	End Sub
 
@@ -11649,7 +11071,6 @@ WhyUMakeMeDoDis:
 
 	Private Sub CBHimHer_LostFocus(sender As Object, e As System.EventArgs) Handles CBHimHer.LostFocus
 		My.Settings.CBHimHer = CBHimHer.Checked
-		My.Settings.Save()
 
 	End Sub
 
@@ -11664,7 +11085,6 @@ WhyUMakeMeDoDis:
 
 	Private Sub CBDomDel_LostFocus(sender As Object, e As System.EventArgs) Handles CBDomDel.LostFocus
 		My.Settings.DomDeleteMedia = CBDomDel.Checked
-		My.Settings.Save()
 	End Sub
 
 	Private Sub BTNMaintenanceValidate_Click(sender As System.Object, e As System.EventArgs) Handles BTNMaintenanceValidate.Click
@@ -12087,12 +11507,10 @@ WhyUMakeMeDoDis:
 
 	Private Sub CBCockToClit_LostFocus(sender As Object, e As System.EventArgs) Handles CBCockToClit.LostFocus
 		My.Settings.CockToClit = CBCockToClit.Checked
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBBallsToPussy_LostFocus(sender As Object, e As System.EventArgs) Handles CBBallsToPussy.LostFocus
 		My.Settings.BallsToPussy = CBBallsToPussy.Checked
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBCockToClit_MouseHover(sender As Object, e As System.EventArgs) Handles CBCockToClit.MouseEnter
@@ -12472,7 +11890,6 @@ WhyUMakeMeDoDis:
 		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
 			LBLContact1ImageDir.Text = FolderBrowserDialog1.SelectedPath
 			My.Settings.Contact1ImageDir = LBLContact1ImageDir.Text
-			My.Settings.Save()
 			Form1.GetContact1Pics()
 		End If
 	End Sub
@@ -12481,7 +11898,6 @@ WhyUMakeMeDoDis:
 		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
 			LBLContact2ImageDir.Text = FolderBrowserDialog1.SelectedPath
 			My.Settings.Contact2ImageDir = LBLContact2ImageDir.Text
-			My.Settings.Save()
 			Form1.GetContact2Pics()
 		End If
 	End Sub
@@ -12490,7 +11906,6 @@ WhyUMakeMeDoDis:
 		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
 			LBLContact3ImageDir.Text = FolderBrowserDialog1.SelectedPath
 			My.Settings.Contact3ImageDir = LBLContact3ImageDir.Text
-			My.Settings.Save()
 			Form1.GetContact3Pics()
 		End If
 	End Sub
@@ -12500,7 +11915,6 @@ WhyUMakeMeDoDis:
 		My.Settings.CBGlitterFeed = CBGlitterFeed.Checked
 		My.Settings.CBGlitterFeedScripts = CBGlitterFeedScripts.Checked
 		My.Settings.CBGlitterFeedOff = CBGlitterFeedOff.Checked
-		My.Settings.Save()
 	End Sub
 
 	Private Sub Button11_Click_1(sender As System.Object, e As System.EventArgs) Handles Button11.Click
@@ -12516,7 +11930,6 @@ WhyUMakeMeDoDis:
 				LBLChastityState.Text = "ON"
 				LBLChastityState.ForeColor = Color.Green
 			End If
-			My.Settings.Save()
 		Else
 			Return
 		End If
@@ -12561,21 +11974,18 @@ WhyUMakeMeDoDis:
 	Private Sub Button14_Click_1(sender As System.Object, e As System.EventArgs) Handles Button14.Click
 		LBLContact1ImageDir.Text = "No path selected"
 		My.Settings.Contact1ImageDir = "No path selected"
-		My.Settings.Save()
 		Form1.Contact1Pics.Clear()
 	End Sub
 
 	Private Sub Button13_Click(sender As System.Object, e As System.EventArgs) Handles Button13.Click
 		LBLContact2ImageDir.Text = "No path selected"
 		My.Settings.Contact2ImageDir = "No path selected"
-		My.Settings.Save()
 		Form1.Contact2Pics.Clear()
 	End Sub
 
 	Private Sub Button12_Click_1(sender As System.Object, e As System.EventArgs) Handles Button12.Click
 		LBLContact3ImageDir.Text = "No path selected"
 		My.Settings.Contact3ImageDir = "No path selected"
-		My.Settings.Save()
 		Form1.Contact3Pics.Clear()
 	End Sub
 
@@ -12711,28 +12121,24 @@ WhyUMakeMeDoDis:
 				Try
 					GlitterAV.Image = Image.FromFile(SettingsList(25).Replace("Domme AV: ", ""))
 					My.Settings.GlitterAV = SettingsList(25).Replace("Domme AV: ", "")
-					My.Settings.Save()
 				Catch
 				End Try
 
 				Try
 					GlitterAV1.Image = Image.FromFile(SettingsList(26).Replace("Contact 1 AV: ", ""))
 					My.Settings.GlitterAV1 = SettingsList(26).Replace("Contact 1 AV: ", "")
-					My.Settings.Save()
 				Catch
 				End Try
 
 				Try
 					GlitterAV2.Image = Image.FromFile(SettingsList(27).Replace("Contact 2 AV: ", ""))
 					My.Settings.GlitterAV2 = SettingsList(27).Replace("Contact 2 AV: ", "")
-					My.Settings.Save()
 				Catch
 				End Try
 
 				Try
 					GlitterAV3.Image = Image.FromFile(SettingsList(28).Replace("Contact 3 AV: ", ""))
 					My.Settings.GlitterAV3 = SettingsList(28).Replace("Contact 3 AV: ", "")
-					My.Settings.Save()
 				Catch
 				End Try
 
@@ -12795,7 +12201,6 @@ WhyUMakeMeDoDis:
 		My.Settings.Contact3ImageDir = LBLContact3ImageDir.Text
 		My.Settings.Glitter3Slider = GlitterSlider3.Value
 
-		My.Settings.Save()
 
 	End Sub
 
@@ -12958,28 +12363,15 @@ WhyUMakeMeDoDis:
 				My.Settings.TeaseAILanguage = "English"
 			End If
 
-			My.Settings.Save()
 
 		End If
 
 	End Sub
 
-	'Private Sub MetroTest_ValueChanged(sender As System.Object, e As System.EventArgs)
-
-	'Dim bpm As Integer
-	'   bpm = MetroTest.Value
-	'Dim MetroVal As Integer = 60 / bpm * 1000
-	'Form1.StrokePace = MetroTest.Value
-
-
-	' Form1.MetroTimer.Interval = MetroVal
-	'End Sub
-
 
 	Private Sub Button25_Click(sender As System.Object, e As System.EventArgs) Handles Button25.Click
 		If GetColor.ShowDialog() = DialogResult.OK Then
 			My.Settings.BackgroundColor = GetColor.Color
-			My.Settings.Save()
 			Form1.ApplyThemeColor()
 		End If
 	End Sub
@@ -12987,7 +12379,6 @@ WhyUMakeMeDoDis:
 	Private Sub Button27_Click_1(sender As System.Object, e As System.EventArgs) Handles Button27.Click
 		If GetColor.ShowDialog() = DialogResult.OK Then
 			My.Settings.ButtonColor = GetColor.Color
-			My.Settings.Save()
 			Form1.ApplyThemeColor()
 		End If
 	End Sub
@@ -12995,7 +12386,6 @@ WhyUMakeMeDoDis:
 	Private Sub Button20_Click(sender As System.Object, e As System.EventArgs) Handles Button20.Click
 		If GetColor.ShowDialog() = DialogResult.OK Then
 			My.Settings.TextColor = GetColor.Color
-			My.Settings.Save()
 			Form1.ApplyThemeColor()
 		End If
 	End Sub
@@ -13003,7 +12393,6 @@ WhyUMakeMeDoDis:
 	Private Sub Button23_Click(sender As System.Object, e As System.EventArgs) Handles Button23.Click
 		If GetColor.ShowDialog() = DialogResult.OK Then
 			My.Settings.ChatWindowColor = GetColor.Color
-			My.Settings.Save()
 			Form1.ApplyThemeColor()
 		End If
 	End Sub
@@ -13018,7 +12407,6 @@ WhyUMakeMeDoDis:
 			GC.Collect()
 			Form1.BackgroundImage = Image.FromFile(OpenFileDialog1.FileName)
 			My.Settings.BackgroundImage = OpenFileDialog1.FileName
-			My.Settings.Save()
 			Form1.ApplyThemeColor()
 		End If
 	End Sub
@@ -13033,7 +12421,6 @@ WhyUMakeMeDoDis:
 		PBBackgroundPreview.Image = Nothing
 		GC.Collect()
 		My.Settings.BackgroundImage = ""
-		My.Settings.Save()
 	End Sub
 
 
@@ -13078,7 +12465,6 @@ WhyUMakeMeDoDis:
 
 				CBFlipBack.Checked = SettingsList(10).Replace("FlipImage: ", "")
 
-				My.Settings.Save()
 
 
 			Catch
@@ -13094,7 +12480,6 @@ WhyUMakeMeDoDis:
 	Private Sub Button21_Click_1(sender As System.Object, e As System.EventArgs) Handles Button21.Click
 		If GetColor.ShowDialog() = DialogResult.OK Then
 			My.Settings.ChatTextColor = GetColor.Color
-			My.Settings.Save()
 			Form1.ApplyThemeColor()
 		End If
 	End Sub
@@ -13102,7 +12487,6 @@ WhyUMakeMeDoDis:
 	Private Sub CBStretchBack_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBStretchBack.CheckedChanged
 		If Form1.ApplyingTheme = False Then
 			My.Settings.BackgroundStretch = CBStretchBack.Checked
-			My.Settings.Save()
 			Form1.ApplyThemeColor()
 		End If
 
@@ -13113,7 +12497,6 @@ WhyUMakeMeDoDis:
 	Private Sub Button30_Click(sender As System.Object, e As System.EventArgs) Handles Button30.Click
 		If GetColor.ShowDialog() = DialogResult.OK Then
 			My.Settings.DateTextColor = GetColor.Color
-			My.Settings.Save()
 			Form1.ApplyThemeColor()
 		End If
 	End Sub
@@ -13121,7 +12504,6 @@ WhyUMakeMeDoDis:
 	Private Sub Button28_Click(sender As System.Object, e As System.EventArgs) Handles Button28.Click
 		If GetColor.ShowDialog() = DialogResult.OK Then
 			My.Settings.DateBackColor = GetColor.Color
-			My.Settings.Save()
 			Form1.ApplyThemeColor()
 		End If
 	End Sub
@@ -13129,7 +12511,6 @@ WhyUMakeMeDoDis:
 	Private Sub CBTransparentTime_CheckedChanged(sender As System.Object, e As System.EventArgs) Handles CBTransparentTime.CheckedChanged
 		If Form1.ApplyingTheme = False Then
 			My.Settings.CBDateTransparent = CBTransparentTime.Checked
-			My.Settings.Save()
 			Try
 				Form1.ApplyThemeColor()
 			Catch
@@ -13193,14 +12574,6 @@ WhyUMakeMeDoDis:
 
 	End Sub
 
-	Private Sub Button33_Click(sender As System.Object, e As System.EventArgs)
-		Form1.MetroThread.Start()
-	End Sub
-
-	Private Sub Button34_Click(sender As System.Object, e As System.EventArgs)
-		Form1.MetroThread.Suspend()
-	End Sub
-
 	Private Sub TimeBoxWakeUp_ValueChanged(sender As System.Object, e As System.EventArgs) Handles TimeBoxWakeUp.ValueChanged
 		If Form1.FormLoading = False Then
 
@@ -13215,7 +12588,6 @@ WhyUMakeMeDoDis:
 
 			' Github Patch My.Settings.WakeUp = Form1.GetTime("SYS_WakeUp")
 			My.Settings.WakeUp = FormatDateTime(Now, DateFormat.ShortDate) & " " & Form1.GetTime("SYS_WakeUp")
-			My.Settings.Save()
 
 
 
@@ -13229,22 +12601,15 @@ WhyUMakeMeDoDis:
 
 	Private Sub NBTypoChance_LostFocus(sender As Object, e As System.EventArgs) Handles NBTypoChance.LostFocus
 		My.Settings.TypoChance = NBTypoChance.Value
-		My.Settings.Save()
 	End Sub
 
 
 	Private Sub LBLBoobPath_MouseHover(sender As Object, e As System.EventArgs) Handles LBLBoobPath.MouseHover
 		TTDir.SetToolTip(LBLBoobPath, LBLBoobPath.Text)
 	End Sub
-	Private Sub LBLBoobURL_MouseHover(sender As Object, e As System.EventArgs) Handles LBLBoobURL.MouseHover
-		TTDir.SetToolTip(LBLBoobURL, LBLBoobURL.Text)
-	End Sub
 
 	Private Sub LBLButtPath_MouseHover(sender As Object, e As System.EventArgs) Handles LBLButtPath.MouseHover
 		TTDir.SetToolTip(LBLButtPath, LBLButtPath.Text)
-	End Sub
-	Private Sub LBLButtURL_MouseHover(sender As Object, e As System.EventArgs) Handles LBLButtURL.MouseHover
-		TTDir.SetToolTip(LBLButtURL, LBLButtURL.Text)
 	End Sub
 
 	Private Sub LBLIHardcore_MouseHover(sender As Object, e As System.EventArgs) Handles LBLIHardcore.MouseHover
@@ -13280,41 +12645,6 @@ WhyUMakeMeDoDis:
 	Private Sub LBLIGeneral_MouseHover(sender As Object, e As System.EventArgs) Handles LBLIGeneral.MouseHover
 		TTDir.SetToolTip(LBLIGeneral, LBLIGeneral.Text)
 	End Sub
-
-	Private Sub LBLURLHardcore_MouseHover(sender As Object, e As System.EventArgs) Handles LBLURLHardcore.MouseHover
-		TTDir.SetToolTip(LBLURLHardcore, LBLURLHardcore.Text)
-	End Sub
-	Private Sub LBLURLSoftcore_MouseHover(sender As Object, e As System.EventArgs) Handles LBLURLSoftcore.MouseHover
-		TTDir.SetToolTip(LBLURLSoftcore, LBLURLSoftcore.Text)
-	End Sub
-	Private Sub LBLURLLesbian_MouseHover(sender As Object, e As System.EventArgs) Handles LBLURLLesbian.MouseHover
-		TTDir.SetToolTip(LBLURLLesbian, LBLURLLesbian.Text)
-	End Sub
-	Private Sub LBLURLBlowjob_MouseHover(sender As Object, e As System.EventArgs) Handles LBLURLBlowjob.MouseHover
-		TTDir.SetToolTip(LBLURLBlowjob, LBLURLBlowjob.Text)
-	End Sub
-	Private Sub LBLURLFemdom_MouseHover(sender As Object, e As System.EventArgs) Handles LBLURLFemdom.MouseHover
-		TTDir.SetToolTip(LBLURLFemdom, LBLURLFemdom.Text)
-	End Sub
-	Private Sub LBLURLLezdom_MouseHover(sender As Object, e As System.EventArgs) Handles LBLURLLezdom.MouseHover
-		TTDir.SetToolTip(LBLURLLezdom, LBLURLLezdom.Text)
-	End Sub
-	Private Sub LBLURLHentai_MouseHover(sender As Object, e As System.EventArgs) Handles LBLURLHentai.MouseHover
-		TTDir.SetToolTip(LBLURLHentai, LBLURLHentai.Text)
-	End Sub
-	Private Sub LBLURLGay_MouseHover(sender As Object, e As System.EventArgs) Handles LBLURLGay.MouseHover
-		TTDir.SetToolTip(LBLURLGay, LBLURLGay.Text)
-	End Sub
-	Private Sub LBLURLMaledom_MouseHover(sender As Object, e As System.EventArgs) Handles LBLURLMaledom.MouseHover
-		TTDir.SetToolTip(LBLURLMaledom, LBLURLMaledom.Text)
-	End Sub
-	Private Sub LBLURLCaptions_MouseHover(sender As Object, e As System.EventArgs) Handles LBLURLCaptions.MouseHover
-		TTDir.SetToolTip(LBLURLCaptions, LBLURLCaptions.Text)
-	End Sub
-	Private Sub LBLURLGeneral_MouseHover(sender As Object, e As System.EventArgs) Handles LBLURLGeneral.MouseHover
-		TTDir.SetToolTip(LBLURLGeneral, LBLURLGeneral.Text)
-	End Sub
-
 
 	Private Sub BTNWICreateURL_MouseHover(sender As Object, e As System.EventArgs) Handles BTNWICreateURL.MouseHover
 		TTDir.SetToolTip(BTNWICreateURL, "Click here to create a new URL File." & Environment.NewLine & Environment.NewLine &
@@ -13460,11 +12790,9 @@ WhyUMakeMeDoDis:
 
 	Private Sub SliderVVolume_LostFocus(sender As Object, e As System.EventArgs) Handles SliderVVolume.LostFocus
 		My.Settings.VVolume = SliderVVolume.Value
-		My.Settings.Save()
 	End Sub
 	Private Sub SliderVRate_LostFocus(sender As Object, e As System.EventArgs) Handles SliderVRate.LostFocus
 		My.Settings.VRate = SliderVRate.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub SliderVVolume_MouseHover(sender As Object, e As System.EventArgs) Handles SliderVVolume.MouseHover
@@ -13488,12 +12816,10 @@ WhyUMakeMeDoDis:
 
 	Private Sub sadisticCheckBox_LostFocus(sender As Object, e As System.EventArgs) Handles sadisticCheckBox.LostFocus
 		My.Settings.DomSadistic = sadisticCheckBox.Checked
-		My.Settings.Save()
 	End Sub
 
 	Private Sub degradingCheckBox_LostFocus(sender As Object, e As System.EventArgs) Handles degradingCheckBox.LostFocus
 		My.Settings.DomDegrading = degradingCheckBox.Checked
-		My.Settings.Save()
 	End Sub
 
 
@@ -13534,7 +12860,6 @@ WhyUMakeMeDoDis:
 
 	Private Sub CBMuteMedia_LostFocus(sender As Object, e As System.EventArgs) Handles CBMuteMedia.LostFocus
 		My.Settings.MuteMedia = CBMuteMedia.Checked
-		My.Settings.Save()
 	End Sub
 
 
@@ -13548,7 +12873,6 @@ WhyUMakeMeDoDis:
 			LBLOfflineMode.Text = "ON"
 			LBLOfflineMode.ForeColor = Color.Green
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub CBNewSlideshow_LostFocus(sender As Object, e As System.EventArgs) Handles CBNewSlideshow.LostFocus
@@ -13557,12 +12881,10 @@ WhyUMakeMeDoDis:
 		Else
 			My.Settings.CBNewSlideshow = False
 		End If
-		My.Settings.Save()
 	End Sub
 
 	Private Sub NBTauntEdging_LostFocus(sender As Object, e As System.EventArgs) Handles NBTauntEdging.LostFocus
 		My.Settings.TauntEdging = NBTauntEdging.Value
-		My.Settings.Save()
 	End Sub
 
 	Private Sub BTNDebugTeaseTimer_Click(sender As System.Object, e As System.EventArgs) Handles BTNDebugTeaseTimer.Click
@@ -13585,167 +12907,90 @@ WhyUMakeMeDoDis:
 		Form1.HoldEdgeTick = 5
 	End Sub
 
+#Region "----------------------------------- GenreImages-Url-Files --------------------------------------"
 
+	Private Sub BtnImageUrlSetFile_Click(sender As System.Object, e As System.EventArgs) Handles BtnImageUrlHardcore.Click,
+					BtnImageUrlSoftcore.Click, BtnImageUrlMaledom.Click, BtnImageUrlLezdom.Click, BtnImageUrlLesbian.Click,
+					BtnImageUrlHentai.Click, BtnImageUrlGeneral.Click, BtnImageUrlGay.Click, BtnImageUrlFemdom.Click,
+					BtnImageUrlCaptions.Click, BtnImageUrlButt.Click, BtnImageUrlBoobs.Click, BtnImageUrlBlowjob.Click
+		Try
+			' Read the Row of the current Button
+			Dim tmpTlpRow As Integer = TlpImageUrls.GetRow(sender)
 
-	Private Sub BTNURLHardcore_Click(sender As System.Object, e As System.EventArgs) Handles BTNURLHardcore.Click
-		WebImageFileDialog.InitialDirectory = Application.StartupPath & "\Images\System\URL Files"
-		If (WebImageFileDialog.ShowDialog = Windows.Forms.DialogResult.OK) Then
-			LBLURLHardcore.Text = WebImageFileDialog.FileName
-			My.Settings.HardcoreURLFile = WebImageFileDialog.FileName
-			My.Settings.Save()
-		End If
-	End Sub
+			' Check if the Button is in the TableLayoutPanel.
+			If tmpTlpRow = -1 Then Throw New Exception("Can't find control in TableLayoutPanel. " &
+													   "This is a major Design issue has to be fixed in code.")
 
-	Private Sub BTNURLSoftcore_Click(sender As System.Object, e As System.EventArgs) Handles BTNURLSoftcore.Click
-		WebImageFileDialog.InitialDirectory = Application.StartupPath & "\Images\System\URL Files"
-		If (WebImageFileDialog.ShowDialog = Windows.Forms.DialogResult.OK) Then
-			LBLURLSoftcore.Text = WebImageFileDialog.FileName
-			My.Settings.SoftcoreURLFile = WebImageFileDialog.FileName
-			My.Settings.Save()
-		End If
-	End Sub
+			' Get the Checkbox for the current button
+			Dim tmpCheckbox As CheckBox = TlpImageUrls.GetControlFromPosition(0, tmpTlpRow)
 
-	Private Sub BTNURLLesbian_Click(sender As System.Object, e As System.EventArgs) Handles BTNURLLesbian.Click
-		WebImageFileDialog.InitialDirectory = Application.StartupPath & "\Images\System\URL Files"
-		If (WebImageFileDialog.ShowDialog = Windows.Forms.DialogResult.OK) Then
-			LBLURLLesbian.Text = WebImageFileDialog.FileName
-			My.Settings.LesbianURLFile = WebImageFileDialog.FileName
-			My.Settings.Save()
-		End If
-	End Sub
+			' Check if the Text-Property has an active Databinding.
+			If tmpCheckbox.DataBindings.Item("Checked") Is Nothing Then _
+				Throw New InvalidDataException("Databinding """" Checked """" was not found in Checkbox." &
+												"This is a major design issue and has to be fixed in code.")
 
-	Private Sub BTNURLBlowjob_Click(sender As System.Object, e As System.EventArgs) Handles BTNURLBlowjob.Click
-		WebImageFileDialog.InitialDirectory = Application.StartupPath & "\Images\System\URL Files"
-		If (WebImageFileDialog.ShowDialog = Windows.Forms.DialogResult.OK) Then
-			LBLURLBlowjob.Text = WebImageFileDialog.FileName
-			My.Settings.BlowjobURLFile = WebImageFileDialog.FileName
-			My.Settings.Save()
-		End If
-	End Sub
+			' Get the TExtBox for the Current Button
+			Dim tmpTextbox As TextBox = TlpImageUrls.GetControlFromPosition(2, tmpTlpRow)
 
-	Private Sub BTNURLFemdom_Click(sender As System.Object, e As System.EventArgs) Handles BTNURLFemdom.Click
-		WebImageFileDialog.InitialDirectory = Application.StartupPath & "\Images\System\URL Files"
-		If (WebImageFileDialog.ShowDialog = Windows.Forms.DialogResult.OK) Then
-			LBLURLFemdom.Text = WebImageFileDialog.FileName
-			My.Settings.FemdomURLFile = WebImageFileDialog.FileName
-			My.Settings.Save()
-		End If
-	End Sub
+			' Check if the Text-Property has an active Databinding.
+			If tmpTextbox.DataBindings.Item("Text") Is Nothing Then _
+				Throw New InvalidDataException("This function is only availabe with a Databound Textbox. " &
+												"This is a major design issue and has to be fixed in code.")
 
-	Private Sub BTNURLLezdom_Click(sender As System.Object, e As System.EventArgs) Handles BTNURLLezdom.Click
-		WebImageFileDialog.InitialDirectory = Application.StartupPath & "\Images\System\URL Files"
-		If (WebImageFileDialog.ShowDialog = Windows.Forms.DialogResult.OK) Then
-			LBLURLLezdom.Text = WebImageFileDialog.FileName
-			My.Settings.LezdomURLFile = WebImageFileDialog.FileName
-			My.Settings.Save()
-		End If
-	End Sub
+			'Declare a new instance of An OpenFileDialog. Use the URL-FilePat as initial
+			Dim tmpFS As New OpenFileDialog With {
+				.Filter = "Textfiles|*.txt",
+				.Multiselect = False,
+				.CheckFileExists = True,
+				.Title = "Select an " & tmpCheckbox.Text & " URL-File",
+				.InitialDirectory = Form1.pathUrlFileDir}
 
-	Private Sub BTNURLHentai_Click(sender As System.Object, e As System.EventArgs) Handles BTNURLHentai.Click
-		WebImageFileDialog.InitialDirectory = Application.StartupPath & "\Images\System\URL Files"
-		If (WebImageFileDialog.ShowDialog = Windows.Forms.DialogResult.OK) Then
-			LBLURLHentai.Text = WebImageFileDialog.FileName
-			My.Settings.HentaiURLFile = WebImageFileDialog.FileName
-			My.Settings.Save()
-		End If
-	End Sub
+			' Check if the URL-FilePath exits -> Otherwise create it.
+			If Not Directory.Exists(tmpFS.InitialDirectory) Then _
+			Directory.CreateDirectory(tmpFS.InitialDirectory)
 
-	Private Sub BTNURLGay_Click(sender As System.Object, e As System.EventArgs) Handles BTNURLGay.Click
-		WebImageFileDialog.InitialDirectory = Application.StartupPath & "\Images\System\URL Files"
-		If (WebImageFileDialog.ShowDialog = Windows.Forms.DialogResult.OK) Then
-			LBLURLGay.Text = WebImageFileDialog.FileName
-			My.Settings.GayURLFile = WebImageFileDialog.FileName
-			My.Settings.Save()
-		End If
-	End Sub
+			Dim tmpPath As String = tmpTextbox.Text
+			If tmpPath.ToLower.EndsWith(".txt") Then
+				If Path.IsPathRooted(tmpPath) AndAlso Directory.Exists(Path.GetDirectoryName(tmpPath)) Then
+					' Set an alternate Initial directory if filepath is absolute 
+					tmpFS.InitialDirectory = Path.GetDirectoryName(tmpPath)
+					tmpFS.FileName = Path.GetFileName(tmpPath)
+				Else
+					' Set the given Filename
+					tmpFS.FileName = tmpPath
+				End If
+			End If
 
-	Private Sub BTNURLMaledom_Click(sender As System.Object, e As System.EventArgs) Handles BTNURLMaledom.Click
-		WebImageFileDialog.InitialDirectory = Application.StartupPath & "\Images\System\URL Files"
-		If (WebImageFileDialog.ShowDialog = Windows.Forms.DialogResult.OK) Then
-			LBLURLMaledom.Text = WebImageFileDialog.FileName
-			My.Settings.MaledomURLFile = WebImageFileDialog.FileName
-			My.Settings.Save()
-		End If
+			If tmpFS.ShowDialog() = DialogResult.OK Then
+				If Path.GetDirectoryName(tmpFS.FileName).ToLower = Path.GetDirectoryName(Form1.pathUrlFileDir).ToLower Then
+					' If the file is located standarddirectory st only the filename
+					tmpTextbox.Text = tmpFS.SafeFileName
+				Else
+					' Otherwise set the absoulte filepath
+					tmpTextbox.Text = tmpFS.FileName
+				End If
+
+				' This will force the Settings to save.
+				tmpCheckbox.Checked = True
+			End If
+		Catch ex As Exception
+			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+			'						       All Errors
+			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+			MsgBox(ex.Message & vbCrLf & "Please report this error at the Milovana Forum.",
+				   MsgBoxStyle.Critical, "Cant Set URl-File")
+			Log.WriteError(ex.Message, ex, "Error Set Url-File")
+		End Try
 	End Sub
 
-	Private Sub BTNURLCaptions_Click(sender As System.Object, e As System.EventArgs) Handles BTNURLCaptions.Click
-		WebImageFileDialog.InitialDirectory = Application.StartupPath & "\Images\System\URL Files"
-		If (WebImageFileDialog.ShowDialog = Windows.Forms.DialogResult.OK) Then
-			LBLURLCaptions.Text = WebImageFileDialog.FileName
-			My.Settings.CaptionsURLFile = WebImageFileDialog.FileName
-			My.Settings.Save()
-		End If
-	End Sub
+#End Region 'GenreImages-Url-Files
 
-	Private Sub BTNURLGeneral_Click(sender As System.Object, e As System.EventArgs) Handles BTNURLGeneral.Click
-		WebImageFileDialog.InitialDirectory = Application.StartupPath & "\Images\System\URL Files"
-		If (WebImageFileDialog.ShowDialog = Windows.Forms.DialogResult.OK) Then
-			LBLURLGeneral.Text = WebImageFileDialog.FileName
-			My.Settings.GeneralURLFile = WebImageFileDialog.FileName
-			My.Settings.Save()
-		End If
-	End Sub
-
-	Private Sub CBURLHardcore_LostFocus(sender As Object, e As System.EventArgs) Handles CBURLHardcore.LostFocus
-		My.Settings.CBURLHardcore = CBURLHardcore.Checked
-		My.Settings.Save()
-	End Sub
-	Private Sub CBURLSoftcore_LostFocus(sender As Object, e As System.EventArgs) Handles CBURLSoftcore.LostFocus
-		My.Settings.CBURLSoftcore = CBURLSoftcore.Checked
-		My.Settings.Save()
-	End Sub
-	Private Sub CBURLLesbian_LostFocus(sender As Object, e As System.EventArgs) Handles CBURLLesbian.LostFocus
-		My.Settings.CBURLLesbian = CBURLLesbian.Checked
-		My.Settings.Save()
-	End Sub
-	Private Sub CBURLBlowjob_LostFocus(sender As Object, e As System.EventArgs) Handles CBURLBlowjob.LostFocus
-		My.Settings.CBURLBlowjob = CBURLBlowjob.Checked
-		My.Settings.Save()
-	End Sub
-	Private Sub CBURLFemdom_LostFocus(sender As Object, e As System.EventArgs) Handles CBURLFemdom.LostFocus
-		My.Settings.CBURLFemdom = CBURLFemdom.Checked
-		My.Settings.Save()
-	End Sub
-	Private Sub CBURLLezdom_LostFocus(sender As Object, e As System.EventArgs) Handles CBURLLezdom.LostFocus
-		My.Settings.CBURLLezdom = CBURLLezdom.Checked
-		My.Settings.Save()
-	End Sub
-	Private Sub CBURLHentai_LostFocus(sender As Object, e As System.EventArgs) Handles CBURLHentai.LostFocus
-		My.Settings.CBURLHentai = CBURLHentai.Checked
-		My.Settings.Save()
-	End Sub
-	Private Sub CBURLGay_LostFocus(sender As Object, e As System.EventArgs) Handles CBURLGay.LostFocus
-		My.Settings.CBURLGay = CBURLGay.Checked
-		My.Settings.Save()
-	End Sub
-	Private Sub CBURLMaledom_LostFocus(sender As Object, e As System.EventArgs) Handles CBURLMaledom.LostFocus
-		My.Settings.CBURLMaledom = CBURLMaledom.Checked
-		My.Settings.Save()
-	End Sub
-	Private Sub CBURLCaptions_LostFocus(sender As Object, e As System.EventArgs) Handles CBURLCaptions.LostFocus
-		My.Settings.CBURLCaptions = CBURLCaptions.Checked
-		My.Settings.Save()
-	End Sub
-	Private Sub CBURLGeneral_LostFocus(sender As Object, e As System.EventArgs) Handles CBURLGeneral.LostFocus
-		My.Settings.CBURLGeneral = CBURLGeneral.Checked
-		My.Settings.Save()
-	End Sub
-	Private Sub CBURLBoobs_LostFocus(sender As Object, e As System.EventArgs) Handles CBURLBoobs.LostFocus
-		My.Settings.CBURLBoobs = CBURLBoobs.Checked
-		My.Settings.Save()
-	End Sub
-	Private Sub CBURLButts_LostFocus(sender As Object, e As System.EventArgs) Handles CBURLButts.LostFocus
-		My.Settings.CBURLButts = CBURLButts.Checked
-		My.Settings.Save()
-	End Sub
 
 	Private Sub CBIButts_LostFocus(sender As Object, e As System.EventArgs) Handles CBIButts.LostFocus
 		My.Settings.CBIButts = CBIButts.Checked
-		My.Settings.Save()
 	End Sub
 	Private Sub CBIBoobs_LostFocus(sender As Object, e As System.EventArgs) Handles CBIBoobs.LostFocus
 		My.Settings.CBIBoobs = CBIBoobs.Checked
-		My.Settings.Save()
 	End Sub
 
 

--- a/Tease AI/My Project/Settings.Designer.vb
+++ b/Tease AI/My Project/Settings.Designer.vb
@@ -1540,13 +1540,13 @@ Namespace My
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("")>  _
-        Public Property LBLBoobURL() As String
+         Global.System.Configuration.DefaultSettingValueAttribute("No URL File selected")>  _
+        Public Property UrlFileBoobs() As String
             Get
-                Return CType(Me("LBLBoobURL"),String)
+                Return CType(Me("UrlFileBoobs"),String)
             End Get
             Set
-                Me("LBLBoobURL") = value
+                Me("UrlFileBoobs") = value
             End Set
         End Property
         
@@ -1564,13 +1564,13 @@ Namespace My
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("")>  _
-        Public Property LBLButtURL() As String
+         Global.System.Configuration.DefaultSettingValueAttribute("No URL File selected")>  _
+        Public Property UrlFileButt() As String
             Get
-                Return CType(Me("LBLButtURL"),String)
+                Return CType(Me("UrlFileButt"),String)
             End Get
             Set
-                Me("LBLButtURL") = value
+                Me("UrlFileButt") = value
             End Set
         End Property
         
@@ -5255,264 +5255,264 @@ Namespace My
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("No URL File selected")>  _
-        Public Property HardcoreURLFile() As String
+        Public Property UrlFileHardcore() As String
             Get
-                Return CType(Me("HardcoreURLFile"),String)
+                Return CType(Me("UrlFileHardcore"),String)
             End Get
             Set
-                Me("HardcoreURLFile") = value
+                Me("UrlFileHardcore") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("No URL File selected")>  _
-        Public Property SoftcoreURLFile() As String
+        Public Property UrlFileSoftcore() As String
             Get
-                Return CType(Me("SoftcoreURLFile"),String)
+                Return CType(Me("UrlFileSoftcore"),String)
             End Get
             Set
-                Me("SoftcoreURLFile") = value
+                Me("UrlFileSoftcore") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("No URL File selected")>  _
-        Public Property LesbianURLFile() As String
+        Public Property UrlFileLesbian() As String
             Get
-                Return CType(Me("LesbianURLFile"),String)
+                Return CType(Me("UrlFileLesbian"),String)
             End Get
             Set
-                Me("LesbianURLFile") = value
+                Me("UrlFileLesbian") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("No URL File selected")>  _
-        Public Property BlowjobURLFile() As String
+        Public Property UrlFileBlowjob() As String
             Get
-                Return CType(Me("BlowjobURLFile"),String)
+                Return CType(Me("UrlFileBlowjob"),String)
             End Get
             Set
-                Me("BlowjobURLFile") = value
+                Me("UrlFileBlowjob") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("No URL File selected")>  _
-        Public Property FemdomURLFile() As String
+        Public Property UrlFileFemdom() As String
             Get
-                Return CType(Me("FemdomURLFile"),String)
+                Return CType(Me("UrlFileFemdom"),String)
             End Get
             Set
-                Me("FemdomURLFile") = value
+                Me("UrlFileFemdom") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("No URL File selected")>  _
-        Public Property LezdomURLFile() As String
+        Public Property UrlFileLezdom() As String
             Get
-                Return CType(Me("LezdomURLFile"),String)
+                Return CType(Me("UrlFileLezdom"),String)
             End Get
             Set
-                Me("LezdomURLFile") = value
+                Me("UrlFileLezdom") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("No URL File selected")>  _
-        Public Property HentaiURLFile() As String
+        Public Property UrlFileHentai() As String
             Get
-                Return CType(Me("HentaiURLFile"),String)
+                Return CType(Me("UrlFileHentai"),String)
             End Get
             Set
-                Me("HentaiURLFile") = value
+                Me("UrlFileHentai") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("No URL File selected")>  _
-        Public Property GayURLFile() As String
+        Public Property UrlFileGay() As String
             Get
-                Return CType(Me("GayURLFile"),String)
+                Return CType(Me("UrlFileGay"),String)
             End Get
             Set
-                Me("GayURLFile") = value
+                Me("UrlFileGay") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("No URL File selected")>  _
-        Public Property MaledomURLFile() As String
+        Public Property UrlFileMaledom() As String
             Get
-                Return CType(Me("MaledomURLFile"),String)
+                Return CType(Me("UrlFileMaledom"),String)
             End Get
             Set
-                Me("MaledomURLFile") = value
+                Me("UrlFileMaledom") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("No URL File selected")>  _
-        Public Property CaptionsURLFile() As String
+        Public Property UrlFileCaptions() As String
             Get
-                Return CType(Me("CaptionsURLFile"),String)
+                Return CType(Me("UrlFileCaptions"),String)
             End Get
             Set
-                Me("CaptionsURLFile") = value
+                Me("UrlFileCaptions") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("No URL File selected")>  _
-        Public Property GeneralURLFile() As String
+        Public Property UrlFileGeneral() As String
             Get
-                Return CType(Me("GeneralURLFile"),String)
+                Return CType(Me("UrlFileGeneral"),String)
             End Get
             Set
-                Me("GeneralURLFile") = value
+                Me("UrlFileGeneral") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
-        Public Property CBURLHardcore() As Boolean
+        Public Property UrlFileHardcoreEnabled() As Boolean
             Get
-                Return CType(Me("CBURLHardcore"),Boolean)
+                Return CType(Me("UrlFileHardcoreEnabled"),Boolean)
             End Get
             Set
-                Me("CBURLHardcore") = value
+                Me("UrlFileHardcoreEnabled") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
-        Public Property CBURLSoftcore() As Boolean
+        Public Property UrlFileSoftcoreEnabled() As Boolean
             Get
-                Return CType(Me("CBURLSoftcore"),Boolean)
+                Return CType(Me("UrlFileSoftcoreEnabled"),Boolean)
             End Get
             Set
-                Me("CBURLSoftcore") = value
+                Me("UrlFileSoftcoreEnabled") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
-        Public Property CBURLLesbian() As Boolean
+        Public Property UrlFileLesbianEnabled() As Boolean
             Get
-                Return CType(Me("CBURLLesbian"),Boolean)
+                Return CType(Me("UrlFileLesbianEnabled"),Boolean)
             End Get
             Set
-                Me("CBURLLesbian") = value
+                Me("UrlFileLesbianEnabled") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
-        Public Property CBURLBlowjob() As Boolean
+        Public Property UrlFileBlowjobEnabled() As Boolean
             Get
-                Return CType(Me("CBURLBlowjob"),Boolean)
+                Return CType(Me("UrlFileBlowjobEnabled"),Boolean)
             End Get
             Set
-                Me("CBURLBlowjob") = value
+                Me("UrlFileBlowjobEnabled") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
-        Public Property CBURLFemdom() As Boolean
+        Public Property UrlFileFemdomEnabled() As Boolean
             Get
-                Return CType(Me("CBURLFemdom"),Boolean)
+                Return CType(Me("UrlFileFemdomEnabled"),Boolean)
             End Get
             Set
-                Me("CBURLFemdom") = value
+                Me("UrlFileFemdomEnabled") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
-        Public Property CBURLLezdom() As Boolean
+        Public Property UrlFileLezdomEnabled() As Boolean
             Get
-                Return CType(Me("CBURLLezdom"),Boolean)
+                Return CType(Me("UrlFileLezdomEnabled"),Boolean)
             End Get
             Set
-                Me("CBURLLezdom") = value
+                Me("UrlFileLezdomEnabled") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
-        Public Property CBURLHentai() As Boolean
+        Public Property UrlFileHentaiEnabled() As Boolean
             Get
-                Return CType(Me("CBURLHentai"),Boolean)
+                Return CType(Me("UrlFileHentaiEnabled"),Boolean)
             End Get
             Set
-                Me("CBURLHentai") = value
+                Me("UrlFileHentaiEnabled") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
-        Public Property CBURLGay() As Boolean
+        Public Property UrlFileGayEnabled() As Boolean
             Get
-                Return CType(Me("CBURLGay"),Boolean)
+                Return CType(Me("UrlFileGayEnabled"),Boolean)
             End Get
             Set
-                Me("CBURLGay") = value
+                Me("UrlFileGayEnabled") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
-        Public Property CBURLMaledom() As Boolean
+        Public Property UrlFileMaledomEnabled() As Boolean
             Get
-                Return CType(Me("CBURLMaledom"),Boolean)
+                Return CType(Me("UrlFileMaledomEnabled"),Boolean)
             End Get
             Set
-                Me("CBURLMaledom") = value
+                Me("UrlFileMaledomEnabled") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
-        Public Property CBURLCaptions() As Boolean
+        Public Property UrlFileCaptionsEnabled() As Boolean
             Get
-                Return CType(Me("CBURLCaptions"),Boolean)
+                Return CType(Me("UrlFileCaptionsEnabled"),Boolean)
             End Get
             Set
-                Me("CBURLCaptions") = value
+                Me("UrlFileCaptionsEnabled") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
-        Public Property CBURLGeneral() As Boolean
+        Public Property UrlFileGeneralEnabled() As Boolean
             Get
-                Return CType(Me("CBURLGeneral"),Boolean)
+                Return CType(Me("UrlFileGeneralEnabled"),Boolean)
             End Get
             Set
-                Me("CBURLGeneral") = value
+                Me("UrlFileGeneralEnabled") = value
             End Set
         End Property
         
@@ -5543,24 +5543,24 @@ Namespace My
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
-        Public Property CBURLBoobs() As Boolean
+        Public Property UrlFileBoobsEnabled() As Boolean
             Get
-                Return CType(Me("CBURLBoobs"),Boolean)
+                Return CType(Me("UrlFileBoobsEnabled"),Boolean)
             End Get
             Set
-                Me("CBURLBoobs") = value
+                Me("UrlFileBoobsEnabled") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
-        Public Property CBURLButts() As Boolean
+        Public Property UrlFileButtEnabled() As Boolean
             Get
-                Return CType(Me("CBURLButts"),Boolean)
+                Return CType(Me("UrlFileButtEnabled"),Boolean)
             End Get
             Set
-                Me("CBURLButts") = value
+                Me("UrlFileButtEnabled") = value
             End Set
         End Property
         
@@ -5723,9 +5723,9 @@ Namespace My
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
-        Public Property WritingProgress() As String
+        Public Property WritingProgress() As Boolean
             Get
-                Return CType(Me("WritingProgress"),String)
+                Return CType(Me("WritingProgress"),Boolean)
             End Get
             Set
                 Me("WritingProgress") = value
@@ -5735,9 +5735,9 @@ Namespace My
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
-        Public Property TimedWriting() As String
+        Public Property TimedWriting() As Boolean
             Get
-                Return CType(Me("TimedWriting"),String)
+                Return CType(Me("TimedWriting"),Boolean)
             End Get
             Set
                 Me("TimedWriting") = value
@@ -5747,9 +5747,9 @@ Namespace My
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("50")>  _
-        Public Property TypeSpeed() As String
+        Public Property TypeSpeed() As Integer
             Get
-                Return CType(Me("TypeSpeed"),String)
+                Return CType(Me("TypeSpeed"),Integer)
             End Get
             Set
                 Me("TypeSpeed") = value

--- a/Tease AI/My Project/Settings.settings
+++ b/Tease AI/My Project/Settings.settings
@@ -374,14 +374,14 @@
     <Setting Name="LBLBoobPath" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
-    <Setting Name="LBLBoobURL" Type="System.String" Scope="User">
-      <Value Profile="(Default)" />
+    <Setting Name="UrlFileBoobs" Type="System.String" Scope="User">
+      <Value Profile="(Default)">No URL File selected</Value>
     </Setting>
     <Setting Name="LBLButtPath" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
-    <Setting Name="LBLButtURL" Type="System.String" Scope="User">
-      <Value Profile="(Default)" />
+    <Setting Name="UrlFileButt" Type="System.String" Scope="User">
+      <Value Profile="(Default)">No URL File selected</Value>
     </Setting>
     <Setting Name="CBBnBLocal" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
@@ -1305,70 +1305,70 @@
     <Setting Name="TauntEdging" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">70</Value>
     </Setting>
-    <Setting Name="HardcoreURLFile" Type="System.String" Scope="User">
+    <Setting Name="UrlFileHardcore" Type="System.String" Scope="User">
       <Value Profile="(Default)">No URL File selected</Value>
     </Setting>
-    <Setting Name="SoftcoreURLFile" Type="System.String" Scope="User">
+    <Setting Name="UrlFileSoftcore" Type="System.String" Scope="User">
       <Value Profile="(Default)">No URL File selected</Value>
     </Setting>
-    <Setting Name="LesbianURLFile" Type="System.String" Scope="User">
+    <Setting Name="UrlFileLesbian" Type="System.String" Scope="User">
       <Value Profile="(Default)">No URL File selected</Value>
     </Setting>
-    <Setting Name="BlowjobURLFile" Type="System.String" Scope="User">
+    <Setting Name="UrlFileBlowjob" Type="System.String" Scope="User">
       <Value Profile="(Default)">No URL File selected</Value>
     </Setting>
-    <Setting Name="FemdomURLFile" Type="System.String" Scope="User">
+    <Setting Name="UrlFileFemdom" Type="System.String" Scope="User">
       <Value Profile="(Default)">No URL File selected</Value>
     </Setting>
-    <Setting Name="LezdomURLFile" Type="System.String" Scope="User">
+    <Setting Name="UrlFileLezdom" Type="System.String" Scope="User">
       <Value Profile="(Default)">No URL File selected</Value>
     </Setting>
-    <Setting Name="HentaiURLFile" Type="System.String" Scope="User">
+    <Setting Name="UrlFileHentai" Type="System.String" Scope="User">
       <Value Profile="(Default)">No URL File selected</Value>
     </Setting>
-    <Setting Name="GayURLFile" Type="System.String" Scope="User">
+    <Setting Name="UrlFileGay" Type="System.String" Scope="User">
       <Value Profile="(Default)">No URL File selected</Value>
     </Setting>
-    <Setting Name="MaledomURLFile" Type="System.String" Scope="User">
+    <Setting Name="UrlFileMaledom" Type="System.String" Scope="User">
       <Value Profile="(Default)">No URL File selected</Value>
     </Setting>
-    <Setting Name="CaptionsURLFile" Type="System.String" Scope="User">
+    <Setting Name="UrlFileCaptions" Type="System.String" Scope="User">
       <Value Profile="(Default)">No URL File selected</Value>
     </Setting>
-    <Setting Name="GeneralURLFile" Type="System.String" Scope="User">
+    <Setting Name="UrlFileGeneral" Type="System.String" Scope="User">
       <Value Profile="(Default)">No URL File selected</Value>
     </Setting>
-    <Setting Name="CBURLHardcore" Type="System.Boolean" Scope="User">
+    <Setting Name="UrlFileHardcoreEnabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="CBURLSoftcore" Type="System.Boolean" Scope="User">
+    <Setting Name="UrlFileSoftcoreEnabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="CBURLLesbian" Type="System.Boolean" Scope="User">
+    <Setting Name="UrlFileLesbianEnabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="CBURLBlowjob" Type="System.Boolean" Scope="User">
+    <Setting Name="UrlFileBlowjobEnabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="CBURLFemdom" Type="System.Boolean" Scope="User">
+    <Setting Name="UrlFileFemdomEnabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="CBURLLezdom" Type="System.Boolean" Scope="User">
+    <Setting Name="UrlFileLezdomEnabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="CBURLHentai" Type="System.Boolean" Scope="User">
+    <Setting Name="UrlFileHentaiEnabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="CBURLGay" Type="System.Boolean" Scope="User">
+    <Setting Name="UrlFileGayEnabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="CBURLMaledom" Type="System.Boolean" Scope="User">
+    <Setting Name="UrlFileMaledomEnabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="CBURLCaptions" Type="System.Boolean" Scope="User">
+    <Setting Name="UrlFileCaptionsEnabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="CBURLGeneral" Type="System.Boolean" Scope="User">
+    <Setting Name="UrlFileGeneralEnabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="CBIBoobs" Type="System.Boolean" Scope="User">
@@ -1377,10 +1377,10 @@
     <Setting Name="CBIButts" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="CBURLBoobs" Type="System.Boolean" Scope="User">
+    <Setting Name="UrlFileBoobsEnabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="CBURLButts" Type="System.Boolean" Scope="User">
+    <Setting Name="UrlFileButtEnabled" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="CBURLPreview" Type="System.Boolean" Scope="User">

--- a/Tease AI/app.config
+++ b/Tease AI/app.config
@@ -401,14 +401,14 @@
             <setting name="LBLBoobPath" serializeAs="String">
                 <value />
             </setting>
-            <setting name="LBLBoobURL" serializeAs="String">
-                <value />
+            <setting name="UrlFileBoobs" serializeAs="String">
+                <value>No URL File selected</value>
             </setting>
             <setting name="LBLButtPath" serializeAs="String">
                 <value />
             </setting>
-            <setting name="LBLButtURL" serializeAs="String">
-                <value />
+            <setting name="UrlFileButt" serializeAs="String">
+                <value>No URL File selected</value>
             </setting>
             <setting name="CBBnBLocal" serializeAs="String">
                 <value>True</value>
@@ -1334,70 +1334,70 @@
             <setting name="TauntEdging" serializeAs="String">
                 <value>70</value>
             </setting>
-            <setting name="HardcoreURLFile" serializeAs="String">
+            <setting name="UrlFileHardcore" serializeAs="String">
                 <value>No URL File selected</value>
             </setting>
-            <setting name="SoftcoreURLFile" serializeAs="String">
+            <setting name="UrlFileSoftcore" serializeAs="String">
                 <value>No URL File selected</value>
             </setting>
-            <setting name="LesbianURLFile" serializeAs="String">
+            <setting name="UrlFileLesbian" serializeAs="String">
                 <value>No URL File selected</value>
             </setting>
-            <setting name="BlowjobURLFile" serializeAs="String">
+            <setting name="UrlFileBlowjob" serializeAs="String">
                 <value>No URL File selected</value>
             </setting>
-            <setting name="FemdomURLFile" serializeAs="String">
+            <setting name="UrlFileFemdom" serializeAs="String">
                 <value>No URL File selected</value>
             </setting>
-            <setting name="LezdomURLFile" serializeAs="String">
+            <setting name="UrlFileLezdom" serializeAs="String">
                 <value>No URL File selected</value>
             </setting>
-            <setting name="HentaiURLFile" serializeAs="String">
+            <setting name="UrlFileHentai" serializeAs="String">
                 <value>No URL File selected</value>
             </setting>
-            <setting name="GayURLFile" serializeAs="String">
+            <setting name="UrlFileGay" serializeAs="String">
                 <value>No URL File selected</value>
             </setting>
-            <setting name="MaledomURLFile" serializeAs="String">
+            <setting name="UrlFileMaledom" serializeAs="String">
                 <value>No URL File selected</value>
             </setting>
-            <setting name="CaptionsURLFile" serializeAs="String">
+            <setting name="UrlFileCaptions" serializeAs="String">
                 <value>No URL File selected</value>
             </setting>
-            <setting name="GeneralURLFile" serializeAs="String">
+            <setting name="UrlFileGeneral" serializeAs="String">
                 <value>No URL File selected</value>
             </setting>
-            <setting name="CBURLHardcore" serializeAs="String">
+            <setting name="UrlFileHardcoreEnabled" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="CBURLSoftcore" serializeAs="String">
+            <setting name="UrlFileSoftcoreEnabled" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="CBURLLesbian" serializeAs="String">
+            <setting name="UrlFileLesbianEnabled" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="CBURLBlowjob" serializeAs="String">
+            <setting name="UrlFileBlowjobEnabled" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="CBURLFemdom" serializeAs="String">
+            <setting name="UrlFileFemdomEnabled" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="CBURLLezdom" serializeAs="String">
+            <setting name="UrlFileLezdomEnabled" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="CBURLHentai" serializeAs="String">
+            <setting name="UrlFileHentaiEnabled" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="CBURLGay" serializeAs="String">
+            <setting name="UrlFileGayEnabled" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="CBURLMaledom" serializeAs="String">
+            <setting name="UrlFileMaledomEnabled" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="CBURLCaptions" serializeAs="String">
+            <setting name="UrlFileCaptionsEnabled" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="CBURLGeneral" serializeAs="String">
+            <setting name="UrlFileGeneralEnabled" serializeAs="String">
                 <value>False</value>
             </setting>
             <setting name="CBIBoobs" serializeAs="String">
@@ -1406,10 +1406,10 @@
             <setting name="CBIButts" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="CBURLBoobs" serializeAs="String">
+            <setting name="UrlFileBoobsEnabled" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="CBURLButts" serializeAs="String">
+            <setting name="UrlFileButtEnabled" serializeAs="String">
                 <value>False</value>
             </setting>
             <setting name="CBURLPreview" serializeAs="String">


### PR DESCRIPTION
Changed the way how UserSettings are stored. Now every time a setting is changed, the settingsfile will be saved after a delay of one second(to keep disk traffic low). This function is activated after the Settings are initially loaded. During reset this feature is suspended.

Removed all references to My.Settings.Save() in Form2.
Added Support for relative filepaths when using GenreImage-UrlFiles. Files outside the "Images\System\Url Files"-directory are neither included on Rebuild nor Refresh! But they are included in DeleteCommands.
The PropertyNames containing the URL-FilePaths have been renamed, in order to enhance readability. Those settings have to be reapplied. This will prevent the use of wrong Url-Files too.

Bugfix: 404 caused the Script to stop. Errors during ImageLoading will create now a LogEntry.
