### PR TITLE
Bugfix Application Close, Marked GetGoto-Bug

### DIFF
--- a/Tease AI/Form1.vb
+++ b/Tease AI/Form1.vb
@@ -682,6 +682,7 @@ ByVal lpstrReturnString As String, ByVal uReturnLength As Integer, ByVal hwndCal
 
 			TeaseTimer.Stop()
 			TeaseAIClock.Stop()
+			Timer1.Stop()
 			UpdateStageTimer.Stop()
 			UpdatesTimer.Stop()
 			StrokeTimeTotalTimer.Stop()
@@ -5268,7 +5269,7 @@ NonModuleEnd:
 	End Sub
 
 	Public Sub GetGoto()
-
+		'BUG: @Goto Command is sometimes searching in the wrong file. Description: https://milovana.com/forum/viewtopic.php?f=2&t=15776&p=219171#p219169
 
 
 		GotoFlag = True


### PR DESCRIPTION
Timer1 was still running on FormClosing.
Marked GetGoto as bugged. It searches sometimes in the wrong file.
