### PR TITLE
Bugfix: Metronome-Reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Fixes added from Community Members:
 
 	Stefaf: Bugfix where user.config was saved before the actual writing. This outdated file was taken on Startup to Replace the settings. Now the file is duplicated after modifications and the File located in %LocalAppData% won't be overwritten.
 
-	Stefaf: Bugfix Metronome was too slow, because it was played and afterwards the delay was waited. It's played now async and stopped before playing again.
+	Stefaf: Bugfix where Metronome was too slow, because it was played and afterwards the delay was waited. It's played now async and stopped before playing again.
+	
+	Stefaf: Bugfix where the Metronome was randomly not responding to SpeedChanges when the threads got out of sync.
    
 
 WIP - SaveState overhaul. Added SaveState Class and replaced Suspend and Resume Session options in File menu with SaveProgramState() and LoadProgramState() subroutines. These are only saving and loading the variables declared in Form 1, they are not functional yet. I'll need to do more work to reset the chat, check timer states, determine whether video was playing and resume accordingly, etc.

--- a/Tease AI/Form1.Designer.vb
+++ b/Tease AI/Form1.Designer.vb
@@ -372,7 +372,6 @@ Partial Class Form1
 		Me.UpdatesTimer = New Tease_AI.teaseAI_Timer()
 		Me.AvoidTheEdge = New Tease_AI.teaseAI_Timer()
 		Me.AvoidTheEdgeResume = New Tease_AI.teaseAI_Timer()
-		Me.StrokePaceTimer = New Tease_AI.teaseAI_Timer()
 		Me.EdgeTauntTimer = New Tease_AI.teaseAI_Timer()
 		Me.HoldEdgeTimer = New Tease_AI.teaseAI_Timer()
 		Me.HoldEdgeTauntTimer = New Tease_AI.teaseAI_Timer()
@@ -3972,10 +3971,6 @@ Partial Class Form1
 		'
 		Me.AvoidTheEdgeResume.Interval = 1000
 		'
-		'StrokePaceTimer
-		'
-		Me.StrokePaceTimer.Interval = 30
-		'
 		'EdgeTauntTimer
 		'
 		Me.EdgeTauntTimer.Interval = 1000
@@ -4201,7 +4196,6 @@ Partial Class Form1
 	Friend WithEvents AvoidTheEdgeResume As Tease_AI.teaseAI_Timer
 	Friend WithEvents SaveFileDialog1 As System.Windows.Forms.SaveFileDialog
 	Friend WithEvents WebImageFileDialog As System.Windows.Forms.OpenFileDialog
-	Friend WithEvents StrokePaceTimer As Tease_AI.teaseAI_Timer
 	Friend WithEvents EdgeTauntTimer As Tease_AI.teaseAI_Timer
 	Friend WithEvents HoldEdgeTimer As Tease_AI.teaseAI_Timer
 	Friend WithEvents HoldEdgeTauntTimer As Tease_AI.teaseAI_Timer

--- a/Tease AI/Form1.resx
+++ b/Tease AI/Form1.resx
@@ -1225,9 +1225,6 @@
   <metadata name="AvoidTheEdgeResume.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>278, 128</value>
   </metadata>
-  <metadata name="StrokePaceTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>753, 128</value>
-  </metadata>
   <metadata name="EdgeTauntTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>1022, 128</value>
   </metadata>


### PR DESCRIPTION
The Metronome was randomly not responding to SpeedChanges. Synclocked the Variable StrokePace to avoid data corruption caused by race conditions. Added new readonly property StrokePaceMetronome, to avoid locking delays while the UIThread is reading the memory registers of StrokePace. The value of this property is changed threadsafe when changing the property StrokePace.
Removed Obsolete StrokePaceTimer: This Timer had no attached TickHandler, so it didn't perform any action.
