### PR TITLE
BugFix: Timeouts and WebExceptions on imagedownloads

### DIFF
--- a/Tease AI/Form1.Designer.vb
+++ b/Tease AI/Form1.Designer.vb
@@ -401,6 +401,7 @@ Partial Class Form1
 		Me.TimeoutTimer = New Tease_AI.teaseAI_Timer()
 		Me.VideoTimer = New Tease_AI.teaseAI_Timer()
 		Me.MultipleEdgesTimer = New Tease_AI.teaseAI_Timer()
+		Me.ClearMainpictureboxToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
 		CType(Me.mainPictureBox, System.ComponentModel.ISupportInitialize).BeginInit()
 		CType(Me.domAvatar, System.ComponentModel.ISupportInitialize).BeginInit()
 		CType(Me.SplitContainer1, System.ComponentModel.ISupportInitialize).BeginInit()
@@ -1252,8 +1253,8 @@ Partial Class Form1
 		'OpenFileDialog1
 		'
 		Me.OpenFileDialog1.FileName = "OpenFileDialog1"
-		Me.OpenFileDialog1.Filter = "JPEG Files (*.jpg)|*.jpg|PNG Files (*.png)|*.png|BMP Files (*.bmp)|*.bmp|All file" & _
-		  "s (*.*)|*.*"
+		Me.OpenFileDialog1.Filter = "JPEG Files (*.jpg)|*.jpg|PNG Files (*.png)|*.png|BMP Files (*.bmp)|*.bmp|All file" &
+	"s (*.*)|*.*"
 		Me.OpenFileDialog1.Title = "Select an image file"
 		'
 		'GetColor
@@ -2037,7 +2038,7 @@ Partial Class Form1
 		'
 		'DebugToolStripMenuItem
 		'
-		Me.DebugToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.RunScriptToolStripMenuItem, Me.DebugMenuToolStripMenuItem, Me.ToolStripSeparator13, Me.RefreshRandomizerToolStripMenuItem})
+		Me.DebugToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.RunScriptToolStripMenuItem, Me.DebugMenuToolStripMenuItem, Me.ToolStripSeparator13, Me.RefreshRandomizerToolStripMenuItem, Me.ClearMainpictureboxToolStripMenuItem})
 		Me.DebugToolStripMenuItem.Name = "DebugToolStripMenuItem"
 		Me.DebugToolStripMenuItem.Size = New System.Drawing.Size(54, 20)
 		Me.DebugToolStripMenuItem.Text = "Debug"
@@ -2045,24 +2046,24 @@ Partial Class Form1
 		'RunScriptToolStripMenuItem
 		'
 		Me.RunScriptToolStripMenuItem.Name = "RunScriptToolStripMenuItem"
-		Me.RunScriptToolStripMenuItem.Size = New System.Drawing.Size(179, 22)
+		Me.RunScriptToolStripMenuItem.Size = New System.Drawing.Size(187, 22)
 		Me.RunScriptToolStripMenuItem.Text = "Run Script"
 		'
 		'DebugMenuToolStripMenuItem
 		'
 		Me.DebugMenuToolStripMenuItem.Name = "DebugMenuToolStripMenuItem"
-		Me.DebugMenuToolStripMenuItem.Size = New System.Drawing.Size(179, 22)
+		Me.DebugMenuToolStripMenuItem.Size = New System.Drawing.Size(187, 22)
 		Me.DebugMenuToolStripMenuItem.Text = "Debug Menu"
 		'
 		'ToolStripSeparator13
 		'
 		Me.ToolStripSeparator13.Name = "ToolStripSeparator13"
-		Me.ToolStripSeparator13.Size = New System.Drawing.Size(176, 6)
+		Me.ToolStripSeparator13.Size = New System.Drawing.Size(184, 6)
 		'
 		'RefreshRandomizerToolStripMenuItem
 		'
 		Me.RefreshRandomizerToolStripMenuItem.Name = "RefreshRandomizerToolStripMenuItem"
-		Me.RefreshRandomizerToolStripMenuItem.Size = New System.Drawing.Size(179, 22)
+		Me.RefreshRandomizerToolStripMenuItem.Size = New System.Drawing.Size(187, 22)
 		Me.RefreshRandomizerToolStripMenuItem.Text = "Refresh Randomizer"
 		'
 		'AboutToolStripMenuItem
@@ -2939,8 +2940,8 @@ Partial Class Form1
 		Me.LBLWishListText.Name = "LBLWishListText"
 		Me.LBLWishListText.Size = New System.Drawing.Size(220, 109)
 		Me.LBLWishListText.TabIndex = 108
-		Me.LBLWishListText.Text = "This is something I really want, let me tell you all about why I want it, you sho" & _
-		  "uld buy it for me because you know you like buying stuff for me. "
+		Me.LBLWishListText.Text = "This is something I really want, let me tell you all about why I want it, you sho" &
+	"uld buy it for me because you know you like buying stuff for me. "
 		'
 		'LBLWishlistCost
 		'
@@ -4084,6 +4085,12 @@ Partial Class Form1
 		'
 		Me.MultipleEdgesTimer.Interval = 1000
 		'
+		'ClearMainpictureboxToolStripMenuItem
+		'
+		Me.ClearMainpictureboxToolStripMenuItem.Name = "ClearMainpictureboxToolStripMenuItem"
+		Me.ClearMainpictureboxToolStripMenuItem.Size = New System.Drawing.Size(187, 22)
+		Me.ClearMainpictureboxToolStripMenuItem.Text = "Clear Mainpicturebox"
+		'
 		'Form1
 		'
 		Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -4542,5 +4549,5 @@ Partial Class Form1
 	Friend WithEvents CBWritingProgress As System.Windows.Forms.CheckBox
 	Friend WithEvents DommeTagBtnNextImage As System.Windows.Forms.Button
 	Friend WithEvents DommeTagBtnLastImage As System.Windows.Forms.Button
-
+	Friend WithEvents ClearMainpictureboxToolStripMenuItem As ToolStripMenuItem
 End Class

--- a/Tease AI/Form1.vb
+++ b/Tease AI/Form1.vb
@@ -584,102 +584,104 @@ ByVal lpstrReturnString As String, ByVal uReturnLength As Integer, ByVal hwndCal
 
 
 	Private Sub Form1_FormClosing(sender As Object, e As System.Windows.Forms.FormClosingEventArgs) Handles Me.FormClosing
-
-
-		mainPictureBox.Image = Nothing
-		Debug.Print("Here?")
-
-		TeaseAIClock.Stop()
-		UpdatesTimer.Stop()
-		StrokeTimeTotalTimer.Stop()
-		StopEverything()
-
-
-
-
-
-
-		'If BeforeTease = False And My.Settings.Sys_SubLeftEarly <> 0 Then My.Settings.Sys_SubLeftEarlyTotal += 1
-
-		If BeforeTease = False And Val(GetVariable("SYS_SubLeftEarly")) <> 0 Then SetVariable("SYS_SubLeftEarlyTotal", Val(GetVariable("SYS_SubLeftEarlyTotal")) + 1)
-
-		My.Settings.Save()
-
-
-		'TempGif.Dispose()
-		'original.Dispose()
-		'resized.Dispose()
-
 		Try
-			GC.Collect()
-		Catch
-		End Try
+
+			mainPictureBox.Image = Nothing
+			Debug.Print("Here?")
+
+			TeaseAIClock.Stop()
+			UpdatesTimer.Stop()
+			StrokeTimeTotalTimer.Stop()
+			StopEverything()
 
 
 
-		If File.Exists(Application.StartupPath & "\System\Metronome") Then
-			File.SetAttributes(Application.StartupPath & "\System\Metronome", FileAttributes.Normal)
-			My.Computer.FileSystem.DeleteFile(Application.StartupPath & "\System\Metronome")
-		End If
-
-		If File.Exists(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\System\Temp\Temp.gif") Then
-			My.Computer.FileSystem.DeleteFile(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\System\Temp\Temp.gif")
-		End If
 
 
-		Try
-			For Each prog As Process In Process.GetProcesses
-				If prog.ProcessName = "Tease AI Metronome" Then
-					prog.Kill()
-				End If
-			Next
+
+			'If BeforeTease = False And My.Settings.Sys_SubLeftEarly <> 0 Then My.Settings.Sys_SubLeftEarlyTotal += 1
+
+			If BeforeTease = False And Val(GetVariable("SYS_SubLeftEarly")) <> 0 Then SetVariable("SYS_SubLeftEarlyTotal", Val(GetVariable("SYS_SubLeftEarlyTotal")) + 1)
+
+			My.Settings.Save()
+
+
+			'TempGif.Dispose()
+			'original.Dispose()
+			'resized.Dispose()
+
+			Try
+				GC.Collect()
+			Catch
+			End Try
+
+
+
+			If File.Exists(Application.StartupPath & "\System\Metronome") Then
+				File.SetAttributes(Application.StartupPath & "\System\Metronome", FileAttributes.Normal)
+				My.Computer.FileSystem.DeleteFile(Application.StartupPath & "\System\Metronome")
+			End If
+
+			If File.Exists(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\System\Temp\Temp.gif") Then
+				My.Computer.FileSystem.DeleteFile(Application.StartupPath & "\Scripts\" & dompersonalitycombobox.Text & "\System\Temp\Temp.gif")
+			End If
+
+
+			Try
+				For Each prog As Process In Process.GetProcesses
+					If prog.ProcessName = "Tease AI Metronome" Then
+						prog.Kill()
+					End If
+				Next
+			Catch ex As Exception
+
+			End Try
+
+
+			Dim TempDate As String
+			Dim TempDateNow As DateTime = DateTime.Now
+
+			TempDate = TempDateNow.ToString("MM.dd.yyyy hhmm")
+
+			'Github Patch Begin
+
+			' If FrmSettings.CBSaveChatlogExit.Checked = True Then
+
+			'If (Not System.IO.Directory.Exists(Application.StartupPath & "\Chatlogs\")) Then
+			'System.IO.Directory.CreateDirectory(Application.StartupPath & "\Chatlogs\")
+			'End If
+
+			'My.Computer.FileSystem.WriteAllText(Application.StartupPath & "\Chatlogs\" & TempDate & " chatlog.html", ChatText.DocumentText, False)
+
+			'End If
+
+			' Github Patch End
+
+			SaveChatLog(TempDate)
+
+			Try
+				FrmSettings.Close()
+				FrmSettings.Dispose()
+			Catch ex As Exception
+			End Try
+
+			Try
+				FrmCardList.Close()
+				FrmCardList.Dispose()
+			Catch ex As Exception
+			End Try
+
+			End
+
+			TeaseAINotify.Visible = False
+			TeaseAINotify.Icon = Nothing
+			TeaseAINotify.Dispose()
+
+
+			System.Windows.Forms.Application.DoEvents()
 		Catch ex As Exception
 
 		End Try
-
-
-		Dim TempDate As String
-		Dim TempDateNow As DateTime = DateTime.Now
-
-		TempDate = TempDateNow.ToString("MM.dd.yyyy hhmm")
-
-		'Github Patch Begin
-
-		' If FrmSettings.CBSaveChatlogExit.Checked = True Then
-
-		'If (Not System.IO.Directory.Exists(Application.StartupPath & "\Chatlogs\")) Then
-		'System.IO.Directory.CreateDirectory(Application.StartupPath & "\Chatlogs\")
-		'End If
-
-		'My.Computer.FileSystem.WriteAllText(Application.StartupPath & "\Chatlogs\" & TempDate & " chatlog.html", ChatText.DocumentText, False)
-
-		'End If
-
-		' Github Patch End
-
-		SaveChatLog(TempDate)
-
-		Try
-			FrmSettings.Close()
-			FrmSettings.Dispose()
-		Catch ex As Exception
-		End Try
-
-		Try
-			FrmCardList.Close()
-			FrmCardList.Dispose()
-		Catch ex As Exception
-		End Try
-
-		End
-
-		TeaseAINotify.Visible = False
-		TeaseAINotify.Icon = Nothing
-		TeaseAINotify.Dispose()
-
-
-		System.Windows.Forms.Application.DoEvents()
-
 	End Sub
 
 	Private Sub SaveChatLog(LogDate As String)
@@ -26218,6 +26220,10 @@ GetDommeSlideshow:
 		FrmSettings.SettingsTabs.SelectTab(15)
 		FrmSettings.Show()
 		FrmSettings.Focus()
+	End Sub
+
+	Private Sub ClearMainpictureboxToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ClearMainpictureboxToolStripMenuItem.Click
+		ClearMainPictureBox()
 	End Sub
 
 #End Region ' Menu


### PR DESCRIPTION
Added FunctionDownloadRemoteImageFile(Strin, String) to get and store an image from a URI. This uses several Catchblocks. If durng saving an Error occurs the image will still be returned.

Reowked BWimageFetcher_DoWork(Object, DoEventArgs.
Now there is an integrated fallback. this will will load an Errorimage, if there is an error during imageloading (Local and Remote).  These Errors are written to log.
Added new StartupParameters:
-forceLocalGif
-disableLocalGif
-forceRemoteGif
-disableRemoteGif
This way you can disable or force enable gif images for all image genres. this does not apply to Dommeslideshows.
Add empry Try-CatchBlock on Form1 Closing to suppress Errormessages on shutdown.

Added Button in form1.vb to call ClearMainPictureBox. But this isn't doing the trick... (Dammit!)
