### PR TITLE
Bugfix NullReferenceException

### DIFF
--- a/Tease AI/Classes/URL_Files_BGW.vb
+++ b/Tease AI/Classes/URL_Files_BGW.vb
@@ -163,13 +163,13 @@ System.ComponentModel.Description("Determines the Target Directory of the URL-Fi
 		''' <summary>
 		''' Stores the Filepath to Dislikelist.
 		''' </summary>
-		<System.ComponentModel.Category("Behavior"),
-System.ComponentModel.Description("Gets or Sets the Filepath to the Dislikelist.")>
 		Private _DislikeListPath As String = "Images\System\DislikedImageURLs.txt"
 		''' <summary>
 		''' Gets or Sets the Filepath To the Dislikelist.
 		''' </summary>
 		''' <returns>Returns the Filepath to the Dislikelist.</returns>
+		<System.ComponentModel.Category("Behavior"),
+System.ComponentModel.Description("Gets or Sets the Filepath to the Dislikelist.")>
 		Public Property DislikeListPath As String
 			Get
 				Return _DislikeListPath

--- a/Tease AI/Form2.Designer.vb
+++ b/Tease AI/Form2.Designer.vb
@@ -1111,6 +1111,7 @@ Partial Class FrmSettings
 		Me.TrackBar2 = New System.Windows.Forms.TrackBar()
 		Me.TxbImgUrlHardcore = New System.Windows.Forms.TextBox()
 		Me.TextBox2 = New System.Windows.Forms.TextBox()
+		Me.BWURLFiles = New Tease_AI.URL_Files.URL_File_BGW()
 		Me.SettingsPanel.SuspendLayout()
 		Me.SettingsTabs.SuspendLayout()
 		Me.TabPage1.SuspendLayout()
@@ -14396,6 +14397,14 @@ Partial Class FrmSettings
 		Me.TextBox2.Size = New System.Drawing.Size(189, 20)
 		Me.TextBox2.TabIndex = 145
 		'
+		'BWURLFiles
+		'
+		Me.BWURLFiles.DislikeListPath = "Images\System\DislikedImageURLs.txt"
+		Me.BWURLFiles.ImageURLFileDir = "Images\System\URL Files\"
+		Me.BWURLFiles.LikeListPath = "Images\System\LikedImageURLs.txt"
+		Me.BWURLFiles.WorkerReportsProgress = True
+		Me.BWURLFiles.WorkerSupportsCancellation = True
+		'
 		'FrmSettings
 		'
 		Me.AllowDrop = True
@@ -15717,7 +15726,6 @@ Partial Class FrmSettings
 	Friend WithEvents CheckBox1 As System.Windows.Forms.CheckBox
 	Friend WithEvents Label135 As System.Windows.Forms.Label
 	Friend WithEvents TrackBar2 As System.Windows.Forms.TrackBar
-	Friend WithEvents BWURLFiles As Tease_AI.URL_Files.URL_File_BGW
 	Friend WithEvents BTNOfflineMode As System.Windows.Forms.Button
 	Friend WithEvents LBLOfflineMode As System.Windows.Forms.Label
 	Friend WithEvents Label140 As System.Windows.Forms.Label
@@ -15833,4 +15841,5 @@ Partial Class FrmSettings
 	Friend WithEvents TxbImageUrlButts As TextBox
 	Friend WithEvents TxbImgUrlHardcore As TextBox
 	Friend WithEvents TextBox2 As TextBox
+	Friend WithEvents BWURLFiles As URL_Files.URL_File_BGW
 End Class

--- a/Tease AI/Form2.resx
+++ b/Tease AI/Form2.resx
@@ -1610,4 +1610,7 @@ Local Images - Select which genres and paths you would like to use for local ima
   <metadata name="TTDir.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>1479, 17</value>
   </metadata>
+  <metadata name="BWURLFiles.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>5, 12</value>
+  </metadata>
 </root>


### PR DESCRIPTION
When starting a URL-Action a NullreferenceException occured. This was because of missing Designercode.
The Object BwUrlFiles was declared, but no new ObjectInstance created.
The description file for the Property "DislikeListPath" moved to the Property. Was the bound variable.
