### PR TITLE
Various Bugfixes+Rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@ WIP - SaveState overhaul. Added SaveState Class and replaced Suspend and Resume 
 
 WIP - DataBinding Overhaul
 
+# Changelog - Patch 54.4.0
+
+Fixes added from Community Members:
+	
+	.* Stefaf: Fixed TargetInvocationException, when loading an image and the fallback failed.
+	.* Stefaf: Added Additional check, if the imagepath to load is empty/NULL. This is checked and logged before the Backgroundworker starts. This way we can track the source of this error better.
+	.* Stefaf: Stretching landscape images applies to all images loaded with the designated Backgroundworker.
+	.* Stefaf: Fixed if .net does not create the localAppData%-directory on start-up, the setting-file duplication is suspended until the settings are automatically saved for the first time. If here an exception occurs, it will be suspended until next time.
+	.* Stefaf: Reworked Custom MainSlideshow. Merged redundant code. The image extensions are the global ones. Added check if a folder exists. Images are now loaded using the designated Backgroundworker.
+	.* Stefaf: Fixed Custom timed slideshow. This was stepping 2 images forward instead of one. Images are loading with the designated Backgroundworker.
+	.* Stefaf: Fixed Combobox for Custom slideshows was overwriting inputs like Control+C and stuff like that. 
+	.* Stefaf: Fixed when the CustomSlideshow fails to load, it was recognized as valid.
+	.* Stefaf: Reworked time usage in logs. After introducing proper versioning, there is no need to a identify the assembly-version, using the filetime. All times in logs are now local times.
+	.* Stefaf: Fixed IndexOutOfRangeException when clicking next or previous image button at the end or start of the slideshow.
+	
+
 # Changelog - Patch 54.3.0
 
 Improved @If[] Command - @If[] can now use "And" and "Or" when making comparisons. For example:

--- a/README.md
+++ b/README.md
@@ -15,20 +15,19 @@ WIP - DataBinding Overhaul
 
 # Changelog - Patch 54.4.0
 
-Fixes added from Community Members:
+######Fixes added from Community Members:
 	
-	.* Stefaf: Fixed TargetInvocationException, when loading an image and the fallback failed.
-	.* Stefaf: Added Additional check, if the imagepath to load is empty/NULL. This is checked and logged before the Backgroundworker starts. This way we can track the source of this error better.
-	.* Stefaf: Stretching landscape images applies to all images loaded with the designated Backgroundworker.
-	.* Stefaf: Fixed if .net does not create the localAppData%-directory on start-up, the setting-file duplication is suspended until the settings are automatically saved for the first time. If here an exception occurs, it will be suspended until next time.
-	.* Stefaf: Reworked Custom MainSlideshow. Merged redundant code. The image extensions are the global ones. Added check if a folder exists. Images are now loaded using the designated Backgroundworker.
-	.* Stefaf: Fixed Custom timed slideshow. This was stepping 2 images forward instead of one. Images are loading with the designated Backgroundworker.
-	.* Stefaf: Fixed Combobox for Custom slideshows was overwriting inputs like Control+C and stuff like that. 
-	.* Stefaf: Fixed when the CustomSlideshow fails to load, it was recognized as valid.
-	.* Stefaf: Reworked time usage in logs. After introducing proper versioning, there is no need to a identify the assembly-version, using the filetime. All times in logs are now local times.
-	.* Stefaf: Fixed IndexOutOfRangeException when clicking next or previous image button at the end or start of the slideshow.
+* Stefaf: Fixed TargetInvocationException, when loading an image and the fallback failed.
+* Stefaf: Added Additional check, if the imagepath to load is empty/NULL. This is checked and logged before the Backgroundworker starts. This way we can track the source of this error better.
+* Stefaf: Stretching landscape images applies to all images loaded with the designated Backgroundworker.
+* Stefaf: Fixed if .net does not create the localAppData%-directory on start-up, the setting-file duplication is suspended until the settings are automatically saved for the first time. If here an exception occurs, it will be suspended until next time.
+* Stefaf: Reworked Custom MainSlideshow. Merged redundant code. The image extensions are the global ones. Added check if a folder exists. Images are now loaded using the designated Backgroundworker.
+* Stefaf: Fixed Custom timed slideshow. This was stepping 2 images forward instead of one. Images are loading with the designated Backgroundworker.
+* Stefaf: Fixed Combobox for Custom slideshows was overwriting inputs like Control+C and stuff like that. 
+* Stefaf: Fixed when the CustomSlideshow fails to load, it was recognized as valid.
+* Stefaf: Reworked time usage in logs. After introducing proper versioning, there is no need to a identify the assembly-version, using the filetime. All times in logs are now local times.
+* Stefaf: Fixed IndexOutOfRangeException when clicking next or previous image button at the end or start of the slideshow.
 	
-
 # Changelog - Patch 54.3.0
 
 Improved @If[] Command - @If[] can now use "And" and "Or" when making comparisons. For example:

--- a/Tease AI/Classes/Log.vb
+++ b/Tease AI/Classes/Log.vb
@@ -1,5 +1,4 @@
 ﻿Imports System.IO
-Imports System.Reflection
 
 ''' <summary>
 ''' Provides Static procedures to write Messages to predefined TextFiles.
@@ -44,10 +43,8 @@ Restart:
 				' Create new file
 				'===============================================================================
 				Using sw As New StreamWriter(Logfile)
-					Dim fecha As Date = IO.File.GetLastWriteTimeUtc(Assembly.GetExecutingAssembly().Location)
 					sw.Write("=========================== LogFile Created =============================" & vbCrLf &
-							 "Build Date (UTC): " & fecha.ToUniversalTime.ToString("yyyy-MM-dd HH:mm:ss") & vbCrLf &
-							 "File Date (UTC): " & Now.ToUniversalTime.ToString("yyyy-MM-dd HH:mm:ss") & vbCrLf &
+							 "File Date: " & Now.ToString("yyyy-MM-dd HH:mm:ss") & vbCrLf &
 							 "If you want to remove the Stacktrace: Use NotePad++ and search Regex with" & vbCrLf &
 							 "MatchPattern: \t@>~@>~[^\a]*?~<@~<@+?\r\n" & vbCrLf &
 							 "ReplacePatten: Leave it Empty" & vbCrLf &
@@ -90,7 +87,7 @@ Restart:
 		Try
 			Write("Exception occured: " & msg)
 			Dim TargetFilePath As String = Application.StartupPath &
-			"\ErrorLogs\" & Today.ToUniversalTime.ToString("yyyy-MM-dd") & "_errorlog.txt"
+			"\ErrorLogs\" & Today.ToString("yyyy-MM-dd") & "_errorlog.txt"
 
 			Dim StList As List(Of String) = Environment.StackTrace.Replace(vbLf, "").Split(vbCrLf).ToList
 			StList.RemoveRange(0, 3)
@@ -110,9 +107,8 @@ Restart:
 			Using fs1 As New FileStream(TargetFilePath, FileMode.Append, FileAccess.Write)
 				Using s1 As New StreamWriter(fs1)
 					s1.Write("###################################################################" & vbCrLf)
-					s1.Write("Date/Time: " & DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss") & vbCrLf)
+					s1.Write("Date/Time: " & Now.ToString("yyyy-MM-dd HH:mm:ss") & vbCrLf)
 					s1.Write("Version: " & My.Application.Info.Version.ToString & vbCrLf)
-					s1.Write("BuildDate (UTC): " & File.GetLastWriteTimeUtc(Assembly.GetExecutingAssembly().Location).ToString("yyyy-MM-dd HH:mm:ss") & vbCrLf)
 					s1.Write("Title: " & title & vbCrLf)
 					s1.Write("Message: " & msg & vbCrLf)
 					s1.Write("Exceptions: " & Replace(ExceptonToString(Exception), vbCrLf, vbCrLf & vbTab) & vbCrLf)

--- a/Tease AI/Classes/mySettings_Partial.vb
+++ b/Tease AI/Classes/mySettings_Partial.vb
@@ -48,7 +48,15 @@ Namespace My
 		Private Sub Savetimer_Tick(sender As Object, e As EventArgs) Handles Savetimer.Tick
 			On Error GoTo Error_All
 			Save()
+
+			If Directory.Exists(Path.GetDirectoryName(LocalAppFilePath)) _
+			And fswLocalAppData.EnableRaisingEvents = False Then
+				fswLocalAppData.Path = Path.GetDirectoryName(LocalAppFilePath)
+				fswLocalAppData.EnableRaisingEvents = True
+			End If
+
 			Savetimer.Stop()
+			Exit Sub
 Error_All:
 		End Sub
 #End Region ' SaveTimer
@@ -136,16 +144,17 @@ Error_All:
 
 #Region "---------------------------------------MyBaseRelated--------------------------------------------"
 
+		Private _loaded As Boolean = False
+
 		Protected Overrides Sub OnSettingsLoaded(sender As Object, e As SettingsLoadedEventArgs)
 			MyBase.OnSettingsLoaded(sender, e)
 
-			fswLocalAppData.Path = Path.GetDirectoryName(LocalAppFilePath )
-			fswLocalAppData.EnableRaisingEvents = True
+			_loaded = False
 		End Sub
 
 		Protected Overrides Sub OnPropertyChanged(sender As Object, e As PropertyChangedEventArgs)
 			MyBase.OnPropertyChanged(sender, e)
-			If Savetimer.Enabled = False Then Savetimer.Start()
+			If Savetimer.Enabled = False And _loaded = True Then Savetimer.Start()
 		End Sub
 
 		''' =========================================================================================================
@@ -161,6 +170,7 @@ Error_All:
 
 		Shadows Sub Reset()
 			fswLocalAppData.EnableRaisingEvents = False
+			_loaded = False
 
 			Dim dupeFilePath As String = GetDuplicatePath()
 
@@ -170,6 +180,7 @@ Error_All:
 
 			MyBase.Reset()
 
+			_loaded = True
 			fswLocalAppData.EnableRaisingEvents = True
 		End Sub
 

--- a/Tease AI/Form1.vb
+++ b/Tease AI/Form1.vb
@@ -282,6 +282,10 @@ Public Class Form1
 
 	Dim GetFolder As String
 	Dim FileCount As Integer
+	''' <summary>
+	''' The highest accessible address in List. Same as:<see cref="_ImageFileNames"/>.Count - 1 
+	''' </summary>
+	<Obsolete("Duplicate Data! Use _ImageFileNames.count -1 instead")>
 	Dim FileCountMax As Integer
 	Private _ImageFileNames As New List(Of String)
 	<Obsolete("Not used anymore. Or change Filecount to this one, to enhance readablility")>
@@ -291,6 +295,7 @@ Public Class Form1
 	Public ApproveImage As Integer = 0
 	<Obsolete("Not used anymore.")>
 	Public WIExit As Boolean
+	<Obsolete("Non threadsafe duplicate of My.Settings.RecentSlideshows. Use this instead.")>
 	Public RecentSlideshows As New List(Of String)
 	<Obsolete("Read data using MainPictureBox.ImageLocation. Set data using ShowImage(String, Boolean) in future releases.")>
 	Dim MainPictureImage As String
@@ -1011,7 +1016,9 @@ ByVal lpstrReturnString As String, ByVal uReturnLength As Integer, ByVal hwndCal
 		'My.Settings.CBGlitterFeedOff = True
 		'End If
 
-		'TODO: Don't know what to do about these settings. The radio buttons staunchly refuse to be DataBound and non-DataBound settings don't currently save, so ¯\_(ツ)_/¯
+		'QUESTION: (1885) Don't know what to do about these settings. The radio buttons staunchly refuse to be DataBound and non-DataBound settings don't currently save, so ¯\_(ツ)_/¯
+		'ANSWER: (Stefaf) I'll take a look at this based on this link: http://stackoverflow.com/questions/11405020/radio-buttons-and-databinding-in-vb-net
+		'TODO-Next-Stefaf: Add Databinding to RadioButtons.
 		If My.Settings.CBGlitterFeed = True Then FrmSettings.CBGlitterFeed.Checked = True
 		If My.Settings.CBGlitterFeedScripts = True Then FrmSettings.CBGlitterFeedScripts.Checked = True
 		If My.Settings.CBGlitterFeedOff = True Then FrmSettings.CBGlitterFeedOff.Checked = True
@@ -7083,157 +7090,193 @@ NullResponseLine2:
 
 #Region "------------------------------------------ Images ----------------------------------------------"
 
-	Private Sub browsefolderButton_Click(sender As System.Object, e As System.EventArgs) Handles browsefolderButton.Click
-		'TODO-Next: Implement ShowImage(String, Boolean) and myDirectory.GetFilesImages(String)
+	Private Sub CustomMainSlidehhowLoad(ByVal Getfolder As String)
+
+	End Sub
+
+	Private Sub LoadCustomizedSlideshow(sender As System.Object, e As System.EventArgs) Handles browsefolderButton.Click, ImageFolderComboBox.KeyDown, ImageFolderComboBox.SelectedIndexChanged
+		'TODO-Next-Stefaf: Implement enhanced RecentSlideshows.Item handling
 		If FrmSettings.CBSettingsPause.Checked = True And FrmSettings.SettingsPanel.Visible = True Then
 			MsgBox("Please close the settings menu or disable ""Pause Program When Settings Menu is Visible"" option first!", , "Warning!")
 			Return
 		End If
+		Try
+			Dim GetFolder As String = ""
+			browsefolderButton.Enabled = False
+			nextButton.Enabled = False
+			previousButton.Enabled = False
+			PicStripTSMIdommeSlideshow.Enabled = False
 
-		If (FolderBrowserDialog1.ShowDialog() = DialogResult.OK) Then
-			GetFolder = FolderBrowserDialog1.SelectedPath
+			If sender Is browsefolderButton Then
+				'===============================================================================
+				'								browsefolderButton
+				'===============================================================================
+				If FolderBrowserDialog1.ShowDialog() = DialogResult.OK Then
+					GetFolder = FolderBrowserDialog1.SelectedPath
 
-			RecentSlideshows.Add(GetFolder)
+					RecentSlideshows.Add(GetFolder)
 
-			Do Until RecentSlideshows.Count < 11
-				RecentSlideshows.Remove(RecentSlideshows(0))
-			Loop
+					Do Until RecentSlideshows.Count < 11
+						RecentSlideshows.Remove(RecentSlideshows(0))
+					Loop
 
-			'Debug.Print(RecentSlideshows(0))
+					ImageFolderComboBox.Items.Clear()
 
-			ImageFolderComboBox.Items.Clear()
+					For Each comboitem As String In RecentSlideshows
+						ImageFolderComboBox.Items.Add(comboitem)
+					Next
 
-			For Each comboitem As String In RecentSlideshows
-				ImageFolderComboBox.Items.Add(comboitem)
-			Next
+					ImageFolderComboBox.Text = GetFolder
 
-			ImageFolderComboBox.Text = GetFolder
+					My.Settings.RecentSlideshows.Add(GetFolder)
 
-			My.Settings.RecentSlideshows.Add(GetFolder)
+					My.Settings.RecentSlideshows.Clear()
 
-			My.Settings.RecentSlideshows.Clear()
+					For i As Integer = 0 To RecentSlideshows.Count - 1
+						My.Settings.RecentSlideshows.Add(RecentSlideshows(i))
+					Next
 
-			For i As Integer = 0 To RecentSlideshows.Count - 1
-				My.Settings.RecentSlideshows.Add(RecentSlideshows(i))
-			Next
-
-
-			SlideshowLoaded = True
-
-			' domVLC.playlist.pause()
-			' domVLC.Visible = False
-			DomWMP.Visible = False
-			DomWMP.Ctlcontrols.pause()
-			mainPictureBox.Visible = True
-			'programsettingsPanel.Visible = False
-			FrmSettings.timedRadio.Enabled = True
-			FrmSettings.teaseRadio.Enabled = True
-
-
-
-
-			'imgfolderTextBox.Text = GetFolder
-
-			FileCount = 0
-			FileCountMax = -1
-			_ImageFileNames.Clear()
-
-
-			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-			'Dim files As String() = DirectoryExt.GetFiles(GetFolder, "*.*", SearchOption.AllDirectories)
-
-			Dim files As String()
-
-			If FrmSettings.CBSlideshowSubDir.Checked = True Then
-				files = myDirectory.GetFiles(GetFolder, "*.*", SearchOption.AllDirectories)
-			Else
-				files = myDirectory.GetFiles(GetFolder, "*.*")
-			End If
-
-			' Dim files As String() = DirectoryExt.GetFiles(GetFolder, "*.*")
-			Array.Sort(files)
-
-			' For Each fi As String In files
-			'If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-			'_ImageFileNames.AddRange(files)
-			'End If
-			'   Next
-
-			Dim TestCOUnt As Integer = 0
-			For Each fi As String In files
-				If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-					TestCOUnt += 1
-					'Debug.Print("fi = " & fi)
-					_ImageFileNames.Add(fi)
 				End If
-			Next
+			ElseIf sender Is ImageFolderComboBox And TypeOf e Is KeyEventArgs
+				'===============================================================================
+				'						ImageFolderComboBox - KeyPressEvent
+				'===============================================================================
+				Dim _e As KeyEventArgs = DirectCast(e, KeyEventArgs)
 
-			' If FrmSettings.CBSlideshowSubDir.Checked = True Then
-			'FileCountMax = DirectoryExt.GetFiles(GetFolder, "*.jpg", SearchOption.AllDirectories).Count
-			'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.png", SearchOption.AllDirectories).Count
-			'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.gif", SearchOption.AllDirectories).Count
-			'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.bmp", SearchOption.AllDirectories).Count
-			'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.jpeg", SearchOption.AllDirectories).Count
-			'Else
-			'   FileCountMax = DirectoryExt.GetFiles(GetFolder, "*.jpg").Count
-			'  FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.png").Count
-			' FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.gif").Count
-			'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.bmp").Count
-			'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.jpeg").Count
-			'End If
-
-			FileCountMax = _ImageFileNames.Count - 1
-
-			'Debug.Print("FileCOuntMax = " & FileCountMax)
-
-
-			If FileCountMax < 0 Then
-				MessageBox.Show(Me, "There are no images in the specified folder.", "Error!", MessageBoxButtons.OK, MessageBoxIcon.Hand)
-				Exit Sub
-			End If
-
-			' Begin Next Button
-			FileCount = 0
-
-			'ClearMainPictureBox()
-
-
-			If FrmSettings.CBSlideshowRandom.Checked = True Then FileCount = randomizer.Next(0, FileCountMax + 1)
-
-			ShowImage(_ImageFileNames(FileCount))
-
-
-
-			nextButton.Enabled = True
-			previousButton.Enabled = True
-			PicStripTSMIdommeSlideshow.Enabled = True
-
-			If FrmSettings.landscapeCheckBox.Checked = True Then
-				If mainPictureBox.Image.Width > mainPictureBox.Image.Height Then
-					mainPictureBox.SizeMode = PictureBoxSizeMode.StretchImage
+				If _e.KeyCode = Keys.Enter Then
+					_e.Handled = True
+					GoTo chooseComboboxText
 				Else
-					mainPictureBox.SizeMode = PictureBoxSizeMode.Zoom
+					Exit Sub
+				End If
+			ElseIf sender Is ImageFolderComboBox And TypeOf e Is EventArgs
+				'===============================================================================
+				'								ImageFolderComboBox
+				'===============================================================================
+chooseComboboxText:
+				If Directory.Exists(ImageFolderComboBox.Text) Or isURL(ImageFolderComboBox.Text) Then
+					GetFolder = ImageFolderComboBox.Text
+				Else
+					'TODO-Next-Stefaf: Rework Recent SlideShow Variable and remove invalid directories.
+					Throw New DirectoryNotFoundException("The given directory """ & ImageFolderComboBox.Text & """ does not exist.")
 				End If
 			Else
-				mainPictureBox.SizeMode = PictureBoxSizeMode.Zoom
+				Throw New NotImplementedException("")
 			End If
 
+			If GetFolder = "" Then
+				Exit Sub
+			ElseIf Not isURL(GetFolder) Then
+				ImageFolderComboBox.Enabled = False
 
-			mainPictureBox.Refresh()
-			mainPictureBox.Invalidate()
+				DomWMP.Visible = False
+				DomWMP.Ctlcontrols.pause()
+				mainPictureBox.Visible = True
 
+				FrmSettings.timedRadio.Enabled = True
+				FrmSettings.teaseRadio.Enabled = True
+
+				SlideshowLoaded = False
+				FileCount = 0
+				FileCountMax = -1
+				_ImageFileNames.Clear()
+
+				If FrmSettings.CBSlideshowSubDir.Checked = True Then
+					_ImageFileNames = myDirectory.GetFilesImages(GetFolder, SearchOption.AllDirectories)
+				Else
+					_ImageFileNames = myDirectory.GetFilesImages(GetFolder, SearchOption.TopDirectoryOnly)
+				End If
+
+				GoTo listLoaded
+
+			ElseIf isURL(ImageFolderComboBox.Text) And Debugger.IsAttached Then
+				'▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+				'						Blog SlideShow (!)Experimental
+				'▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+				Dim tmpReq As Net.HttpWebRequest
+				Dim tmpRes As Net.HttpWebResponse
+
+				tmpReq = Net.HttpWebRequest.Create(ImageFolderComboBox.Text & "api/read?start=" & 1 & "&num=5000")
+				tmpRes = tmpReq.GetResponse
+
+				Using reader As New Xml.XmlTextReader(tmpRes.GetResponseStream)
+					Dim tmpDoc As New Xml.XmlDocument()
+					tmpDoc.Load(reader)
+
+					tmpReq.Abort()
+					tmpRes.Close()
+
+					DomWMP.Visible = False
+					DomWMP.Ctlcontrols.pause()
+					mainPictureBox.Visible = True
+
+					FrmSettings.timedRadio.Enabled = True
+					FrmSettings.teaseRadio.Enabled = True
+
+					SlideshowLoaded = False
+					FileCount = 0
+					FileCountMax = -1
+					_ImageFileNames.Clear()
+
+					For Each ___PhotoNode As Xml.XmlNode In tmpDoc.DocumentElement.SelectNodes("//photo-url")
+						If CInt(___PhotoNode.Attributes.ItemOf("max-width").InnerText) = 1280 Then
+							_ImageFileNames.Add(___PhotoNode.InnerXml)
+
+						End If
+					Next
+				End Using
+
+				GoTo listLoaded
+				'▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+				' Blog SlideShow - End
+				'▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+			Else
+
+				ImageFolderComboBox.Text = "Not a valid directory"
+
+			End If
+			Exit Sub
+
+listLoaded:
+			If _ImageFileNames.Count <= 0 Then
+
+				MessageBox.Show(Me, "There are no images in the specified folder.", "Error!",
+									MessageBoxButtons.OK, MessageBoxIcon.Hand)
+				Exit Sub
+			Else
+				SlideshowLoaded = True
+				FileCountMax = _ImageFileNames.Count - 1
+			End If
+
+			If My.Settings.CBSlideshowRandom = True Then _
+				FileCount = randomizer.Next(0, _ImageFileNames.Count)
+
+			ShowImage(_ImageFileNames(FileCount), True)
+			JustShowedBlogImage = False
+
+			'TODO: FrmSettings.timedRadio.Checked - Remove CrossForm DataAccess
 			If FrmSettings.timedRadio.Checked = True Then
 				SlideshowTimerTick = FrmSettings.slideshowNumBox.Value
 				SlideshowTimer.Start()
 			End If
-			' End Next Button
-		End If
 
+		Catch ex As Exception
+			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+			'                                            All Errors
+			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
+			MessageBox.Show("Unable to load custom slideshow : " & vbCrLf & vbCrLf & ex.Message,
+							"Open CustomSlideshow failed",
+							MessageBoxButtons.OK, MessageBoxIcon.Error)
+		Finally
+			browsefolderButton.Enabled = True
+			nextButton.Enabled = True
+			previousButton.Enabled = True
+			PicStripTSMIdommeSlideshow.Enabled = True
+			ImageFolderComboBox.Enabled = True
+		End Try
 	End Sub
 
 	Private Sub imagesNextButton_Click(sender As System.Object, e As System.EventArgs) Handles nextButton.Click, previousButton.Click
-		'TODO-Next: Implement ShowImage(String, Boolean) + Rework
-
 		Try
 			If My.Settings.CBSettingsPause And FrmSettings.SettingsPanel.Visible = True Then
 				MsgBox("Please close the settings menu or disable ""Pause Program When Settings Menu is Visible"" option first!", , "Warning!")
@@ -7247,11 +7290,11 @@ Retry:
 			If sender Is nextButton Then
 				' ====================== Next Image =======================
 				FileCount += 1
-				If FileCount > _ImageFileNames.Count Then FileCount = 0
+				If FileCount >= _ImageFileNames.Count - 1 Then FileCount = 0
 			ElseIf sender Is previousButton
 				' ==================== Previous Image =====================
 				FileCount -= 1
-				If FileCount < 0 Then FileCount = _ImageFileNames.Count
+				If FileCount <= 0 Then FileCount = _ImageFileNames.Count - 1
 			Else
 				' ======================== Error ==========================
 				Throw New NotImplementedException("Action for button not implemented.")
@@ -7275,6 +7318,7 @@ Retry:
 				ImageFolderComboBox.Enabled = False
 				nextButton.Enabled = False
 				previousButton.Enabled = False
+				PicStripTSMIdommeSlideshow.Enabled = False
 
 				ShowImage(_ImageFileNames(FileCount), True)
 
@@ -7287,22 +7331,8 @@ Retry:
 				ImageFolderComboBox.Enabled = True
 				nextButton.Enabled = True
 				previousButton.Enabled = True
+				PicStripTSMIdommeSlideshow.Enabled = True
 			End Try
-
-
-			If FrmSettings.landscapeCheckBox.Checked = True Then
-				If mainPictureBox.Image.Width > mainPictureBox.Image.Height Then
-					mainPictureBox.SizeMode = PictureBoxSizeMode.StretchImage
-				Else
-					mainPictureBox.SizeMode = PictureBoxSizeMode.Zoom
-				End If
-			Else
-				mainPictureBox.SizeMode = PictureBoxSizeMode.Zoom
-			End If
-
-
-			mainPictureBox.Refresh()
-			mainPictureBox.Invalidate()
 
 		Catch ex As Exception
 			'▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨▨
@@ -7316,357 +7346,6 @@ Retry:
 	Private Sub ImageFolderComboBox_MouseWheel(sender As Object, e As System.Windows.Forms.MouseEventArgs) Handles ImageFolderComboBox.MouseWheel
 		Dim mwe As HandledMouseEventArgs = DirectCast(e, HandledMouseEventArgs)
 		mwe.Handled = True
-	End Sub
-
-	Private Sub ImageFolderComboBox_SelectedIndexChanged(sender As System.Object, e As System.EventArgs) Handles ImageFolderComboBox.SelectedIndexChanged
-		'TODO-Next: Implement ShowImage(Of String, Boolean)() And myDirectory.GetFilesImages(Of String)
-
-		If FrmSettings.CBSettingsPause.Checked = True And FrmSettings.SettingsPanel.Visible = True Then
-			MsgBox("Please close the settings menu or disable ""Pause Program When Settings Menu is Visible"" option first!", , "Warning!")
-			Return
-		End If
-
-
-
-		If My.Computer.FileSystem.DirectoryExists(ImageFolderComboBox.Text) Then
-
-			SlideshowLoaded = True
-
-			'domVLC.playlist.pause()
-			'domVLC.Visible = False
-			DomWMP.Visible = False
-			DomWMP.Ctlcontrols.pause()
-			mainPictureBox.Visible = True
-			'programsettingsPanel.Visible = False
-
-
-			FrmSettings.timedRadio.Enabled = True
-			FrmSettings.teaseRadio.Enabled = True
-
-			FileCount = 0
-			FileCountMax = -1
-			_ImageFileNames.Clear()
-
-			GetFolder = ImageFolderComboBox.Text
-
-			Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-			'Dim files As String() = DirectoryExt.GetFiles(GetFolder, "*.*", SearchOption.AllDirectories)
-
-			Dim files As String()
-
-			If FrmSettings.CBSlideshowSubDir.Checked = True Then
-				files = myDirectory.GetFiles(GetFolder, "*.*", SearchOption.AllDirectories)
-			Else
-				files = myDirectory.GetFiles(GetFolder, "*.*")
-			End If
-
-
-			' Dim files As String() = DirectoryExt.GetFiles(GetFolder, "*.*")
-			Array.Sort(files)
-			' For Each fi As String In files
-			'If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-			'_ImageFileNames.AddRange(files)
-			'End If
-			'   Next
-
-			Dim TestCOUnt As Integer = 0
-			For Each fi As String In files
-				If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-					TestCOUnt += 1
-					'Debug.Print("fi = " & fi)
-					_ImageFileNames.Add(fi)
-				End If
-			Next
-
-			' If FrmSettings.CBSlideshowSubDir.Checked = True Then
-			'FileCountMax = DirectoryExt.GetFiles(GetFolder, "*.jpg", SearchOption.AllDirectories).Count
-			'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.png", SearchOption.AllDirectories).Count
-			'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.gif", SearchOption.AllDirectories).Count
-			'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.bmp", SearchOption.AllDirectories).Count
-			'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.jpeg", SearchOption.AllDirectories).Count
-			'Else
-			'   FileCountMax = DirectoryExt.GetFiles(GetFolder, "*.jpg").Count
-			'  FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.png").Count
-			' FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.gif").Count
-			'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.bmp").Count
-			'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.jpeg").Count
-			'End If
-
-			FileCountMax = _ImageFileNames.Count - 1
-
-			'Debug.Print("FileCOuntMax = " & FileCountMax)
-
-			' If FileCountMax = -1 Then
-			If FileCountMax < 1 Then
-				MessageBox.Show(Me, "There are no images in the specified folder.", "Error!", MessageBoxButtons.OK, MessageBoxIcon.Exclamation)
-				Exit Sub
-			End If
-
-
-			' Begin Next Button
-			FileCount = 0
-
-			'ClearMainPictureBox()
-
-
-
-			If FrmSettings.CBSlideshowRandom.Checked = True Then FileCount = randomizer.Next(0, FileCountMax + 1)
-
-			ShowImage(_ImageFileNames(FileCount))
-			JustShowedBlogImage = False
-
-			nextButton.Enabled = True
-			previousButton.Enabled = True
-			PicStripTSMIdommeSlideshow.Enabled = True
-
-			If FrmSettings.landscapeCheckBox.Checked = True Then
-				If mainPictureBox.Image.Width > mainPictureBox.Image.Height Then
-					mainPictureBox.SizeMode = PictureBoxSizeMode.StretchImage
-				Else
-					mainPictureBox.SizeMode = PictureBoxSizeMode.Zoom
-				End If
-			Else
-				mainPictureBox.SizeMode = PictureBoxSizeMode.Zoom
-			End If
-
-			mainPictureBox.Refresh()
-			mainPictureBox.Invalidate()
-
-			If FrmSettings.timedRadio.Checked = True Then
-				SlideshowTimerTick = FrmSettings.slideshowNumBox.Value
-				SlideshowTimer.Start()
-			End If
-
-		Else
-
-			ImageFolderComboBox.Text = "Not a valid directory"
-
-		End If
-
-
-
-
-
-
-	End Sub
-
-	Private Sub ImageFolderComboBox_KeyPress(sender As Object, e As System.Windows.Forms.KeyPressEventArgs) Handles ImageFolderComboBox.KeyPress
-		'TODO-Next: Implement ShowImage(String, Boolean) and myDirectory.GetFilesImages(String)
-
-
-		If FrmSettings.CBSettingsPause.Checked = True And FrmSettings.SettingsPanel.Visible = True Then
-			MsgBox("Please close the settings menu or disable ""Pause Program When Settings Menu is Visible"" option first!", , "Warning!")
-			Return
-		End If
-
-		If e.KeyChar = Convert.ToChar(13) Then
-
-			e.Handled = True
-			' sendButton.PerformClick()
-			e.KeyChar = Chr(0)
-
-			If My.Computer.FileSystem.DirectoryExists(ImageFolderComboBox.Text) Then
-
-				GetFolder = ImageFolderComboBox.Text
-
-				RecentSlideshows.Add(GetFolder)
-
-				Do Until RecentSlideshows.Count < 11
-					RecentSlideshows.Remove(RecentSlideshows(0))
-				Loop
-
-				'Debug.Print(RecentSlideshows(0))
-
-				ImageFolderComboBox.Items.Clear()
-
-				For Each comboitem As String In RecentSlideshows
-					ImageFolderComboBox.Items.Add(comboitem)
-				Next
-
-				ImageFolderComboBox.Text = GetFolder
-
-				My.Settings.RecentSlideshows.Add(GetFolder)
-
-				My.Settings.RecentSlideshows.Clear()
-
-				For i As Integer = 0 To RecentSlideshows.Count - 1
-					My.Settings.RecentSlideshows.Add(RecentSlideshows(i))
-				Next
-
-
-
-				SlideshowLoaded = True
-
-				' domVLC.playlist.pause()
-				'domVLC.Visible = False
-				DomWMP.Visible = False
-				DomWMP.Ctlcontrols.pause()
-				mainPictureBox.Visible = True
-				'programsettingsPanel.Visible = False
-
-
-				FrmSettings.timedRadio.Enabled = True
-				FrmSettings.teaseRadio.Enabled = True
-
-				FileCount = 0
-				FileCountMax = -1
-				_ImageFileNames.Clear()
-
-
-
-				Dim supportedExtensions As String = "*.png,*.jpg,*.gif,*.bmp,*.jpeg"
-				'Dim files As String() = DirectoryExt.GetFiles(GetFolder, "*.*", SearchOption.AllDirectories)
-
-				Dim files As String()
-
-				If FrmSettings.CBSlideshowSubDir.Checked = True Then
-					files = myDirectory.GetFiles(GetFolder, "*.*", SearchOption.AllDirectories)
-				Else
-					files = myDirectory.GetFiles(GetFolder, "*.*")
-				End If
-
-
-				' Dim files As String() = DirectoryExt.GetFiles(GetFolder, "*.*")
-				Array.Sort(files)
-
-				' For Each fi As String In files
-				'If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-				'_ImageFileNames.AddRange(files)
-				'End If
-				'   Next
-
-				Dim TestCOUnt As Integer = 0
-				For Each fi As String In files
-					If supportedExtensions.Contains(Path.GetExtension(LCase(fi))) Then
-						TestCOUnt += 1
-						'Debug.Print("fi = " & fi)
-						_ImageFileNames.Add(fi)
-					End If
-				Next
-
-				' If FrmSettings.CBSlideshowSubDir.Checked = True Then
-				'FileCountMax = DirectoryExt.GetFiles(GetFolder, "*.jpg", SearchOption.AllDirectories).Count
-				'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.png", SearchOption.AllDirectories).Count
-				'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.gif", SearchOption.AllDirectories).Count
-				'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.bmp", SearchOption.AllDirectories).Count
-				'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.jpeg", SearchOption.AllDirectories).Count
-				'Else
-				'   FileCountMax = DirectoryExt.GetFiles(GetFolder, "*.jpg").Count
-				'  FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.png").Count
-				' FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.gif").Count
-				'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.bmp").Count
-				'FileCountMax += DirectoryExt.GetFiles(GetFolder, "*.jpeg").Count
-				'End If
-
-				FileCountMax = _ImageFileNames.Count - 1
-
-				'Debug.Print("FileCOuntMax = " & FileCountMax)
-
-				' If FileCountMax = -1 Then
-				If FileCountMax < 1 Then
-					MessageBox.Show(Me, "There are no images in the specified folder.", "Error!", MessageBoxButtons.OK, MessageBoxIcon.Exclamation)
-					Exit Sub
-				End If
-
-
-				' Begin Next Button
-				FileCount = 0
-
-				'ClearMainPictureBox()
-
-
-
-				If FrmSettings.CBSlideshowRandom.Checked = True Then FileCount = randomizer.Next(0, FileCountMax + 1)
-
-				ShowImage(_ImageFileNames(FileCount))
-				JustShowedBlogImage = False
-
-
-				nextButton.Enabled = True
-				previousButton.Enabled = True
-				PicStripTSMIdommeSlideshow.Enabled = True
-
-				If FrmSettings.landscapeCheckBox.Checked = True Then
-					If mainPictureBox.Image.Width > mainPictureBox.Image.Height Then
-						mainPictureBox.SizeMode = PictureBoxSizeMode.StretchImage
-					Else
-						mainPictureBox.SizeMode = PictureBoxSizeMode.Zoom
-					End If
-				Else
-					mainPictureBox.SizeMode = PictureBoxSizeMode.Zoom
-				End If
-
-				mainPictureBox.Refresh()
-				mainPictureBox.Invalidate()
-
-				If FrmSettings.timedRadio.Checked = True Then
-					SlideshowTimerTick = FrmSettings.slideshowNumBox.Value
-					SlideshowTimer.Start()
-				End If
-
-			ElseIf isURL(ImageFolderComboBox.Text) And Debugger.IsAttached Then
-				'▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
-				'						Blog SlideShow (!)Experimental
-				'▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
-				Dim tmpReq As Net.HttpWebRequest
-				Dim tmpRes As Net.HttpWebResponse
-
-				tmpReq = Net.HttpWebRequest.Create(ImageFolderComboBox.Text & "api/read?start=" & 1 & "&num=5000")
-				tmpRes = tmpReq.GetResponse
-
-				Using reader As New Xml.XmlTextReader(tmpRes.GetResponseStream)
-					Dim tmpDoc As New Xml.XmlDocument()
-					tmpDoc.Load(reader)
-
-					tmpReq.Abort()
-					tmpRes.Close()
-
-					_ImageFileNames.Clear()
-
-					For Each ___PhotoNode As Xml.XmlNode In tmpDoc.DocumentElement.SelectNodes("//photo-url")
-						If CInt(___PhotoNode.Attributes.ItemOf("max-width").InnerText) = 1280 Then
-							_ImageFileNames.Add(___PhotoNode.InnerXml)
-
-						End If
-					Next
-					FileCountMax = _ImageFileNames.Count - 1
-
-				End Using
-
-				FileCount = 0
-
-				If _ImageFileNames.Count <= 0 Then
-					CustomSlideshow = False
-					SlideshowLoaded = False
-					Exit Sub
-				End If
-
-				SlideshowLoaded = True
-
-				ShowImage(_ImageFileNames(FileCount), True)
-
-				nextButton.Enabled = True
-				previousButton.Enabled = True
-				PicStripTSMIdommeSlideshow.Enabled = True
-
-				If FrmSettings.timedRadio.Checked = True Then
-					SlideshowTimerTick = FrmSettings.slideshowNumBox.Value
-					SlideshowTimer.Start()
-				End If
-				'▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
-				' Blog SlideShow - End
-				'▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
-			Else
-
-				ImageFolderComboBox.Text = "Not a valid directory"
-
-			End If
-
-
-
-		End If
-
-
 	End Sub
 
 #End Region ' Images
@@ -17933,7 +17612,7 @@ PoundLoop:
 
 
 	Private Sub SlideshowTimer_Tick(sender As System.Object, e As System.EventArgs) Handles SlideshowTimer.Tick
-		'TODO-Next: Implement ShowImage(String, Boolean) + Rework
+		'TODO: Remove CrossForm data access
 		If FrmSettings.CBSettingsPause.Checked = True And FrmSettings.SettingsPanel.Visible = True Then Return
 
 		If SlideshowLoaded = False Or FrmSettings.timedRadio.Checked = False Or TeaseVideo = True Or LockImage = True Or JustShowedBlogImage = True Or CustomSlideshow = True Then Return
@@ -17943,11 +17622,9 @@ PoundLoop:
 		If SlideshowTimerTick < 1 Then
 
 TryNext:
+			'--------------FileCount += 1
 			FileCount += 1
-			'Debug.Print("Filecount = " & FileCount)
-			'Debug.Print("FileCOuntMax = " & FileCountMax)
-			FileCount += 1
-			If FileCount > FileCountMax Then
+			If FileCount > _ImageFileNames.Count - 1 Then
 				If FrmSettings.CBNewSlideshow.Checked = True Then
 					NewDommeSlideshow = True
 					OriginalDommeSlideshow = _ImageFileNames(0)
@@ -17959,21 +17636,21 @@ TryNext:
 				End If
 			End If
 
-			If File.Exists(_ImageFileNames(FileCount)) Then
-			Else
+			If Not (File.Exists(_ImageFileNames(FileCount)) _
+					Or isURL(_ImageFileNames(FileCount))) Then
 				ClearMainPictureBox()
-				Return
+				Exit Sub
 			End If
 
 			If _ImageFileNames(FileCount).Contains(".db") Then GoTo TryNext
 
 
 
-			If FrmSettings.CBSlideshowRandom.Checked = True Then FileCount = randomizer.Next(0, FileCountMax + 1)
+			If My.Settings.CBSlideshowRandom = True Then FileCount = randomizer.Next(0, _ImageFileNames.Count)
 
 
 			Try
-				ShowImage(_ImageFileNames(FileCount))
+				ShowImage(_ImageFileNames(FileCount), True)
 				JustShowedBlogImage = False
 				JustShowedSlideshowImage = True
 
@@ -17981,20 +17658,6 @@ TryNext:
 				GoTo TryNext
 			End Try
 
-
-			If FrmSettings.landscapeCheckBox.Checked = True Then
-				If mainPictureBox.Image.Width > mainPictureBox.Image.Height Then
-					mainPictureBox.SizeMode = PictureBoxSizeMode.StretchImage
-				Else
-					mainPictureBox.SizeMode = PictureBoxSizeMode.Zoom
-				End If
-			Else
-				mainPictureBox.SizeMode = PictureBoxSizeMode.Zoom
-			End If
-
-
-			mainPictureBox.Refresh()
-			mainPictureBox.Invalidate()
 
 			SlideshowTimerTick = FrmSettings.slideshowNumBox.Value
 		End If
@@ -18966,81 +18629,41 @@ saveImage:
 #Region "-------------------------------------------------- DommeSlideshow ----------------------------------------------------"
 
 	Private Sub PicStripTSMIdommeSlideshowGoToLast_Click(sender As System.Object, e As System.EventArgs) Handles PicStripTSMIdommeSlideshowGoToLast.Click
-		'TODO-Next: Implement ShowImage(String, Boolean) and myDirectory.GetFilesImages(String)
 
 		If FrmSettings.CBSettingsPause.Checked = True And FrmSettings.SettingsPanel.Visible = True Then
 			MsgBox("Please close the settings menu or disable ""Pause Program When Settings Menu Is Visible"" option first!", , "Warning!")
 			Return
 		End If
-
 
 		If SlideshowLoaded = False Or TeaseVideo = True Or LockImage = True Then Return
 
 		FileCount = FileCountMax
 
-		ClearMainPictureBox()
-
 		Try
-			ShowImage(_ImageFileNames(FileCount))
+			ShowImage(_ImageFileNames(FileCount), True)
 			JustShowedBlogImage = False
 		Catch
 
 		End Try
-
-		If FrmSettings.landscapeCheckBox.Checked = True Then
-			If mainPictureBox.Image.Width > mainPictureBox.Image.Height Then
-				mainPictureBox.SizeMode = PictureBoxSizeMode.StretchImage
-			Else
-				mainPictureBox.SizeMode = PictureBoxSizeMode.Zoom
-			End If
-		Else
-			mainPictureBox.SizeMode = PictureBoxSizeMode.Zoom
-		End If
-
-		mainPictureBox.Refresh()
-		mainPictureBox.Invalidate()
-
 	End Sub
 
 	Private Sub PicStripTSMIdommeSlideshow_GoToFirst_Click(sender As System.Object, e As System.EventArgs) Handles PicStripTSMIdommeSlideshow_GoToFirst.Click
-		'TODO-Next: Implement ShowImage(String, Boolean) and myDirectory.GetFilesImages(String)
 
 		If FrmSettings.CBSettingsPause.Checked = True And FrmSettings.SettingsPanel.Visible = True Then
 			MsgBox("Please close the settings menu or disable ""Pause Program When Settings Menu Is Visible"" option first!", , "Warning!")
 			Return
 		End If
 
-
 		If SlideshowLoaded = False Or TeaseVideo = True Or LockImage = True Then Return
 
 		FileCount = 0
 
-		ClearMainPictureBox()
-
-
 		Try
-			ShowImage(_ImageFileNames(FileCount))
-
+			ShowImage(_ImageFileNames(FileCount), True)
 			JustShowedBlogImage = False
 		Catch
 
 		End Try
-
-		If FrmSettings.landscapeCheckBox.Checked = True Then
-			If mainPictureBox.Image.Width > mainPictureBox.Image.Height Then
-				mainPictureBox.SizeMode = PictureBoxSizeMode.StretchImage
-			Else
-				mainPictureBox.SizeMode = PictureBoxSizeMode.Zoom
-			End If
-		Else
-			mainPictureBox.SizeMode = PictureBoxSizeMode.Zoom
-		End If
-
-		mainPictureBox.Refresh()
-		mainPictureBox.Invalidate()
-
-
-
 	End Sub
 
 	Private Sub PicStripTSMIdommeSlideshowLoadNewSlideshow_Click(sender As System.Object, e As System.EventArgs) Handles PicStripTSMIdommeSlideshowLoadNewSlideshow.Click
@@ -19088,7 +18711,7 @@ saveImage:
 
 
 	Public Sub LoadDommeImageFolder()
-		'TODO-Next: Implement ShowImage(String, Boolean) and myDirectory.GetFilesImages(String) + Rework
+		'TODO-Next-Stefaf: Implement ShowImage(String, Boolean) and myDirectory.GetFilesImages(String) + Rework
 
 		Dim NewSlideshowAttempts As Integer = 0
 
@@ -24052,7 +23675,7 @@ playLoop:
 
 	<Obsolete("Use ShowImage(String, Boolean) instead")>
 	Public Sub ShowImage(ByVal ImageToShow As String)
-		'TODO-Next: Function ShowImage is decpreciated. Remove all references
+		'TODO-Next-Stefaf: Function ShowImage is decpreciated. Remove all references
 		PBImage = ImageToShow
 		ImageLocation = ImageToShow
 		ImageThread = New Thread(AddressOf DisplayImage) With {.Name = "ImageThread"}
@@ -24066,7 +23689,7 @@ playLoop:
 	''' </summary>
 	<Obsolete("Use ShowImage(String, Boolean) instead")>
 	Private Sub DisplayImage()
-		'TODO-Next: Function DisplayImage is decpreciated. Remove all references
+		'TODO-Next-Stefaf: Function DisplayImage is decpreciated. Remove all references
 		If FormLoading = True Then Return
 		If PBImage = "" Then Return
 

--- a/Tease AI/Form2.vb
+++ b/Tease AI/Form2.vb
@@ -4475,7 +4475,7 @@ trypreviousimage:
 
 
 	Public Sub VerifyLocalImagePaths()
-		'TODO-Next: Validate User-Settings on Startup using myDireectory and assigning the My.Settings default values on failure.
+		'TODO-Next-Stefaf: Validate User-Settings on Startup using myDireectory and assigning the My.Settings default values on failure.
 		Dim ImageList As New List(Of String)
 		ImageList.Clear()
 

--- a/Tease AI/My Project/AssemblyInfo.vb
+++ b/Tease AI/My Project/AssemblyInfo.vb
@@ -18,7 +18,7 @@ Imports System.Runtime.InteropServices
 <Assembly: ComVisible(False)>
 
 'The following GUID is for the ID of the typelib if this project is exposed to COM
-<Assembly: Guid("d21ae695-f2f4-4131-87b8-0a1636163cd6")> 
+<Assembly: Guid("d21ae695-f2f4-4131-87b8-0a1636163cd6")>
 
 ' Version information for an assembly consists of the following four values:
 '
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("0.54.3.0")> 
+<Assembly: AssemblyVersion("0.54.4.0")>
 <Assembly: AssemblyFileVersion("1.0.0.0")> 


### PR DESCRIPTION
- Incremented AssemblyVersion to 0.54.4.0
- Stefaf: Fixed TargetInvocationException, when loading an image and the fallback failed.
- Stefaf: Added Additional check, if the imagepath to load is empty/NULL. This is checked and logged before the Backgroundworker starts. This way we can track the source of this error better.
- Stefaf: Stretching landscape images applies to all images loaded with the designated Backgroundworker.
- Stefaf: Fixed if .net does not create the localAppData%-directory on start-up, the setting-file duplication is suspended until the settings are automatically saved for the first time. If here an exception occurs, it will be suspended until next time.
- Stefaf: Reworked Custom MainSlideshow. Merged redundant code. The image extensions are the global ones. Added check if a folder exists. Images are now loaded using the designated Backgroundworker.
- Stefaf: Fixed Custom timed slideshow. This was stepping 2 images forward instead of one. Images are loading with the designated Backgroundworker.
- Stefaf: Fixed Combobox for Custom slideshows was overwriting inputs like Control+C and stuff like that.
- Stefaf: Fixed when the CustomSlideshow fails to load, it was recognized as valid.
- Stefaf: Reworked time usage in logs. After introducing proper versioning, there is no need to a identify the assembly-version, using the filetime. All times in logs are now local times.
- Stefaf: Fixed IndexOutOfRangeException when clicking next or previous image button at the end or start of the slideshow.
