### PR TITLE
BugFix Exception on Closing

### DIFF
--- a/Tease AI/Form1.vb
+++ b/Tease AI/Form1.vb
@@ -583,19 +583,19 @@ ByVal lpstrReturnString As String, ByVal uReturnLength As Integer, ByVal hwndCal
 
 
 
-	Private Sub Form1_FormClosed(sender As Object, e As System.Windows.Forms.FormClosedEventArgs) Handles Me.FormClosed
-
+	Private Sub Form1_FormClosing(sender As Object, e As System.Windows.Forms.FormClosingEventArgs) Handles Me.FormClosing
 
 
 		mainPictureBox.Image = Nothing
 		Debug.Print("Here?")
 
+		TeaseAIClock.Stop()
 		UpdatesTimer.Stop()
 		StrokeTimeTotalTimer.Stop()
 		StopEverything()
 
-		'ScriptTimer.Stop()
-		'StrokeTimer.Stop()
+
+
 
 
 
@@ -10454,7 +10454,7 @@ RinseLatherRepeat:
 
 				' Change evtl. wrong given Slashes
 				ImageToShow = ImageToShow.Replace("/", "\")
-				
+
 				ImageToShow = Application.StartupPath & "\Images\" & ImageToShow
 				ImageToShow = ImageToShow.Replace("\\", "\")
 
@@ -15229,11 +15229,11 @@ VTSkip:
 					Return False
 				End If
 
-				End If
+			End If
 
 		Else
-				If CompareDatesWithTime(GetDate(DateFlag)) <> 1 Then Return True
-				Return False
+			If CompareDatesWithTime(GetDate(DateFlag)) <> 1 Then Return True
+			Return False
 		End If
 
 		Return False


### PR DESCRIPTION
Changed Form1.FormClosed to Form1.FormClosing to call everything before it's disposing. TeaseAIClock is stopped now.

This solves the following errors on application close:
System.InvalidOperationException: The form referred to itself during construction from a default instance, which led to infinite recursion. Within the Form's constructor refer to the form using 'Me.'
